### PR TITLE
Organization admins can revoke CCLA invitations.

### DIFF
--- a/app/assets/stylesheets/libs/_structure.scss
+++ b/app/assets/stylesheets/libs/_structure.scss
@@ -79,8 +79,12 @@ body {
 
   .tabs { margin-bottom: 40px !important; }
 
-  .signature, .contributors {
+  .signature {
     @include grid-column(5, $collapse: true);
+  }
+
+  .contributors {
+    @include grid-column(12, $collapse: true);
   }
 
   .agreement {

--- a/app/authorizers/invitation_authorizer.rb
+++ b/app/authorizers/invitation_authorizer.rb
@@ -14,4 +14,8 @@ class InvitationAuthorizer < Authorizer::Base
   def resend?
     index?
   end
+
+  def revoke?
+    index?
+  end
 end

--- a/app/controllers/organization_invitations_controller.rb
+++ b/app/controllers/organization_invitations_controller.rb
@@ -70,6 +70,22 @@ class OrganizationInvitationsController < ApplicationController
       invitation for #{@invitation.email}"
   end
 
+  #
+  # DELETE /organizations/:organization_id/invitations/:id/resend
+  #
+  # Revokes an invitation.
+  #
+  def revoke
+    @invitation = Invitation.with_token!(params[:id])
+
+    authorize! @invitation
+
+    @invitation.destroy
+
+    redirect_to :back, notice: "Successfully revoked
+      invitation for #{@invitation.email}"
+  end
+
   private
 
   def invitation_params

--- a/app/views/organization_invitations/index.html.erb
+++ b/app/views/organization_invitations/index.html.erb
@@ -46,7 +46,12 @@
               <% end %>
             </td>
             <td><%= "Pending" %></td>
-            <td><%= link_to "Resend", resend_organization_invitation_path(@organization, invitation), method: :patch, class: 'button secondary radius tiny', rel: 'resend_invitation' %></td>
+            <td>
+              <ul class="button-group radius">
+                <li><%= link_to "Resend", resend_organization_invitation_path(@organization, invitation), method: :patch, class: 'button secondary tiny', rel: 'resend_invitation' %></li>
+                <li><%= link_to "Revoke", revoke_organization_invitation_path(@organization, invitation), method: :delete, class: 'button alert tiny', rel: 'revoke_invitation' %></li>
+              </ul>
+            </td>
           </tr>
         <% end %>
 
@@ -85,11 +90,4 @@
     </table>
   </div>
 
-  <div class="agreement">
-    <div class="panel">
-      <%= render_markdown(@organization.latest_ccla_signature.ccla.head) %>
-      <%= render_markdown(@organization.latest_ccla_signature.ccla.body) %>
-      <footer><%= @organization.latest_ccla_signature.ccla.version %></footer>
-    </div>
-  </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Supermarket::Application.routes.draw do
 
       member do
         patch :resend
+        delete :revoke
       end
     end
   end

--- a/spec/authorizers/invitation_authorizer_spec.rb
+++ b/spec/authorizers/invitation_authorizer_spec.rb
@@ -13,6 +13,7 @@ describe InvitationAuthorizer do
     it { should permit(:create) }
     it { should permit(:update) }
     it { should permit(:resend) }
+    it { should permit(:revoke) }
   end
 
   context 'as an organization contributor' do
@@ -23,5 +24,6 @@ describe InvitationAuthorizer do
     it { should_not permit(:create) }
     it { should_not permit(:update) }
     it { should_not permit(:resend) }
+    it { should_not permit(:revoke) }
   end
 end

--- a/spec/controllers/organization_invitations_controller_spec.rb
+++ b/spec/controllers/organization_invitations_controller_spec.rb
@@ -169,4 +169,36 @@ describe OrganizationInvitationsController do
       end
     end
   end
+
+  describe 'DELETE #revoke' do
+    let!(:invitation) { create(:invitation) }
+    before { request.env['HTTP_REFERER'] = 'the_previous_path' }
+
+    context 'user is authorized to resend Invitation' do
+      before { auto_authorize!(Invitation, 'revoke') }
+
+      it 'destroys the invitation' do
+        expect {
+          delete :revoke, organization_id: organization.id,
+            id: invitation.token
+        }.to change(Invitation, :count).by(-1)
+      end
+    end
+
+    context 'user is not authorized to revoke Invitation' do
+      it "doesn't revoke the invitation" do
+        expect {
+          delete :revoke, organization_id: organization.id,
+            id: invitation.token
+        }.to_not change(Invitation, :count).by(-1)
+      end
+
+      it 'responds with 404' do
+        delete :revoke, organization_id: organization.id,
+          id: invitation.token
+
+        should respond_with(404)
+      end
+    end
+  end
 end

--- a/spec/features/ccla_invitation_actions_spec.rb
+++ b/spec/features/ccla_invitation_actions_spec.rb
@@ -8,3 +8,12 @@ describe 'resending an invitation to a CCLA' do
     expect_to_see_success_message
   end
 end
+
+describe 'cancelling an invitation to a CCLA' do
+  it 'removes the invitation' do
+    sign_ccla_and_invite_admin_to('Acme')
+    follow_relation 'revoke_invitation'
+
+    expect_to_see_success_message
+  end
+end


### PR DESCRIPTION
:fork_and_knife: This allows good ole organization admins to revoke invitations. If a user accepts a revoked invitation, they are presented with a 404. This _might_ not be what we want to happen, so we should discuss that!

Pivotal Tracker ID: 65497338
https://www.pivotaltracker.com/story/show/65497338

![screen shot 2014-02-20 at 9 40 56 am](https://f.cloud.github.com/assets/928367/2219684/235b8d9e-9a44-11e3-924e-9d8c13777c87.png)

Worth noting: I called the controller action `revoke` instead of `destroy`. I thought it was more intention revealing of what is happening. Is it a Rails sin to not have the DELETE action be called `destroy`? This also leads me to question - should the record be destroyed or should we just have a flag that gets set to `revoked=true`? Do we care about having a record of revoked invitations? All of the questions!
