### PR TITLE
Auto authorize spec helper

### DIFF
--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -133,5 +133,4 @@ describe ProfileController do
       end
     end
   end
-
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -10,5 +10,4 @@ describe UsersController do
       expect(assigns[:user]).to eql(user)
     end
   end
-
 end

--- a/spec/support/auto_authorize.rb
+++ b/spec/support/auto_authorize.rb
@@ -1,0 +1,16 @@
+#
+# Stubs out an action for a given model.
+# Useful in controller specs where we don't care about the
+# business logic for who is authorized but merely what happens
+# when they are.
+#
+# @example
+#   auto_authorize!(model, 'action')
+#
+# @param [ActiveRecord::Base]
+# @param [String]
+#
+def auto_authorize!(model, action)
+  allow_any_instance_of(model.policy_class.constantize)
+    .to receive((action + '?').to_sym) { true }
+end


### PR DESCRIPTION
:fork_and_knife: This adds a `auto_authorize!` spec helper which stubs out actions for a given record authorizer. This reads a lot nicer when you're actually in the specs and having a method that accomplishes this lends for the opportunity to document it!

I also refactored some specs to take advantage of contexts for testing authorized/unauthorized states.
