### PR TITLE
Add Gravatar support for Users.

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,28 @@
+module UsersHelper
+  #
+  # Return the image_tag of the specified user's gravatar based on their
+  # email. If the user does not have a Gravatar, the default Gravatar image is
+  # displayed. The default size is 48 pixels.
+  #
+  # @param [User] the User for get the Gravatar for
+  # @param optional [Hash] options
+  # @option options [Integer] the size of the Gravatar in pixels, default: 48
+  #
+  # @example Gravtar for current_user
+  #   gravatar_for current_user, size: 72
+  #
+  # @return [String] the HTML element for the image with the src being the
+  #   user's Gravatar, the alt being the User's name and the class being
+  #   gravatar.
+  #
+  def gravatar_for(user, options = {})
+    options = {
+      size: 48
+    }.merge(options)
+
+    size = options[:size]
+    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
+    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
+    image_tag(gravatar_url, alt: user.name, class: "gravatar")
+  end
+end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,6 +4,8 @@
   </div>
 
   <div class="content">
+    <%= gravatar_for @user, size: 72 %>
+
     <% @user.accounts.for('github').each do |account| %>
       <p>
         <%= account.username %> [GitHub]<br />

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe UsersHelper do
+  describe '#gravatar_for' do
+    it "returns the image tag for the specified user's gravtar image" do
+      user = create(:user, email: 'johndoe@example.com')
+      expect(gravatar_for(user)).to eq( '<img alt="John Doe" class="gravatar" src="https://secure.gravatar.com/avatar/fd876f8cd6a58277fc664d47ea10ad19?s=48" />')
+    end
+
+    it "returns the image tag for the specified user's gravtar image with size" do
+      user = create(:user, email: 'johndoe@example.com')
+      expect(gravatar_for(user, size: 128)).to eq( '<img alt="John Doe" class="gravatar" src="https://secure.gravatar.com/avatar/fd876f8cd6a58277fc664d47ea10ad19?s=128" />')
+    end
+  end
+end


### PR DESCRIPTION
Creates `UserHelper#gravatar_for` which takes a User as a parameter and an
optional options hash. The options hash may contain the size for the gravatar,
which defaults to 48.

The method determines the Gravatar based on the user's email.

Displays the user's Gravatar on their profile.

Example use in a view:

``` erb
<%= gravatar_for current_user, size: 72 %>
```

or

``` erb
<%= gravatar_for current_user %>
```

Pivotal Tracker ID: 63206080
https://www.pivotaltracker.com/story/show/63206080

What it looks like:

![screen shot 2014-01-27 at 1 43 30 pm](https://f.cloud.github.com/assets/928367/2012038/76c726f6-8783-11e3-849d-0c4963537ef9.png)

Pivotal Tracker ID: 63206080
https://www.pivotaltracker.com/story/show/63206080
