### PR TITLE
Add Twitter username to users

### DIFF
--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -52,6 +52,7 @@ class ProfileController < ApplicationController
       :first_name,
       :last_name,
       :company,
+      :twitter_username,
       :irc_nickname,
       :jira_username
     )

--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -28,6 +28,9 @@
           <div class="company-field">
             <%= f.text_field :company, placeholder: 'Company', title: 'Company' %>
           </div>
+          <div class="twitterusername-field">
+            <%= f.text_field :twitter_username, placeholder: 'Twitter Username', title: 'twitter username' %>
+          </div>
           <div class="ircnickname-field">
             <%= f.text_field :irc_nickname, placeholder: 'IRC Nickname', title: 'irc nickname' %>
           </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,6 +11,12 @@
           <span class="fa fa-building"></span> <%= @user.company %>
         </li>
 
+        <% if @user.twitter_username.present? %>
+          <li data-tooltip class="has-tip" title="<%= @user.name %>'s Twitter Username.">
+            <i class="fa fa-twitter"></i> <%= @user.twitter_username %>
+          </li>
+        <% end %>
+
         <% if @user.irc_nickname.present? %>
           <li data-tooltip class="has-tip" title="<%= @user.name %>'s IRC Nickname.">
             <i class="fa fa-comment"></i> <%= @user.irc_nickname %>

--- a/db/migrate/20140218160134_add_twitter_username_to_users.rb
+++ b/db/migrate/20140218160134_add_twitter_username_to_users.rb
@@ -1,0 +1,5 @@
+class AddTwitterUsernameToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :twitter_username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140214190948) do
+ActiveRecord::Schema.define(version: 20140218160134) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -176,6 +176,7 @@ ActiveRecord::Schema.define(version: 20140214190948) do
     t.string   "last_sign_in_ip"
     t.string   "jira_username"
     t.string   "irc_nickname"
+    t.string   "twitter_username"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -31,6 +31,7 @@ describe ProfileController do
           'first_name' => 'Bob',
           'last_name' => 'Smith',
           'company' => 'Acme',
+          'twitter_username' => 'bobbo',
           'irc_nickname' => 'bobbo',
           'jira_username' => 'bobbo'
         })
@@ -42,6 +43,7 @@ describe ProfileController do
           'first_name' => 'Bob',
           'last_name' => 'Smith',
           'company' => 'Acme',
+          'twitter_username' => 'bobbo',
           'irc_nickname' => 'bobbo',
           'jira_username' => 'bobbo'
         })


### PR DESCRIPTION
:fork_and_knife: Since we're no longer allowing users to link their Twitter account via OAuth since it has no current value. This adds a twitter_username attribute to User and exposes it to /users/:id and /profile/edit.
