### PR TITLE
Add link GitHub account action

### DIFF
--- a/app/controllers/ccla_signatures_controller.rb
+++ b/app/controllers/ccla_signatures_controller.rb
@@ -103,7 +103,7 @@ class CclaSignaturesController < ApplicationController
     if !current_user.linked_github_account?
       store_location_for current_user, request.path
 
-      redirect_to current_user,
+      redirect_to link_github_profile_path,
         notice: t('ccla_signature.requires_linked_github')
     end
   end

--- a/app/controllers/icla_signatures_controller.rb
+++ b/app/controllers/icla_signatures_controller.rb
@@ -121,7 +121,7 @@ class IclaSignaturesController < ApplicationController
     if !current_user.linked_github_account?
       store_location_for current_user, request.path
 
-      redirect_to current_user,
+      redirect_to link_github_profile_path,
         notice: t('icla_signature.requires_linked_github')
     end
   end

--- a/app/views/profile/link_github.html.erb
+++ b/app/views/profile/link_github.html.erb
@@ -1,0 +1,3 @@
+<h1>Link GitHub</h1>
+<p>In order for Supermarket to tie your GitHub commits with your signed CLA you must link your GitHub account with your Supermarket profile. By clicking the button below you'll be redirected to GitHub to authorize Supermarket with limited public access to your GitHub account.</p>
+<%= link_to '<i class="fa fa-github"></i> Connect GitHub'.html_safe, auth_path(:github), class: 'button radius expand', id: 'connect-github' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Supermarket::Application.routes.draw do
   resource :profile, controller: 'profile', only: [:update, :edit] do
     collection do
       patch :change_password
+      get :link_github, path: 'link-github'
     end
   end
 

--- a/spec/controllers/ccla_signatures_controller_spec.rb
+++ b/spec/controllers/ccla_signatures_controller_spec.rb
@@ -39,7 +39,7 @@ describe CclaSignaturesController do
       end
 
       it 'redirects the user to their profile' do
-        expect(response).to redirect_to(user)
+        expect(response).to redirect_to(link_github_profile_path)
       end
 
       it 'prompts the user to link their GitHub account' do
@@ -91,8 +91,8 @@ describe CclaSignaturesController do
         }
       end
 
-      it 'redirects the user to their profile' do
-        expect(response).to redirect_to(user)
+      it 'directs the user to link their github account' do
+        expect(response).to redirect_to(link_github_profile_path)
       end
 
       it 'prompts the user to link their github account' do
@@ -163,8 +163,8 @@ describe CclaSignaturesController do
         }
       end
 
-      it 'redirects the user to their profile' do
-        expect(response).to redirect_to(user)
+      it 'directs the user to link their github account' do
+        expect(response).to redirect_to(link_github_profile_path)
       end
 
       it 'prompts the user to link their github account' do

--- a/spec/controllers/icla_signatures_controller_spec.rb
+++ b/spec/controllers/icla_signatures_controller_spec.rb
@@ -69,8 +69,8 @@ describe IclaSignaturesController do
         get :new
       end
 
-      it 'redirects the user to their profile' do
-        expect(response).to redirect_to(admin)
+      it 'directs the user to link their github account' do
+        expect(response).to redirect_to(link_github_profile_path)
       end
 
       it 'prompts the user to link their GitHub account' do
@@ -93,8 +93,8 @@ describe IclaSignaturesController do
         post :create, icla_signature: { first_name: 'T', last_name: 'Rex' }
       end
 
-      it 'redirects the user to their profile' do
-        expect(response).to redirect_to(admin)
+      it 'directs the user to link their github account' do
+        expect(response).to redirect_to(link_github_profile_path)
       end
 
       it 'prompts the user to link their GitHub account' do
@@ -168,7 +168,7 @@ describe IclaSignaturesController do
       end
 
       it 'redirects the user to their profile' do
-        expect(response).to redirect_to(admin)
+        expect(response).to redirect_to(link_github_profile_path)
       end
 
       it 'prompts the user to link their GitHub account' do

--- a/spec/features/account_linking_spec.rb
+++ b/spec/features/account_linking_spec.rb
@@ -3,6 +3,7 @@ require 'spec_feature_helper'
 describe 'linking an OAuth account to a user' do
   it 'associates a user with a GitHub account' do
     sign_in(create(:user))
+    manage_github_accounts
     connect_github_account
     expect_to_see_success_message
   end
@@ -11,6 +12,7 @@ end
 describe 'unlinking an OAuth account on a user' do
   it 'unassociates a user with a GitHub account' do
     sign_in(create(:user))
+    manage_github_accounts
     connect_github_account
     click_link 'manage-github-accounts'
     click_link 'disconnect-github'

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -135,10 +135,13 @@ module FeatureHelpers
   end
 
   def connect_github_account
-    click_link 'View Profile'
-    click_link 'manage-profile'
-    click_link 'manage-github-accounts'
     click_link 'connect-github'
+  end
+
+  def manage_github_accounts
+    click_link 'View Profile'
+    click_link 'Manage Profile'
+    click_link 'manage-github-accounts'
   end
 
   def expect_to_see_success_message


### PR DESCRIPTION
:fork_and_knife: Currently users are just dumped to /users/:id when they are prompted to link their GitHub account and then just have to figure out how to. This adds a new action at /profile/link-github that just provides a nice big button that starts the OAuth process. Users are now dumped to this action if they attempt to sign a CLA without having a linked GitHub account.
![screen shot 2014-02-18 at 9 53 08 am](https://f.cloud.github.com/assets/316507/2196267/8c79de46-98ac-11e3-8334-9bec8d534be9.png)
