### PR TITLE
Cache Travis depedency installing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.0.0
 before_script:


### PR DESCRIPTION
Caching Bundler with Travis CI speeds up the build duration.

Information here: http://docs.travis-ci.com/user/caching/#Caching-directories-(Bundler%2C-dependencies)

This should speed up the Travis CI build process a whole lot.
