### PR TITLE
Change contributor invitation links to full URLs.

### DIFF
--- a/app/views/invitation_mailer/invitation_email.md.erb
+++ b/app/views/invitation_mailer/invitation_email.md.erb
@@ -1,1 +1,1 @@
-<%= link_to "Accept Invitation", @invitation, class: "invitation" %>
+<%= link_to "Accept Invitation", invitation_url(@invitation), class: "invitation" %>

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -117,7 +117,9 @@ module FeatureHelpers
     body = invitation.parts.find { |p| p.content_type =~ /html/ }.body.to_s
     html = Nokogiri::HTML(body)
     url = html.css('a.invitation').first.attribute('href').value
-    visit url
+    path = URI(url).path
+
+    visit path
   end
 
   def remove_contributor_from(organization)


### PR DESCRIPTION
:fork_and_knife:

Bare paths are not much use in emails. Note that this won't take full effect until our domains are set up.
