### PR TITLE
CLA API and OAuth2 Provider Spike

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'pg'
 gem 'redcarpet' # markdown parsing
 gem 'unicorn'
 gem 'unicorn-rails'
+gem 'doorkeeper'
 
 gem 'neat'
 gem 'sass-rails',   '~> 4.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
     database_cleaner (1.2.0)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.4)
+    doorkeeper (1.0.0)
+      railties (>= 3.1)
     erubis (2.7.0)
     execjs (2.0.2)
     factory_girl (4.2.0)
@@ -182,6 +184,7 @@ DEPENDENCIES
   byebug
   capybara
   database_cleaner
+  doorkeeper
   factory_girl
   launchy
   magiconf

--- a/app/controllers/api/agreements_controller.rb
+++ b/app/controllers/api/agreements_controller.rb
@@ -1,0 +1,10 @@
+class Api::AgreementsController < ApiController
+  doorkeeper_for :all
+
+  def show
+    @account = Account.find_by(provider: 'github', username: params[:github_username])
+    @user = @account.user
+
+    render json: { signed_agreement: @user.signed_icla? || @user.signed_ccla? }
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,2 @@
+class ApiController < ActionController::Base
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,6 +52,19 @@ class User < ActiveRecord::Base
   end
 
   #
+  # Determine if the current user signed the Corporate Contributor License
+  # Agreement.
+  #
+  # @todo Expand this functionality to search for the most recently active
+  #       CCLA and return some sort of history instead.
+  #
+  # @return [Boolean]
+  #
+  def signed_ccla?
+    !ccla_signatures.empty?
+  end
+
+  #
   # The name of the current user.
   #
   # @example

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,67 @@
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use.
+  # Currently supported options are :active_record, :mongoid2, :mongoid3, :mongo_mapper
+  orm :active_record
+
+  # This block will be called to check whether the resource owner is authenticated or not.
+  resource_owner_authenticator do
+    User.find_by_id(session[:user_id]) || redirect_to(sign_in_path)
+  end
+
+  # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
+  # admin_authenticator do
+  #   # Put your admin authentication logic here.
+  #   # Example implementation:
+  #   Admin.find_by_id(session[:admin_id]) || redirect_to(new_admin_session_url)
+  # end
+
+  # Authorization Code expiration time (default 10 minutes).
+  # authorization_code_expires_in 10.minutes
+
+  # Access token expiration time (default 2 hours).
+  # If you want to disable expiration, set this to nil.
+  # access_token_expires_in 2.hours
+
+  # Issue access tokens with refresh token (disabled by default)
+  # use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter :confirmation => true (default false) if you want to enforce ownership of
+  # a registered application
+  # Note: you must also run the rails g doorkeeper:application_owner generator to provide the necessary support
+  # enable_application_owner :confirmation => false
+
+  # Define access token scopes for your provider
+  # For more information go to https://github.com/applicake/doorkeeper/wiki/Using-Scopes
+  # default_scopes  :public
+  # optional_scopes :write, :update
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out the wiki for more information on customization
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out the wiki for more information on customization
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Change the test redirect uri for client apps
+  # When clients register with the following redirect uri, they won't be redirected to any server and the authorization code will be displayed within the provider
+  # The value can be any string. Use nil to disable this feature. When disabled, clients must provide a valid URL
+  # (Similar behaviour: https://developers.google.com/accounts/docs/OAuth2InstalledApp#choosingredirecturi)
+  #
+  # test_redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with trusted a application.
+  # skip_authorization do |resource_owner, client|
+  #   client.superapp? or resource_owner.admin?
+  # end
+
+  # WWW-Authenticate Realm (default "Doorkeeper").
+  # realm "Doorkeeper"
+end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,74 @@
+en:
+  activerecord:
+    errors:
+      models:
+        application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              has_query_parameter: 'cannot contain a query parameter.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+  mongoid:
+    errors:
+      models:
+        application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              has_query_parameter: 'cannot contain a query parameter.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+  mongo_mapper:
+    errors:
+      models:
+        application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              has_query_parameter: 'cannot contain a query parameter.'
+              invalid_uri: 'must be a valid URI.'
+              relative_uri: 'must be an absolute URI.'
+  doorkeeper:
+    errors:
+      messages:
+        # Common error messages
+        invalid_request: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+        invalid_redirect_uri: 'The redirect uri included is not valid.'
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        #configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfiged.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        # Password Access token errors
+        invalid_resource_owner: 'The provided resource owner credentials are not valid, or resource owner cannot be found'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Supermarket::Application.routes.draw do
+  use_doorkeeper
+
   namespace :api do
     resources :icla_signatures, path: 'icla-signatures'
     resources :users
@@ -18,6 +20,10 @@ Supermarket::Application.routes.draw do
 
   match 'auth/:provider/callback' => 'sessions#create', as: :auth_callback, via: [:get, :post]
   get 'auth/failure' => 'sessions#failure', as: :auth_failure
+
+  scope 'api', format: :json do
+    get '/agreements/:github_username' => 'api/agreements#show'
+  end
 
   root 'icla_signatures#index'
 end

--- a/db/migrate/20140115193908_create_doorkeeper_tables.rb
+++ b/db/migrate/20140115193908_create_doorkeeper_tables.rb
@@ -1,0 +1,42 @@
+class CreateDoorkeeperTables < ActiveRecord::Migration
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,         :null => false
+      t.string  :uid,          :null => false
+      t.string  :secret,       :null => false
+      t.text    :redirect_uri, :null => false
+      t.timestamps
+    end
+
+    add_index :oauth_applications, :uid, :unique => true
+
+    create_table :oauth_access_grants do |t|
+      t.integer  :resource_owner_id, :null => false
+      t.integer  :application_id,    :null => false
+      t.string   :token,             :null => false
+      t.integer  :expires_in,        :null => false
+      t.text     :redirect_uri,      :null => false
+      t.datetime :created_at,        :null => false
+      t.datetime :revoked_at
+      t.string   :scopes
+    end
+
+    add_index :oauth_access_grants, :token, :unique => true
+
+    create_table :oauth_access_tokens do |t|
+      t.integer  :resource_owner_id
+      t.integer  :application_id
+      t.string   :token,             :null => false
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.datetime :revoked_at
+      t.datetime :created_at,        :null => false
+      t.string   :scopes
+    end
+
+    add_index :oauth_access_tokens, :token, :unique => true
+    add_index :oauth_access_tokens, :resource_owner_id
+    add_index :oauth_access_tokens, :refresh_token, :unique => true
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140109194347) do
+ActiveRecord::Schema.define(version: 20140115193908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,6 +102,57 @@ ActiveRecord::Schema.define(version: 20140109194347) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "invitations", force: true do |t|
+    t.integer  "organization_id"
+    t.string   "email"
+    t.string   "token"
+    t.boolean  "admin"
+    t.boolean  "accepted"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "invitations", ["organization_id"], name: "index_invitations_on_organization_id", using: :btree
+
+  create_table "oauth_access_grants", force: true do |t|
+    t.integer  "resource_owner_id", null: false
+    t.integer  "application_id",    null: false
+    t.string   "token",             null: false
+    t.integer  "expires_in",        null: false
+    t.text     "redirect_uri",      null: false
+    t.datetime "created_at",        null: false
+    t.datetime "revoked_at"
+    t.string   "scopes"
+  end
+
+  add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
+
+  create_table "oauth_access_tokens", force: true do |t|
+    t.integer  "resource_owner_id"
+    t.integer  "application_id"
+    t.string   "token",             null: false
+    t.string   "refresh_token"
+    t.integer  "expires_in"
+    t.datetime "revoked_at"
+    t.datetime "created_at",        null: false
+    t.string   "scopes"
+  end
+
+  add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
+  add_index "oauth_access_tokens", ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id", using: :btree
+  add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
+
+  create_table "oauth_applications", force: true do |t|
+    t.string   "name",         null: false
+    t.string   "uid",          null: false
+    t.string   "secret",       null: false
+    t.text     "redirect_uri", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
 
   create_table "organization_users", force: true do |t|
     t.integer  "user_id"


### PR DESCRIPTION
:construction: This explores what it would look like to implement a basic CLA API using OAuth2 for authentication (via [Doorkeeper](https://github.com/applicake/doorkeeper)). In order for this to be mergeable the following should happen.
- [ ] Add tests for the API endpoint
- [ ] Override Doorkeeper controllers so applications are scoped only to the current user
- [ ] Override Doorkeeper views so they fit in with the rest of the application.
