### PR TITLE
Handle blank contributors invites.

### DIFF
--- a/app/controllers/organization_invitations_controller.rb
+++ b/app/controllers/organization_invitations_controller.rb
@@ -34,7 +34,8 @@ class OrganizationInvitationsController < ApplicationController
       redirect_to organization_invitations_path(@organization),
         notice: "Invited #{@invitation.email} to #{@organization.name}"
     else
-      render 'index'
+      redirect_to organization_invitations_path(@organization),
+        alert: t('organization_invitations.invite.failure')
     end
   end
 

--- a/app/views/organization_invitations/index.html.erb
+++ b/app/views/organization_invitations/index.html.erb
@@ -1,10 +1,11 @@
 <h1>Invite contributors to <%= @organization.name %></h1>
 
-<%= form_for([@organization, @invitation]) do |f| %>
+<%= form_for([@organization, @invitation], data: { abide: true }) do |f| %>
   <%= render 'application/form_errors', record: @invitation %>
   <div class="row collapse">
     <div class="small-10 columns">
-      <%= f.email_field :email, placeholder: 'Contributor Email',  title: 'Contributor Email', autofocus: true %>
+      <%= f.email_field :email, placeholder: 'Contributor Email',  title: 'Contributor Email', autofocus: true, require: '', pattern: 'email' %>
+      <small class="error">A valid email is required.</small>
     </div>
     <div class="small-2 columns">
       <%= f.submit 'Send Invite', class: 'button primary radius postfix' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,9 @@ en:
     requires_linked_github: "You need to link your GitHub account before you sign an ICLA"
   ccla_signature:
     requires_linked_github: "You need to link your GitHub account before you sign a CCLA"
+  organization_invitations:
+    invite:
+      failure: "Your invitation was unable to be sent. Did you specify an email address?"
   curry:
     repositories:
       subscribe:

--- a/spec/controllers/organization_invitations_controller_spec.rb
+++ b/spec/controllers/organization_invitations_controller_spec.rb
@@ -73,6 +73,15 @@ describe OrganizationInvitationsController do
             invitation: { email: 'chef@example.com' }
         }.to change(ActionMailer::Base.deliveries, :size).by(1)
       end
+
+      it 'displays an alert if the invitation did not save' do
+        post :create,
+          organization_id: organization.id,
+          invitation: { email: '' }
+
+        expect(flash.now[:alert]).
+          to eql(I18n.t('organization_invitations.invite.failure'))
+      end
     end
 
     context 'user is not authorized to create an Invitation' do


### PR DESCRIPTION
:fork_and_knife: Redirect to the organization_invitations_path if an invitation is not valid. Add
abide to the form.

Closes: https://app.getsentry.com/chef/supermarket/group/15124570/#http
