### PR TITLE
Enable Travis CI Slack Notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 notifications:
   email: false
+  webhooks: https://getchef.slack.com/services/hooks/travis?token=ECftsW2P2itUaz1MhfiU6cS4
 rvm:
   - 2.0.0
 before_script:


### PR DESCRIPTION
:fork_and_knife: This enables Travis CI to notify Slack the token is semi-secret so there's no real need to encrypt it. As stated in the Slack docs:

> Your integration token is semi-secret. The worst someone could do if they had it was post Travis payloads to your channel. They could not read any data.
