### PR TITLE
Quell Test Warnings

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,11 @@ module Supermarket
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
+    # Skip locale validation.
+    # Note: if the time comes to support locales, this will want to be set to
+    # true.
+    config.i18n.enforce_available_locales = false
+
     # Allow magiconf to work with application configuration
     Magiconf.setup!
   end


### PR DESCRIPTION
:fork_and_knife: There are two parts to this pull request. One is code related:

Set config.il18n.enforce_available_locales to false. This commit takes a stance on config.il18n.enforce_available_locales. At this time, multiple locales are not being handled. If, in the future, multiple locales are needed, this should get set to true.

---

The second is dev environment related. I had been getting warnings from PhantomJS like:

``` text
2014-01-28 16:18:48.730 phantomjs[22745:507] CoreText performance note: Client called CTFontCreateWithName() using name "Helvetica Neue" and got font with PostScript name "HelveticaNeue". For best performance, only use PostScript names when calling this API
```

They are a _bit_ annoying. By updating PhantomJS, it removes the warning. If you are on OS X and using homebrew, a simple `brew update && brew reinstall phantomjs` should suffice.
