### PR TITLE
Only configure Sentry if configuration exists

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,5 +1,7 @@
-require 'raven'
+if Supermarket::Config.sentry_url.present?
+  require 'raven'
 
-Raven.configure do |config|
-  config.dsn = Supermarket::Config.sentry_url
+  Raven.configure do |config|
+    config.dsn = Supermarket::Config.sentry_url
+  end
 end


### PR DESCRIPTION
:fork_and_knife: This prevents Rails from failing on startup if a Sentry URL hasn't been configured.
