### PR TITLE
Add License Finder.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,3 +63,8 @@ Good: Add some feature
 
 ### Writing Tests
 In order to ensure the integrity of the project (and prevent regressions), we _cannot_ merge any patch that does not have adequate test coverage. Even if you have never written tests before, the existing tests serve as great boilerplate examples. At minimum, changes to a model must have a unit spec, changes to a controller must have a request spec, changes to a view must have a view or capybara spec, changes to the javascript must have a polgergist spec.
+
+### Adding Dependencies
+If you are adding dependencies to the project (gems in the Gemfile or npm
+packages in `packages.json`, please run `license_finder` to make sure that none
+of the added dependencies conflict  with the project's whitelisted licenses.

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,10 @@ group :doc do
   gem 'yard', require: false
 end
 
+group :development do
+  gem 'license_finder', git: "https://github.com/pivotal/LicenseFinder.git" # checks for compatible licenses
+end
+
 group :test do
   gem 'capybara'
   gem 'factory_girl'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/pivotal/LicenseFinder.git
+  revision: a8f92052e57aa0118358f075ad19a35427b6c72e
+  specs:
+    license_finder (0.9.4)
+      bundler
+      httparty
+      rake
+      sequel
+      sqlite3
+      thor
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -67,8 +79,12 @@ GEM
       thor (>= 0.13.6)
     hashie (2.0.5)
     hike (1.2.3)
+    httparty (0.12.0)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
     httpauth (0.2.0)
     i18n (0.6.9)
+    json (1.8.1)
     jwt (0.1.8)
       multi_json (>= 1.5)
     kgio (2.8.1)
@@ -84,6 +100,7 @@ GEM
     mini_portile (0.5.2)
     minitest (4.7.5)
     multi_json (1.8.2)
+    multi_xml (0.5.5)
     multipart-post (1.2.0)
     neat (1.4.0)
       bourbon (>= 2.1)
@@ -141,7 +158,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.12.0)
-    rake (10.1.0)
+    rake (10.1.1)
     redcarpet (3.0.0)
     rspec-core (2.14.6)
     rspec-expectations (2.14.3)
@@ -159,6 +176,7 @@ GEM
       railties (>= 4.0.0, < 5.0)
       sass (>= 3.1.10)
       sprockets-rails (~> 2.0.0)
+    sequel (4.6.0)
     shoulda-matchers (2.4.0)
       activesupport (>= 3.0.0)
     sprockets (2.10.1)
@@ -170,6 +188,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    sqlite3 (1.3.8)
     thor (0.18.1)
     thread_safe (0.1.3)
       atomic
@@ -207,6 +226,7 @@ DEPENDENCIES
   factory_girl
   foreman
   launchy
+  license_finder!
   magiconf
   mail_view
   neat

--- a/config/license_finder.yml
+++ b/config/license_finder.yml
@@ -1,0 +1,11 @@
+---
+whitelist:
+- MIT
+- Apache 2.0
+- BSD
+ignore_groups:
+- test
+- development
+- devDependencies
+dependencies_file_dir: './doc/'
+project_name: Supermarket

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "devDependencies": {
     "chai": "~1.8.1",
     "karma": "~0.10.2",
+    "mocha": "~1.13.0",
     "karma-mocha": "~0.1.0",
     "karma-osx-reporter": "0.0.3",
     "karma-spec-reporter": "0.0.6",
-    "mocha": "~1.13.0",
     "sprockets-chain": "0.0.9"
   }
 }


### PR DESCRIPTION
[License Finder](https://github.com/pivotal/LicenseFinder) checks the licenses of the gems and npm packages we are using to
make sure they do not conflict with the project. The config/license_finder.yml
contains the whitelisted licenses and the ignored Gemfile groups.

To use license_finder, simply run `license_finder`.

License Finder checks gems specified in the `Gemfile` and npm packages specified in `package.json`.

If there are other licenses we should whitelist, feel free to share them here.

Running the `license_finder` currently yields:

```
Dependencies that need approval:
jwt, 0.1.8, other
kgio, 2.8.1, LGPL
mocha, 1.13.0, ISC
raindrops, 0.12.0, LGPL
unicorn, 4.6.3, GPLv2
unicorn-rails, 1.1.0, other
```

We should keep track of dependencies that need approval and see if we can whitelist that license. If not, then we will have to figure out what to do from there.

---

Current whitelist:
- MIT
- Apache 2.0
- BSD
