### PR TITLE
View Profile to /edit/profile

### DIFF
--- a/app/views/application/_sidebar.html.erb
+++ b/app/views/application/_sidebar.html.erb
@@ -12,7 +12,7 @@
         <% end %>
 
         <li><%= link_to 'Sign CCLA', new_ccla_signature_path %></li>
-        <li><%= link_to 'View Profile', current_user %></li>
+        <li><%= link_to 'View Profile', edit_profile_path %></li>
 
         <% if current_user && current_user.is?(:admin) %>
           <li>

--- a/spec/features/change_password_spec.rb
+++ b/spec/features/change_password_spec.rb
@@ -4,7 +4,6 @@ describe 'changing the current user password' do
   it 'changes the current users password' do
     sign_in(create(:user))
     click_link 'View Profile'
-    click_link 'manage-profile'
     click_link 'manage-password'
 
     fill_in 'user_current_password', with: 'password'

--- a/spec/features/edit_profile_spec.rb
+++ b/spec/features/edit_profile_spec.rb
@@ -4,7 +4,6 @@ describe 'editing the current user profile' do
   it 'updates the users profile' do
     sign_in(create(:user))
     click_link 'View Profile'
-    click_link 'manage-profile'
 
     fill_in 'user_email', with: 'eddardstark@agofai.com'
     fill_in 'user_first_name', with: 'Eddard'

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -87,7 +87,6 @@ module FeatureHelpers
 
   def manage_agreements
     click_link 'View Profile'
-    click_link 'manage-profile'
     click_link 'manage-agreements'
   end
 
@@ -136,7 +135,6 @@ module FeatureHelpers
 
   def connect_github_account
     click_link 'View Profile'
-    click_link 'manage-profile'
     click_link 'manage-github-accounts'
     click_link 'connect-github'
   end


### PR DESCRIPTION
:fork_and_knife: It makes more sense that when a user views their profile their intention is to manage their profile in some fashion. So this changes "View Profile" in the main navigation to head on over to /edit/profile.
