### PR TITLE
Remove non-existent recipes

### DIFF
--- a/chef/cookbooks/supermarket/recipes/default.rb
+++ b/chef/cookbooks/supermarket/recipes/default.rb
@@ -17,11 +17,10 @@
 # limitations under the License.
 #
 
-include_recipe 'supermarket::_git'
-include_recipe 'supermarket::_editors'
 include_recipe 'supermarket::_node'
 include_recipe 'supermarket::_postgres'
 include_recipe 'supermarket::_redis'
+include_recipe 'supermarket::_sidekiq'
 include_recipe 'supermarket::_ruby'
 include_recipe 'supermarket::_nginx'
 include_recipe 'supermarket::_application'


### PR DESCRIPTION
:fork_and_knife: This removes recipes that were removed in #117 from the default Supermarket recipe so the default recipe doesn't fail.
