### PR TITLE
Don't allow users to join CCLA twice

### DIFF
--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -28,12 +28,12 @@ class ContributorsController < ApplicationController
   end
 
   private
-    def find_contributor
-      @contributor = Contributor.find(params[:id])
-    end
 
-    def contributor_params
-      params.require(:contributor).permit(:admin)
-    end
+  def find_contributor
+    @contributor = Contributor.find(params[:id])
+  end
+
+  def contributor_params
+    params.require(:contributor).permit(:admin)
+  end
 end
-

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -7,15 +7,22 @@ class InvitationsController < ApplicationController
   end
 
   def update
-    @contributor = Contributor.create!(
+    @contributor = Contributor.new(
       organization: @invitation.organization,
       user: current_user,
       admin: @invitation.admin
     )
 
-    @invitation.accept
-    redirect_to current_user, notice: "Successfully joined
-      #{@contributor.organization.name}"
+    if @contributor.save
+      @invitation.accept
+      redirect_to current_user, notice: "Successfully joined
+        #{@contributor.organization.name}"
+    else
+      redirect_to current_user, alert: "You've already signed
+        #{@invitation.organization}'s CCLA, please sign in as a
+        different user to accept or if this invitation was sent
+        in error no action is required."
+    end
   end
 
   def destroy

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -4,6 +4,10 @@ class Contributor < ActiveRecord::Base
   belongs_to :organization
   belongs_to :user
 
+  # Validations
+  # --------------------
+  validates_uniqueness_of :user_id, scope: :organization_id
+
   #
   # Returns the +Contributor+'s primary email address.
   #

--- a/spec/controllers/invitations_controller_spec.rb
+++ b/spec/controllers/invitations_controller_spec.rb
@@ -47,6 +47,17 @@ describe InvitationsController do
         put :update, id: invitation.token
       }.to change(Contributor.where(admin: true), :count).by(1)
     end
+
+    it "it doesn't create a new Contributor if the same user already belongs to the CCLA (organization)" do
+      organization = create(:organization)
+      invitation_1 = create(:invitation, organization: organization)
+      invitation_2 = create(:invitation, organization: organization)
+
+      expect {
+        put :update, id: invitation_1.token
+        put :update, id: invitation_2.token
+      }.to_not change(Contributor, :count).by(2)
+    end
   end
 
   describe 'DELETE #destroy' do

--- a/spec/features/ccla_invitation_spec.rb
+++ b/spec/features/ccla_invitation_spec.rb
@@ -1,17 +1,38 @@
 require 'spec_feature_helper'
 
 describe 'inviting people to sign a CCLA' do
+  let(:user) { create(:user) }
+
   it 'sends invited users an email prompting them to sign the CCLA and they accept' do
     sign_ccla_and_invite_admin_to('Acme')
     sign_out
-    sign_in(create(:user))
+    sign_in(user)
     accept_invitation_to_become_admin_of('Acme')
   end
 
-  it 'sends invited users and email prompting them to sign the CCLA and they decline' do
+  it 'sends invited users an email prompting them to sign the CCLA and they decline' do
     sign_ccla_and_invite_admin_to('Acme')
     sign_out
-    sign_in(create(:user))
+    sign_in(user)
     decline_invitation_to_join('Acme')
+  end
+
+  it "doesn't allow users to accept an invitation to a CCLA they already belong to" do
+    sign_ccla_and_invite_admin_to('Acme')
+    sign_out
+
+    sign_in(user)
+    accept_invitation_to_become_admin_of('Acme')
+    sign_out
+
+    sign_in(known_users[:bob])
+    invite_admin('admin@example.com')
+    sign_out
+
+    sign_in(user)
+    receive_and_visit_invitation
+    click_link 'Accept'
+
+    expect(page).to have_selector '.flash.alert'
   end
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -97,7 +97,7 @@ module FeatureHelpers
     check 'invitation_admin'
     find_button('Send invitation').click
 
-	expect_to_see_success_message
+    expect_to_see_success_message
     expect(all('#invitation_admin:checked').size).to eql(1)
   end
 
@@ -114,6 +114,8 @@ module FeatureHelpers
     invitation = ActionMailer::Base.deliveries.detect { |email|
       /Invitation/ =~ email['Subject'].to_s
     }
+
+    ActionMailer::Base.deliveries.clear
 
     body = invitation.parts.find { |p| p.content_type =~ /html/ }.body.to_s
     html = Nokogiri::HTML(body)


### PR DESCRIPTION
:fork_and_knife: This resolves an issue where users were able to join the same CCLA multiple times. This is unexpected behavior so we're resolving it with a little validation on `Contributor` and a alert message if the user attempts this behavior.
