### PR TITLE
Update magiconf to 1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     kgio (2.8.1)
     launchy (2.4.2)
       addressable (~> 2.3)
-    magiconf (0.1.2)
+    magiconf (1.0.0)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)


### PR DESCRIPTION
This is the latest stable release of Magiconf. I also changed the license from MIT to Apache 2.0, so it's now safe to use in this project.
