### PR TITLE
CCLA table expanding fix

### DIFF
--- a/app/assets/javascripts/expandTable.js
+++ b/app/assets/javascripts/expandTable.js
@@ -1,5 +1,6 @@
 $(function() {
-  $(".expand").click(function() {
+  $(".expand").click(function(event) {
+    event.preventDefault();
     $('.contributor-' + $(this).data('id')).toggle();
   });
 });


### PR DESCRIPTION
:fork_and_knife: This fixes an issue where when you click view contributors on the CCLA list it would jump to the top of the page as it's an anchor link. This just adds preventDefault to tame this behavior.
