### PR TITLE
Allow users to change their password

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -72,7 +72,7 @@ form section {
   }
 }
 
-input[type='text'] {
+input[type='text'], input[type='email'], input[type='tel'], input[type='password'] {
   background: #fff;
   border: 1px solid lighten($secondary-gray, 25%);
   border-radius: $radius;

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -4,12 +4,33 @@ class ProfileController < ApplicationController
   #
   # PATCH /profile
   #
-  # Update the current_user's attributes
+  # Update the current_user's profile
   #
   def update
-    current_user.update_attributes(user_params)
+    if current_user.update_attributes(user_params)
+      redirect_to current_user, notice: 'Profile successfully updated.'
+    else
+      render 'edit'
+    end
+  end
 
-    redirect_to current_user, notice: 'Profile successfully updated.'
+  #
+  # PATCH /profile/change_password
+  #
+  # Change the current_user's password
+  #
+  def change_password
+    if current_user.update_with_password(password_params)
+      #
+      # Sign in the user bypassing validation in case
+      # their password changed.
+      #
+      sign_in current_user, bypass: true
+
+      redirect_to current_user, notice: 'Password successfully changed.'
+    else
+      render 'edit'
+    end
   end
 
   #
@@ -36,4 +57,14 @@ class ProfileController < ApplicationController
     )
   end
 
+  #
+  # The strong params for the user's password.
+  #
+  def password_params
+    params.require(:user).permit(
+      :current_password,
+      :password,
+      :password_confirmation
+    )
+  end
 end

--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -1,14 +1,14 @@
-<%= form_for(current_user, url: profile_path) do |f| %>
-  <div class="page">
-    <div class="title">
-      <span class="fa fa-user"></span> Edit Profile
-    </div>
+<div class="page">
+  <div class="title">
+    <span class="fa fa-user"></span> Edit Profile
+  </div>
 
-    <div class="content">
+  <div class="content">
+    <%= form_for(current_user, url: profile_path) do |f| %>
       <%= render 'application/form_errors', record: current_user %>
 
       <section class="fields">
-        <fieldset class="name">
+        <fieldset>
           <%= f.text_field :email, placeholder: 'Email', title: 'Email' %>
           <%= f.text_field :first_name, placeholder: 'First Name', title: 'First Name' %>
           <%= f.text_field :last_name, placeholder: 'Last Name', title: 'Last Name' %>
@@ -24,6 +24,22 @@
       <section>
         <%= f.submit 'Update Profile', class: 'button primary' %>
       </section>
-    </div>
+    <% end %>
+
+    <%= form_for(current_user, url: change_password_profile_path) do |f| %>
+      <section class="fields">
+        <fieldset>
+          <h4>Change Password</h4>
+          <%= f.password_field :current_password, placeholder: 'Current password' %>
+          <%= f.password_field :password, placeholder: 'New Password' %>
+          <%= f.password_field :password_confirmation, placeholder: 'Password confirmation' %>
+        </fieldset>
+      </section>
+
+      <section>
+        <%= f.submit 'Change Password', class: 'button primary' %>
+      </section>
+    <% end %>
   </div>
-<% end %>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,11 @@ Supermarket::Application.routes.draw do
     resources :accounts, only: [:destroy]
   end
 
-  resource :profile, controller: 'profile', only: [:update, :edit]
+  resource :profile, controller: 'profile', only: [:update, :edit] do
+    collection do
+      patch :change_password
+    end
+  end
 
   resources :invitations, only: [:show, :update, :destroy]
 

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ProfileController do
-  let(:user) { create(:user) }
+  let(:user) { create(:user, password: 'password', password_confirmation: 'password') }
 
   describe 'PATCH #update' do
     context 'user is authenticated' do
@@ -44,6 +44,59 @@ describe ProfileController do
           'company' => 'Acme',
           'irc_nickname' => 'bobbo',
           'jira_username' => 'bobbo'
+        })
+      end
+    end
+
+    context 'user is not authenticated' do
+      it 'redirects to the sign in page' do
+        sign_out user
+
+        patch :update
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe 'PATCH #change_password' do
+    context 'user is authenticated' do
+      before do
+        sign_in user
+
+        patch :change_password, user: {
+          current_password: 'password',
+          password: 'winter123',
+          password_confirmation:'winter123'
+        }
+      end
+
+      it 'changes the users password' do
+        old_encrypted_password = user.encrypted_password
+        user.reload
+
+        expect(user.encrypted_password).to_not eql(old_encrypted_password)
+      end
+
+      it 'redirects to the user profile' do
+        expect(response).to redirect_to(user)
+      end
+
+      it 'uses strong parameters' do
+        fake_user = stub_model(User)
+
+        expect(fake_user).to receive(:update_with_password).with({
+          'current_password' => 'password',
+          'password' => 'winter123',
+          'password_confirmation' => 'winter123'
+        })
+
+        controller.stub(:current_user) { fake_user }
+
+        patch :change_password, user: attributes_for(:user, {
+          'current_password' => 'password',
+          'password' => 'winter123',
+          'password_confirmation' => 'winter123'
         })
       end
     end

--- a/spec/features/change_password_spec.rb
+++ b/spec/features/change_password_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_feature_helper'
+
+describe 'changing the current user password' do
+  it 'changes the current users password' do
+    sign_in(create(:user))
+    click_link 'View Profile'
+    click_link 'Edit Profile'
+
+    fill_in 'user_current_password', with: 'password'
+    fill_in 'user_password', with: 'winter123'
+    fill_in 'user_password_confirmation', with: 'winter123'
+
+    find_button('Change Password').click
+
+    expect(page).to have_selector '.flash.notice'
+  end
+ end

--- a/spec/features/edit_profile_spec.rb
+++ b/spec/features/edit_profile_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_feature_helper'
 
 describe 'editing the current user profile' do
-  it 'goes to the edit profile page' do
+  it 'updates the users profile' do
     sign_in(create(:user))
     click_link 'View Profile'
     click_link 'Edit Profile'
+
     fill_in 'user_email', with: 'eddardstark@agofai.com'
     fill_in 'user_first_name', with: 'Eddard'
     fill_in 'user_last_name', with: 'Stark'
     fill_in 'user_irc_nickname', with: 'eddardstark'
     fill_in 'user_company', with: 'Winterfell'
     fill_in 'user_jira_username', with: 'eddardstark'
+
     find_button('Update Profile').click
+
     expect(page).to have_selector '.flash.notice'
   end
 end


### PR DESCRIPTION
:fork_and_knife: This allows users to change their password from their user profile edit page. Users are required to enter their current password in order to make a password change for security reasons.
