### PR TITLE
Turn off Travis CI email notifications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+notifications:
+  email: false
 rvm:
   - 2.0.0
 before_script:


### PR DESCRIPTION
I would like to proposal turning off Travis CI email notifications. Since we are using a code->PR->merge workflow with GitHub, Travis is baked into the interface. This means that before any code gets merged in, we should see that Travis CI tests are passing.

I find that the Travis emails to be a overwhelming, so I wanted to propose this and ask if anyone prefers them to be on? If they are turned on, we could specify the emails to get notified as an alternative solution.

I have not personally found a way to unsubscribe from only Travis CI notifications (the emails points to their docs which is what lead to this PR).

Thanks!
