### PR TITLE
Make managing CCLAs and contributors more cohesive

### DIFF
--- a/app/assets/stylesheets/libs/_structure.scss
+++ b/app/assets/stylesheets/libs/_structure.scss
@@ -77,7 +77,9 @@ body {
   @include grid-row($behavior: nest);
   margin: 0;
 
-  .signature {
+  .tabs { margin-bottom: 40px !important; }
+
+  .signature, .contributors {
     @include grid-column(5, $collapse: true);
   }
 

--- a/app/controllers/organization_invitations_controller.rb
+++ b/app/controllers/organization_invitations_controller.rb
@@ -1,6 +1,6 @@
 class OrganizationInvitationsController < ApplicationController
+  before_filter :authenticate_user!
   before_filter :find_organization
-
 
   #
   # GET /organizations/:organization_id/invitations

--- a/app/helpers/contributors_helper.rb
+++ b/app/helpers/contributors_helper.rb
@@ -1,0 +1,25 @@
+module ContributorsHelper
+  #
+  # Returns a link to remove a contributor from a CCLA with different text and
+  # rel depending on if the contributor belongs to the current user or not.
+  #
+  # @param [Contributor] the contributor to remove
+  #
+  # @example Remove contributor link for a given contributor
+  #   remove_contributor_link_for(contributor)
+  #
+  # @return [String] a HTML link to remove a contributor
+  #
+  def remove_contributor_link_for(contributor)
+    if contributor.user == current_user
+      text = 'Remove Myself as a Contributor'
+      rel = 'remove_self'
+    else
+      text = 'Remove Contributor'
+      rel = 'remove_contributor'
+    end
+
+    return link_to text, organization_contributor_url(contributor.organization, contributor),
+      method: :delete, rel: rel, class: 'button secondary radius tiny'
+  end
+end

--- a/app/views/ccla_signatures/show.html.erb
+++ b/app/views/ccla_signatures/show.html.erb
@@ -1,5 +1,10 @@
 <div class="cla">
-  <h1>Corporate Contributor License Agreement <small>(CCLA)</small></h1>
+  <h1>Corporate Contributor License Agreement for <%= @ccla_signature.organization.name %> <small>(CCLA)</small></h1>
+
+  <dl class="tabs">
+    <dd class="active"><%= link_to 'Signature', @ccla_signature %></dd>
+    <dd><%= link_to 'Contributors', organization_invitations_path(@ccla_signature.organization) %></dd>
+  </dl>
 
   <div class="signature">
     <%= form_for(@ccla_signature.dup, url: { action: :re_sign }, data: { abide: true }) do |f| %>

--- a/app/views/organization_invitations/index.html.erb
+++ b/app/views/organization_invitations/index.html.erb
@@ -1,86 +1,95 @@
-<h1>Invite contributors to <%= @organization.name %></h1>
+<div class="cla">
+  <h1>Corporate Contributor License Agreement for <%= @organization.name %> <small>(CCLA)</small></h1>
 
-<%= form_for([@organization, @invitation], data: { abide: true }) do |f| %>
-  <%= render 'application/form_errors', record: @invitation %>
-  <div class="row collapse">
-    <div class="small-10 columns">
-      <%= f.email_field :email, placeholder: 'Contributor Email',  title: 'Contributor Email', autofocus: true, require: '', pattern: 'email' %>
-      <small class="error">A valid email is required.</small>
-    </div>
-    <div class="small-2 columns">
-      <%= f.submit 'Send Invite', class: 'button primary radius postfix' %>
-    </div>
-  </div>
-  <div class="row collapse">
-    <div class="small-12 columns">
-      <%= f.check_box :admin  %>
-      <label for="invitation_admin">Make this user an admin of <%= @organization.name %>.</label>
-    </div>
-  </div>
-<% end %>
-<br>
-<h2>Contributors</h2>
-<table width="100%">
-  <thead>
-    <tr>
-      <th>Email</th>
-      <th>Admin</th>
-      <th>Status</th>
-      <th>Actions</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @pending_invitations.each do |invitation| %>
-      <tr class="contributor <%= invitation.admin? ? 'admin' : '' %>">
-        <td><%= invitation.email %></td>
-        <td>
-          <%= form_for [@organization, invitation], remote: true do |f| %>
-            <%= f.check_box :admin, class: 'auto trigger' %>
-          <% end %>
-        </td>
-        <td><%= "Pending" %></td>
-        <td><%= link_to "Resend", resend_organization_invitation_path(@organization, invitation), method: :patch, class: 'button secondary radius tiny', rel: 'resend_invitation' %></td>
-      </tr>
+  <dl class="tabs">
+    <dd><%= link_to 'Signature', @organization.latest_ccla_signature  %></dd>
+    <dd class="active"><%= link_to 'Contributors', organization_invitations_path(@organization) %></dd>
+  </dl>
+
+  <div class="contributors">
+    <%= form_for([@organization, @invitation], data: { abide: true }) do |f| %>
+      <%= render 'application/form_errors', record: @invitation %>
+      <div class="row collapse">
+        <div class="small-10 columns">
+          <%= f.email_field :email, placeholder: 'Contributor Email', title: 'Contributor Email', autofocus: true, require: true, pattern: 'email' %>
+          <small class="error">A valid email is required.</small>
+        </div>
+        <div class="small-2 columns">
+          <%= f.submit 'Send Invite', class: 'button primary radius postfix' %>
+        </div>
+      </div>
+      <div class="row collapse">
+        <div class="small-12 columns">
+          <%= f.check_box :admin  %>
+          <label for="invitation_admin">Make this user an admin of the <%= @organization.name %> CCLA.</label>
+        </div>
+      </div>
     <% end %>
-
-    <% @contributors.each do |contributor| %>
-      <tr class="contributor <%= contributor.admin? ? 'admin' : '' %>">
-        <td><%= contributor.email %></td>
-        <td>
-          <% if contributor.user != current_user %>
-            <%= form_for [@organization, contributor], remote: true do |f| %>
-              <%= f.check_box :admin, class: 'auto trigger' %>
-            <% end %>
-          <% else %>
-            <input type="checkbox" disabled>
-          <% end %>
-        </td>
-        <td><%= "Accepted" %></td>
-        <% if contributor.user == current_user %>
-          <% text = "Remove Myself as a Contributor" %>
-          <% rel = "remove_self" %>
-        <% else %>
-          <% text = "Remove Contributor" %>
-          <% rel = "remove_contributor" %>
+    <br>
+    <h2>Contributors</h2>
+    <table width="100%">
+      <thead>
+        <tr>
+          <th>Email</th>
+          <th>Admin</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @pending_invitations.each do |invitation| %>
+          <tr class="contributor <%= invitation.admin? ? 'admin' : '' %>">
+            <td><%= invitation.email %></td>
+            <td>
+              <%= form_for [@organization, invitation], remote: true do |f| %>
+                <%= f.check_box :admin, class: 'auto trigger' %>
+              <% end %>
+            </td>
+            <td><%= "Pending" %></td>
+            <td><%= link_to "Resend", resend_organization_invitation_path(@organization, invitation), method: :patch, class: 'button secondary radius tiny', rel: 'resend_invitation' %></td>
+          </tr>
         <% end %>
 
-        <td>
-          <% if policy(contributor).destroy? %>
-            <%= link_to text, organization_contributor_url(@organization, contributor), method: :delete, rel: rel %>
-          <% else %>
-            -
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
+        <% @contributors.each do |contributor| %>
+          <tr class="contributor <%= contributor.admin? ? 'admin' : '' %>">
+            <td><%= contributor.email %></td>
+            <td>
+              <% if contributor.user != current_user %>
+                <%= form_for [@organization, contributor], remote: true do |f| %>
+                  <%= f.check_box :admin, class: 'auto trigger' %>
+                <% end %>
+              <% else %>
+                <input type="checkbox" disabled>
+              <% end %>
+            </td>
+            <td><%= "Active" %></td>
+            <td>
+              <% if policy(contributor).destroy? %>
+                <%= remove_contributor_link_for(contributor) %>
+              <% else %>
+                -
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
 
-    <% @declined_invitations.each do |invitation| %>
-      <tr class="contributor <%= invitation.admin? ? 'admin' : '' %>">
-        <td><%= invitation.email %></td>
-        <td><%= invitation.admin? ? 'Admin' : 'Contributor' %></td>
-        <td><%= "Declined" %></td>
-        <td>-</td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+        <% @declined_invitations.each do |invitation| %>
+          <tr class="contributor <%= invitation.admin? ? 'admin' : '' %>">
+            <td><%= invitation.email %></td>
+            <td><%= invitation.admin? ? 'Admin' : 'Contributor' %></td>
+            <td><%= "Declined" %></td>
+            <td>-</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="agreement">
+    <div class="panel">
+      <%= render_markdown(@organization.latest_ccla_signature.ccla.head) %>
+      <%= render_markdown(@organization.latest_ccla_signature.ccla.body) %>
+      <footer><%= @organization.latest_ccla_signature.ccla.version %></footer>
+    </div>
+  </div>
+</div>

--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -86,7 +86,7 @@
               <td class="text-right">
                 <%= link_to "Edit CCLA", contributor.organization.latest_ccla_signature %>
                 <span> or</span>
-                <%= link_to "Invite Contributors", organization_invitations_url(contributor.organization), rel: 'invite_contributors' %>
+                <%= link_to "Manage Contributors", organization_invitations_url(contributor.organization), rel: 'invite_contributors' %>
               </td>
             </tr>
           <% else %>

--- a/spec/helpers/contributors_helper_spec.rb
+++ b/spec/helpers/contributors_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe ContributorsHelper do
+  let(:user) { create(:user) }
+
+  describe '#remove_contributor_link_for' do
+    it 'returns a remove myself contributor link when the current user owns the contributor' do
+      helper.stub(:current_user) { user }
+      contributor = create(:contributor, user: user)
+
+      expect(helper.remove_contributor_link_for(contributor)).to match(/<a.*remove_self/)
+    end
+
+    it 'returns a remove contributor link  when the current user owns the contributor' do
+      helper.stub(:current_user) { user }
+      contributor = create(:contributor)
+
+      expect(helper.remove_contributor_link_for(contributor)).to match(/<a.*remove_contributor/)
+    end
+  end
+end


### PR DESCRIPTION
:fork_and_knife: This adds links between viewing a CCLA and managing contributors to make the UI more cohesive. It also moves some view logic for remove contributors links into a helper method and tests it.
