### PR TITLE
Update meta content viewport syntax.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <link rel="apple-touch-icon" href="<%= image_url('apple-touch-icon.png') %>"/>
 
     <!-- Viewport -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0; maximum-scale=1.0; user-scalable=0;">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
 
     <%= stylesheet_link_tag 'application' %>
     <%= csrf_meta_tags %>


### PR DESCRIPTION
This fixes the Viewport error when running specs.
