### PR TITLE
Add SQLite3 development headers

### DIFF
--- a/chef/cookbooks/supermarket/recipes/_ruby.rb
+++ b/chef/cookbooks/supermarket/recipes/_ruby.rb
@@ -32,4 +32,7 @@ package 'ruby2.0-dev'
 package 'libxslt-dev'
 package 'libxml2-dev'
 
+# SQLite3 requires development headers
+package 'libsqlite3-dev'
+
 gem_package 'bundler'


### PR DESCRIPTION
:fork_and_knife: Some gems require SQLite3 development headers in order to properly compile, this pull request adds them to the `_ruby` recipe.
