### PR TITLE
Allow CCLA invitations to be resent

### DIFF
--- a/app/authorizers/invitation_authorizer.rb
+++ b/app/authorizers/invitation_authorizer.rb
@@ -10,4 +10,8 @@ class InvitationAuthorizer < Authorizer::Base
   def update?
     index?
   end
+
+  def resend?
+    index?
+  end
 end

--- a/app/controllers/organization_invitations_controller.rb
+++ b/app/controllers/organization_invitations_controller.rb
@@ -39,7 +39,7 @@ class OrganizationInvitationsController < ApplicationController
   end
 
   #
-  # PATCH /organizations/:organization_id/invitations/:token
+  # PATCH /organizations/:organization_id/invitations/:id
   #
   # Updates an invitation.
   #
@@ -51,6 +51,22 @@ class OrganizationInvitationsController < ApplicationController
     @invitation.update_attributes(invitation_params)
 
     head 204
+  end
+
+  #
+  # PATCH /organizations/:organization_id/invitations/:id/resend
+  #
+  # Resends email for a given invitation.
+  #
+  def resend
+    @invitation = Invitation.find_by(token: params[:id])
+
+    authorize! @invitation
+
+    InvitationMailer.deliver_invitation(@invitation)
+
+    redirect_to :back, notice: "Successfully resent
+      invitation for #{@invitation.email}"
   end
 
   private

--- a/app/views/organization_invitations/index.html.erb
+++ b/app/views/organization_invitations/index.html.erb
@@ -41,7 +41,7 @@
             <% end %>
           </td>
           <td><%= "Pending" %></td>
-          <td></td>
+          <td><%= link_to "Resend", resend_organization_invitation_path(@organization, invitation), method: :patch %></td>
         </tr>
       <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,12 @@ Supermarket::Application.routes.draw do
 
     resources :invitations,
       only: [:index, :create, :update],
-      controller: :organization_invitations
+      controller: :organization_invitations do
+
+      member do
+        patch :resend
+      end
+    end
   end
 
   match 'auth/:provider/callback' => 'accounts#create', as: :auth_callback, via: [:get, :post]

--- a/spec/authorizers/invitation_authorizer_spec.rb
+++ b/spec/authorizers/invitation_authorizer_spec.rb
@@ -12,6 +12,7 @@ describe InvitationAuthorizer do
     it { should permit(:index) }
     it { should permit(:create) }
     it { should permit(:update) }
+    it { should permit(:resend) }
   end
 
   context 'as an organization contributor' do
@@ -21,5 +22,6 @@ describe InvitationAuthorizer do
     it { should_not permit(:index) }
     it { should_not permit(:create) }
     it { should_not permit(:update) }
+    it { should_not permit(:resend) }
   end
 end

--- a/spec/features/ccla_invitation_spec.rb
+++ b/spec/features/ccla_invitation_spec.rb
@@ -1,4 +1,3 @@
-require 'nokogiri'
 require 'spec_feature_helper'
 
 describe 'inviting people to sign a CCLA' do
@@ -15,5 +14,4 @@ describe 'inviting people to sign a CCLA' do
     sign_in(create(:user))
     decline_invitation_to_join('Acme')
   end
-
 end

--- a/spec/features/ccla_resend_invitation_spec.rb
+++ b/spec/features/ccla_resend_invitation_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_feature_helper'
+
+describe 'resending an invitation to a CCLA' do
+  it 'resends invited users an email prompting them to sign the CCLA' do
+    sign_ccla_and_invite_admin_to('Acme')
+    click_link 'Resend'
+    expect_to_see_success_message
+  end
+end


### PR DESCRIPTION
:fork_and_knife: This allows CCLA invitations to be resent after their initial creation.
