### PR TITLE
Clarify commit author import collaborators

### DIFF
--- a/spec/workers/curry/import_unknown_pull_request_commit_authors_worker_spec.rb
+++ b/spec/workers/curry/import_unknown_pull_request_commit_authors_worker_spec.rb
@@ -2,10 +2,15 @@ require 'spec_helper'
 
 describe Curry::ImportUnknownPullRequestCommitAuthorsWorker do
 
-  it 'imports commit authors from the given Pull Request' do
+  before do
     allow(Curry::ClaValidationWorker).to receive(:perform_async)
+    allow_any_instance_of(Curry::ImportUnknownPullRequestCommitAuthors).
+      to receive(:import)
+  end
 
-    pull_request = create(:pull_request)
+  let(:pull_request) { create(:pull_request) }
+
+  it 'imports commit authors from the given Pull Request' do
     expect_any_instance_of(Curry::ImportUnknownPullRequestCommitAuthors).
       to receive(:import)
 
@@ -14,9 +19,9 @@ describe Curry::ImportUnknownPullRequestCommitAuthorsWorker do
   end
 
   it 'runs the ClaValidationWorker' do
-    pull_request = create(:pull_request)
     expect(Curry::ClaValidationWorker).
-      to receive(:perform_async)
+      to receive(:perform_async).
+      with(pull_request.id)
 
     worker = Curry::ImportUnknownPullRequestCommitAuthorsWorker.new
     worker.perform(pull_request.id)


### PR DESCRIPTION
:fork_and_knife:

These specs now document which messages we expect to send to collaborators. They're also more protected from changes to the internals of the collaborators. This might conflict slightly with what you're working on, @brettchalupa. Let me know if you want to work together to resolve those conflicts.
