### PR TITLE
Allow CLAs to be updated

### DIFF
--- a/app/assets/stylesheets/agreements/new.scss
+++ b/app/assets/stylesheets/agreements/new.scss
@@ -1,55 +1,10 @@
-form.new_icla_signature, form.new_ccla_signature {
-  section {
-    @include row;
-  }
+.signature {
+  @include span-columns(4);
+}
 
-  .agreement-header {
-    > h1 {
-      font-family: $helvetica;
-      margin: 2em 0 0 0;
-      text-align: center;
-      text-transform: none;
-    }
-
-    > h2 {
-      font-family: $helvetica;
-      margin: 0 0 1em 0;
-      text-align: center;
-      text-transform: none;
-    }
-  }
-
-  .agreement-body {
-    footer {
-      @include row;
-      margin: 1em 0 1em 0;
-      text-align: right;
-    }
-  }
-
-  #ccla_signature_prefix, #ccla_signature_suffix,
-    #icla_signature_prefix, #icla_signature_suffix {
-      @include span-columns(1);
-  }
-
-  #ccla_signature_zip, #icla_signature_zip {
-    @include span-columns(2);
-  }
-
-  #ccla_signature_first_name, #ccla_signature_middle_name,
-    #ccla_signature_phone, #ccla_signature_city, #ccla_signature_state,
-    #icla_signature_first_name, #icla_signature_middle_name,
-    #icla_signature_phone, #icla_signature_city, #icla_signature_state {
-      @include span-columns(3);
-  }
-
-  #ccla_signature_last_name, #ccla_signature_company,
-    #ccla_signature_country, #icla_signature_last_name,
-    #icla_signature_company, #icla_signature_country {
-      @include span-columns(4);
-  }
-
-  #ccla_signature_email,  #icla_signature_email {
-    @include span-columns(5);
-  }
+.agreement {
+  @include span-columns(8);
+  padding-left: 20px;
+  height: 850px;;
+  overflow-y: scroll;
 }

--- a/app/assets/stylesheets/mixins/page.scss
+++ b/app/assets/stylesheets/mixins/page.scss
@@ -28,6 +28,7 @@
   }
 
   .content {
+    @include row;
     margin: 3em;
 
     @include mobile {

--- a/app/controllers/icla_signatures_controller.rb
+++ b/app/controllers/icla_signatures_controller.rb
@@ -1,7 +1,8 @@
 class IclaSignaturesController < ApplicationController
-  before_filter :redirect_if_signed!, only: [:new, :create, :update]
+  before_filter :redirect_if_signed!, only: [:new, :create]
   before_filter :authenticate_user!, except: [:index]
-  before_filter :require_linked_github_account!, only: [:new, :create]
+  before_filter :require_linked_github_account!, only: [:new, :create, :update]
+  before_filter :find_and_authorize_icla_signature!, only: [:show, :update]
 
   #
   # GET /icla-signatures
@@ -16,11 +17,9 @@ class IclaSignaturesController < ApplicationController
   #
   # GET /icla-signatures/:id
   #
-  # Show a single signature.
+  # Show a single ICLA signature.
   #
   def show
-    @icla_signature = IclaSignature.find(params[:id])
-    authorize! @icla_signature
   end
 
   #
@@ -48,7 +47,7 @@ class IclaSignaturesController < ApplicationController
   #
   # POST /icla-signatures
   #
-  # Create a new Icla signature
+  # Create a new ICLA signature
   #
   def create
     @icla_signature = IclaSignature.new(icla_signature_params)
@@ -65,16 +64,16 @@ class IclaSignaturesController < ApplicationController
   end
 
   #
-  # DELETE /icla-signatures
+  # PATCH /icla-signatures/:id
   #
-  # Delete an Icla signature
+  # Updates a ICLA signature.
   #
-  def destroy
-    @icla_signature = IclaSignature.find(params[:id])
-    authorize! @icla_signature
-
-    @icla_signature.destroy
-    redirect_to icla_signatures_path
+  def update
+    if @icla_signature.update_attributes(icla_signature_params)
+      redirect_to @icla_signature, notice: "Successfully updated your ICLA."
+    else
+      render 'show'
+    end
   end
 
   private
@@ -117,10 +116,15 @@ class IclaSignaturesController < ApplicationController
   #
   def require_linked_github_account!
     if !current_user.linked_github_account?
-      store_location_for current_user, new_icla_signature_path
+      store_location_for current_user, request.path
 
       redirect_to current_user,
         notice: t('icla_signature.requires_linked_github')
     end
+  end
+
+  def find_and_authorize_icla_signature!
+    @icla_signature = IclaSignature.find(params[:id])
+    authorize! @icla_signature
   end
 end

--- a/app/models/ccla_signature.rb
+++ b/app/models/ccla_signature.rb
@@ -18,11 +18,17 @@ class CclaSignature < ActiveRecord::Base
   validates_presence_of :state
   validates_presence_of :zip
   validates_presence_of :country
-  validates_acceptance_of :agreement, allow_nil: false
+  validates_acceptance_of :agreement, allow_nil: false, on: :create
 
   # Accessors
   # --------------------
   attr_accessor :agreement
+
+  # Callbacks
+  # --------------------
+  before_update do
+    organization.update_attributes!(name: company)
+  end
 
   def name
     "#{first_name} #{last_name}"

--- a/app/models/icla_signature.rb
+++ b/app/models/icla_signature.rb
@@ -16,7 +16,7 @@ class IclaSignature < ActiveRecord::Base
   validates_presence_of :state
   validates_presence_of :zip
   validates_presence_of :country
-  validates_acceptance_of :agreement, allow_nil: false
+  validates_acceptance_of :agreement, allow_nil: false, on: :create
 
   # Accessors
   # --------------------

--- a/app/views/ccla_signatures/_form.html.erb
+++ b/app/views/ccla_signatures/_form.html.erb
@@ -1,0 +1,40 @@
+<%= form_for(@ccla_signature) do |f| %>
+  <%= render 'application/form_errors', record: @ccla_signature %>
+
+  <section class="fields">
+    <fieldset class="name">
+      <%= f.text_field :prefix, placeholder: 'Prefix',  title: 'Prefix' %>
+      <%= f.text_field :first_name, placeholder: 'First Name *', title: 'First Name' %>
+      <%= f.text_field :middle_name, placeholder: 'Middle Name', title: 'Middle Name' %>
+      <%= f.text_field :last_name, placeholder: 'Last Name *', title: 'Last Name' %>
+      <%= f.text_field :suffix, placeholder: 'Suffix', title: 'Suffix' %>
+    </fieldset>
+    <fieldset class="contact">
+      <%= f.text_field :company, placeholder: 'Company *', title: 'Company' %>
+      <%= f.telephone_field :phone, placeholder: 'Phone *', title: 'Phone' %>
+      <%= f.email_field :email, placeholder: 'Email *', title: 'Email' %>
+    </fieldset>
+    <fieldset class="address">
+      <%= f.text_field :address_line_1, placeholder: 'Address Line 1 *', title: 'Address Line 1' %>
+      <%= f.text_field :address_line_2, placeholder: 'Address Line 2', title: 'Address Line 2' %>
+      <%= f.text_field :city, placeholder: 'City *', title: 'City' %>
+      <%= f.text_field :state, placeholder: 'State or Province *', title: 'State or Province' %>
+      <%= f.text_field :zip, placeholder: 'Postal Code *', title: 'Postal Code' %>
+      <%= f.text_field :country, placeholder: 'Country *', title: 'Country' %>
+    </fieldset>
+  </section>
+
+  <% unless @ccla_signature.persisted? %>
+    <section class="checkbox-with-label">
+      <fieldset>
+        <%= f.check_box :agreement %>
+      </fieldset>
+      <p>I have read and accept the terms of this agreement</p>
+    </section>
+  <% end %>
+
+  <section>
+    <%= f.hidden_field :ccla_id %>
+    <%= f.submit submit_text, class: 'button secondary' %>
+  </section>
+<% end %>

--- a/app/views/ccla_signatures/new.html.erb
+++ b/app/views/ccla_signatures/new.html.erb
@@ -1,57 +1,24 @@
-<%= form_for(@ccla_signature) do |f| %>
-  <div class="page">
-    <div class="title">
-      <span class="fa fa-file-text"></span>Corporate Contributor License Agreement (CCLA)
+<div class="page">
+  <div class="title">
+    <span class="fa fa-file-text"></span>Corporate Contributor License Agreement (CCLA)
+  </div>
+
+  <div class="content">
+    <div class="callout info">
+      You have been asked to sign an CCLA as part of the <%= link_to 'Community Contribution process', 'http://docs.opscode.com/community_contributions.html', target: :blank %>. Please read the document below and complete the form to file your CCLA.
     </div>
 
-    <div class="content">
-      <div class="callout info">
-        You have been asked to sign an CCLA as part of the <%= link_to 'Community Contribution process', 'http://docs.opscode.com/community_contributions.html', target: :blank %>. Please read the document below and complete the form to file your CCLA.
-      </div>
+    <div class="signature">
+      <%= render 'form', submit_text: 'Sign CCLA' %>
+    </div>
 
+    <div class="agreement">
       <header class="agreement-header"><%= render_markdown(@ccla_signature.ccla.head) %></header>
-
-      <%= render 'application/form_errors', record: @ccla_signature %>
-
-      <section class="fields">
-        <fieldset class="name">
-          <%= f.text_field :prefix, placeholder: 'Prefix',  title: 'Prefix' %>
-          <%= f.text_field :first_name, placeholder: 'First Name *', title: 'First Name' %>
-          <%= f.text_field :middle_name, placeholder: 'Middle Name', title: 'Middle Name' %>
-          <%= f.text_field :last_name, placeholder: 'Last Name *', title: 'Last Name' %>
-          <%= f.text_field :suffix, placeholder: 'Suffix', title: 'Suffix' %>
-        </fieldset>
-        <fieldset class="contact">
-          <%= f.text_field :company, placeholder: 'Company *', title: 'Company' %>
-          <%= f.telephone_field :phone, placeholder: 'Phone *', title: 'Phone' %>
-          <%= f.email_field :email, placeholder: 'Email *', title: 'Email' %>
-        </fieldset>
-        <fieldset class="address">
-          <%= f.text_field :address_line_1, placeholder: 'Address Line 1 *', title: 'Address Line 1' %>
-          <%= f.text_field :address_line_2, placeholder: 'Address Line 2', title: 'Address Line 2' %>
-          <%= f.text_field :city, placeholder: 'City *', title: 'City' %>
-          <%= f.text_field :state, placeholder: 'State or Province *', title: 'State or Province' %>
-          <%= f.text_field :zip, placeholder: 'Postal Code *', title: 'Postal Code' %>
-          <%= f.text_field :country, placeholder: 'Country *', title: 'Country' %>
-        </fieldset>
-      </section>
-
       <section class="agreement-body">
         <%= render_markdown(@ccla_signature.ccla.body) %>
         <footer><%= @ccla_signature.ccla.version %></footer>
       </section>
-
-      <section class="checkbox-with-label">
-        <fieldset>
-          <%= f.check_box :agreement %>
-        </fieldset>
-        <p>I have read and accept the terms of this agreement</p>
-      </section>
-
-      <section>
-        <%= f.hidden_field :ccla_id %>
-        <%= f.submit 'Sign CCLA', class: 'button secondary' %>
-      </section>
     </div>
   </div>
-<% end %>
+  </div>
+</div>

--- a/app/views/ccla_signatures/show.html.erb
+++ b/app/views/ccla_signatures/show.html.erb
@@ -4,23 +4,29 @@
   </div>
 
   <div class="content">
-    <p>
-      <strong>Number</strong>
-      <%= @ccla_signature.id %>
-    </p>
-    <p>
-      <strong>Name</strong>
-      <%= @ccla_signature.name %>
-    </p>
-    <p>
-      <strong>Company</strong>
-      <%= @ccla_signature.company %>
-    </p>
+    <div class="signature">
+      <% if policy(@ccla_signature).update? %>
+        <%= render 'form', submit_text: 'Update CCLA' %>
+      <% else %>
+        <p>
+          <strong>Number</strong>
+          <%= @ccla_signature.id %>
+        </p>
+        <p>
+          <strong>Name</strong>
+          <%= @ccla_signature.name %>
+        </p>
+        <p>
+          <strong>Company</strong>
+          <%= @ccla_signature.company %>
+        </p>
+      <% end %>
+    </div>
 
-    <hr>
-
-    <%= render_markdown(@ccla_signature.ccla.head) %>
-    <%= render_markdown(@ccla_signature.ccla.body) %>
-    <%= @ccla_signature.ccla.version %>
+    <div class="agreement">
+      <%= render_markdown(@ccla_signature.ccla.head) %>
+      <%= render_markdown(@ccla_signature.ccla.body) %>
+      <%= @ccla_signature.ccla.version %>
+    </div>
   </div>
 </div>

--- a/app/views/icla_signatures/_form.html.erb
+++ b/app/views/icla_signatures/_form.html.erb
@@ -1,0 +1,42 @@
+<%= form_for(@icla_signature) do |f| %>
+  <%= render 'application/form_errors', record: @icla_signature %>
+
+  <section class="fields">
+    <fieldset class="name">
+      <%= f.text_field :prefix, placeholder: 'Prefix',  title: 'Prefix' %>
+      <%= f.text_field :first_name, placeholder: 'First Name *', title: 'First Name' %>
+      <%= f.text_field :middle_name, placeholder: 'Middle Name', title: 'Middle Name' %>
+      <%= f.text_field :last_name, placeholder: 'Last Name *', title: 'Last Name' %>
+      <%= f.text_field :suffix, placeholder: 'Suffix', title: 'Suffix' %>
+    </fieldset>
+    <fieldset class="contact">
+      <%= f.text_field :company, placeholder: 'Company', title: 'Company' %>
+      <%= f.telephone_field :phone, placeholder: 'Phone *', title: 'Phone' %>
+      <%= f.email_field :email, placeholder: 'Email *', title: 'Email' %>
+    </fieldset>
+    <fieldset class="address">
+      <%= f.text_field :address_line_1, placeholder: 'Address Line 1 *', title: 'Address Line 1' %>
+      <%= f.text_field :address_line_2, placeholder: 'Address Line 2', title: 'Address Line 2' %>
+      <%= f.text_field :city, placeholder: 'City *', title: 'City' %>
+      <%= f.text_field :state, placeholder: 'State or Province *', title: 'State or Province' %>
+      <%= f.text_field :zip, placeholder: 'Postal Code *', title: 'Postal Code' %>
+      <%= f.text_field :country, placeholder: 'Country *', title: 'Country' %>
+    </fieldset>
+  </section>
+
+  <% unless @icla_signature.persisted? %>
+    <section class="checkbox-with-label">
+      <fieldset>
+        <%= f.check_box :agreement %>
+        <%= label_tag :icla_signature_agreement, '' %>
+      </fieldset>
+      <p>I have read and accept the terms of this agreement</p>
+    </section>
+  <% end %>
+
+  <section>
+    <%= f.hidden_field :user_id %>
+    <%= f.hidden_field :icla_id %>
+    <%= f.submit submit_text, class: 'button secondary' %>
+  </section>
+<% end %>

--- a/app/views/icla_signatures/index.html.erb
+++ b/app/views/icla_signatures/index.html.erb
@@ -19,7 +19,7 @@
       <% @icla_signatures.each do |icla_signature| %>
         <tr>
           <td align="center" width="50"><%= icla_signature.id %></td>
-          <td><%= link_to icla_signature.user.name, icla_signature %></td>
+          <td><%= link_to icla_signature.user.name, icla_signature.user %></td>
           <td width="200"><%= icla_signature.user.company %></td>
           <td width="250"><%= icla_signature.signed_at.to_date.to_s(:long) %></td>
         </tr>

--- a/app/views/icla_signatures/new.html.erb
+++ b/app/views/icla_signatures/new.html.erb
@@ -1,59 +1,23 @@
-<%= form_for(@icla_signature) do |f| %>
-  <div class="page">
-    <div class="title">
-      <span class="fa fa-file-text"></span>Individual Contributor License Agreement (ICLA)
+<div class="page">
+  <div class="title">
+    <span class="fa fa-file-text"></span>Individual Contributor License Agreement (ICLA)
+  </div>
+
+  <div class="content">
+    <div class="callout info">
+      You have been asked to sign an ICLA as part of the <%= link_to 'Community Contribution process', 'http://docs.opscode.com/community_contributions.html', target: :blank %>. Please read the document below and complete the form to file your ICLA.
     </div>
 
-    <div class="content">
-      <div class="callout info">
-        You have been asked to sign an ICLA as part of the <%= link_to 'Community Contribution process', 'http://docs.opscode.com/community_contributions.html', target: :blank %>. Please read the document below and complete the form to file your ICLA.
-      </div>
+    <div class="signature">
+      <%= render 'form', submit_text: 'Sign ICLA' %>
+    </div>
 
+    <div class="agreement">
       <header class="agreement-header"><%= render_markdown(@icla_signature.icla.head) %></header>
-
-      <%= render 'application/form_errors', record: @icla_signature %>
-
-      <section class="fields">
-        <fieldset class="name">
-          <%= f.text_field :prefix, placeholder: 'Prefix',  title: 'Prefix' %>
-          <%= f.text_field :first_name, placeholder: 'First Name *', title: 'First Name' %>
-          <%= f.text_field :middle_name, placeholder: 'Middle Name', title: 'Middle Name' %>
-          <%= f.text_field :last_name, placeholder: 'Last Name *', title: 'Last Name' %>
-          <%= f.text_field :suffix, placeholder: 'Suffix', title: 'Suffix' %>
-        </fieldset>
-        <fieldset class="contact">
-          <%= f.text_field :company, placeholder: 'Company', title: 'Company' %>
-          <%= f.telephone_field :phone, placeholder: 'Phone *', title: 'Phone' %>
-          <%= f.email_field :email, placeholder: 'Email *', title: 'Email' %>
-        </fieldset>
-        <fieldset class="address">
-          <%= f.text_field :address_line_1, placeholder: 'Address Line 1 *', title: 'Address Line 1' %>
-          <%= f.text_field :address_line_2, placeholder: 'Address Line 2', title: 'Address Line 2' %>
-          <%= f.text_field :city, placeholder: 'City *', title: 'City' %>
-          <%= f.text_field :state, placeholder: 'State or Province *', title: 'State or Province' %>
-          <%= f.text_field :zip, placeholder: 'Postal Code *', title: 'Postal Code' %>
-          <%= f.text_field :country, placeholder: 'Country *', title: 'Country' %>
-        </fieldset>
-      </section>
-
       <section class="agreement-body">
         <%= render_markdown(@icla_signature.icla.body) %>
         <footer><%= @icla_signature.icla.version %></footer>
       </section>
-
-      <section class="checkbox-with-label">
-        <fieldset>
-          <%= f.check_box :agreement %>
-          <%= label_tag :icla_signature_agreement, '' %>
-        </fieldset>
-        <p>I have read and accept the terms of this agreement</p>
-      </section>
-
-      <section>
-        <%= f.hidden_field :user_id %>
-        <%= f.hidden_field :icla_id %>
-        <%= f.submit 'Sign ICLA', class: 'button secondary' %>
-      </section>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/icla_signatures/show.html.erb
+++ b/app/views/icla_signatures/show.html.erb
@@ -4,19 +4,29 @@
   </div>
 
   <div class="content">
-    <p>
-      <strong>Number</strong>
-      <%= @icla_signature.id %>
-    </p>
-    <p>
-      <strong>Name</strong>
-      <%= @icla_signature.name %>
-    </p>
+    <div class="signature">
+      <% if policy(@icla_signature).update? %>
+        <%= render 'form', submit_text: 'Update ICLA' %>
+      <% else %>
+        <p>
+          <strong>Number</strong>
+          <%= @icla_signature.id %>
+        </p>
+        <p>
+          <strong>Name</strong>
+          <%= @icla_signature.name %>
+        </p>
+        <p>
+          <strong>Company</strong>
+          <%= @icla_signature.company %>
+        </p>
+      <% end %>
+    </div>
 
-    <hr>
-
-    <%= render_markdown(@icla_signature.icla.head) %>
-    <%= render_markdown(@icla_signature.icla.body) %>
-    <%= @icla_signature.icla.version %>
+    <div class="agreement">
+      <%= render_markdown(@icla_signature.icla.head) %>
+      <%= render_markdown(@icla_signature.icla.body) %>
+      <%= @icla_signature.icla.version %>
+    </div>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -35,14 +35,14 @@
     <p><%= link_to 'Connect Twitter Account', auth_path(:twitter) %></p>
 
     <% if @user.icla_signatures.any? %>
-      <p><%= link_to "View ICLA", @user.icla_signatures.first %></p>
+      <p><%= link_to "Edit ICLA", @user.icla_signatures.first %></p>
     <% end %>
 
     <% @user.contributors.each do |contributor| %>
       <% if contributor.admin? %>
         <p>
         Admin of <%= contributor.organization.name %> -
-        <%= link_to "View CCLA", contributor.organization.ccla_signature %>
+        <%= link_to "Edit CCLA", contributor.organization.ccla_signature %>
         or
         <%= link_to "Invite Contributors", organization_invitations_url(contributor.organization) %>
         </p>

--- a/spec/features/ccla_updating_spec.rb
+++ b/spec/features/ccla_updating_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_feature_helper'
+
+describe 'updating a CCLA' do
+  before { create(:ccla) }
+
+  it 'updates the CCLA signature and associated Organization name' do
+    sign_in(create(:user))
+    sign_ccla
+    click_link 'View Profile'
+    click_link 'Edit CCLA'
+
+    fill_in 'ccla_signature_company', with: 'Cramer Development'
+    click_button 'Update CCLA'
+
+    expect_to_see_success_message
+
+    click_link 'View Profile'
+
+    expect(page).to have_content('Admin of Cramer Development')
+  end
+end

--- a/spec/features/icla_signing_spec.rb
+++ b/spec/features/icla_signing_spec.rb
@@ -5,11 +5,9 @@ describe 'signing a ICLA' do
 
   it 'associates the signer with a icla' do
     sign_in(create(:user))
-    click_link "Sign ICLA"
-    click_link "Connect GitHub Account"
     sign_icla
     click_link 'View Profile'
-    expect(page).to have_content 'View ICLA'
+    expect(page).to have_content 'Edit ICLA'
     expect(page).to have_no_content 'Sign ICLA'
   end
 end

--- a/spec/features/icla_updating_spec.rb
+++ b/spec/features/icla_updating_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_feature_helper'
+
+describe 'updating a ICLA' do
+  before { create(:icla) }
+
+  it 'updates the ICLA signature' do
+    sign_in(create(:user))
+    sign_icla
+    click_link 'View Profile'
+    click_link 'Edit ICLA'
+
+    click_button 'Update ICLA'
+    expect_to_see_success_message
+  end
+end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -15,6 +15,9 @@ module FeatureHelpers
   end
 
   def sign_icla
+    click_link "Sign ICLA"
+    click_link "Connect GitHub Account"
+
     fill_in 'icla_signature_first_name', with: 'John'
     fill_in 'icla_signature_last_name', with: 'Doe'
     fill_in 'icla_signature_company', with: 'Chef'
@@ -97,7 +100,7 @@ module FeatureHelpers
     check 'invitation_admin'
     find_button('Send invitation').click
 
-	expect_to_see_success_message
+    expect_to_see_success_message
     expect(all('#invitation_admin:checked').size).to eql(1)
   end
 


### PR DESCRIPTION
:fork_and_knife: This adds the ability to update CLA signatures. It also starts to move in the direction of the CLA mockups where the signature form is in the left column and the CLA is in the right column.

This is what it looks like now.

![screen shot 2014-02-03 at 3 44 32 pm](https://f.cloud.github.com/assets/316507/2069426/8c657602-8d14-11e3-8be0-330bdeb9fe53.png)
