### PR TITLE
CCLA table expanding fix

### DIFF
--- a/app/assets/javascripts/expandContributors.js
+++ b/app/assets/javascripts/expandContributors.js
@@ -1,0 +1,6 @@
+$(function() {
+  $(".expand-contributors").click(function(event) {
+    event.preventDefault();
+    $('.contributor-' + $(this).data('id')).toggle();
+  });
+});

--- a/app/assets/javascripts/expandTable.js
+++ b/app/assets/javascripts/expandTable.js
@@ -1,5 +1,0 @@
-$(function() {
-  $(".expand").click(function() {
-    $('.contributor-' + $(this).data('id')).toggle();
-  });
-});

--- a/app/views/ccla_signatures/index.html.erb
+++ b/app/views/ccla_signatures/index.html.erb
@@ -14,7 +14,7 @@
         <tr>
           <td><%= ccla_signature.company %></td>
           <td><%= ccla_signature.signed_at.to_date.to_s(:long) %></td>
-          <td colspan="2" width="25%"><a href="#" class="expand button radius tiny" data-id="<%= ccla_signature.id %>">View</a></td>
+          <td colspan="2" width="25%"><a href="#" class="expand-contributors button radius tiny" data-id="<%= ccla_signature.id %>">View</a></td>
         </tr>
 
         <tr class="text-left hide contributor-<%= ccla_signature.id %>">


### PR DESCRIPTION
:fork_and_knife: This fixes an issue where when you click view contributors on the CCLA list it would jump to the top of the page as it's an anchor link. This just adds preventDefault to tame this behavior. It also changes the binding class for the click event so it doesn't conflict with the Foundation expand class.
