### PR TITLE
Implement initial version of listing cookbooks through the API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'statsd-ruby', require: 'statsd'
 gem 'octokit', github: 'octokit/octokit.rb', require: false
 gem 'sidekiq'
 gem 'premailer-rails', group: [:development, :production]
+gem 'jbuilder'
 
 gem 'sass-rails',   '~> 4.0.1'
 gem 'compass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,9 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.6.9)
+    jbuilder (1.5.3)
+      activesupport (>= 3.0.0)
+      multi_json (>= 1.2.0)
     jquery-rails (3.1.0)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -296,6 +299,7 @@ DEPENDENCIES
   dotenv-rails
   factory_girl
   foreman
+  jbuilder
   jquery-rails
   launchy
   license_finder

--- a/app/controllers/api/v1/cookbooks_controller.rb
+++ b/app/controllers/api/v1/cookbooks_controller.rb
@@ -1,0 +1,10 @@
+class Api::V1::CookbooksController < ApplicationController
+
+  def index
+    @start = params.fetch(:start, 0).to_i
+    @items = [params.fetch(:items, 10).to_i, 100].min
+    @total = Cookbook.count
+    @cookbooks = Cookbook.all.order('name ASC').limit(@items).offset(@start)
+  end
+
+end

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -1,0 +1,7 @@
+class Cookbook < ActiveRecord::Base
+
+  def to_param
+    name.downcase.parameterize
+  end
+
+end

--- a/app/views/api/v1/cookbooks/index.json.jbuilder
+++ b/app/views/api/v1/cookbooks/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.start @start
+json.total @total
+json.items @cookbooks do |cookbook|
+  json.cookbook_name cookbook.name
+  json.cookbook_maintainer cookbook.maintainer
+  json.cookbook_description cookbook.description
+  json.cookbook api_v1_cookbook_url(cookbook)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,9 @@ Supermarket::Application.routes.draw do
    end
 
   namespace :api do
-    resources :icla_signatures, path: 'icla-signatures'
-    resources :users
+    namespace :v1 do
+      resources :cookbooks, only: [:index, :show], defaults: { format: :json }
+    end
   end
 
   resources :icla_signatures, path: 'icla-signatures' do

--- a/db/migrate/20140224215236_create_cookbooks.rb
+++ b/db/migrate/20140224215236_create_cookbooks.rb
@@ -1,0 +1,11 @@
+class CreateCookbooks < ActiveRecord::Migration
+  def change
+    create_table :cookbooks do |t|
+      t.string :name, null: false
+      t.string :maintainer, null: false
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140218160134) do
+ActiveRecord::Schema.define(version: 20140224215236) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,14 @@ ActiveRecord::Schema.define(version: 20140218160134) do
 
   add_index "contributors", ["organization_id"], name: "index_contributors_on_organization_id", using: :btree
   add_index "contributors", ["user_id"], name: "index_contributors_on_user_id", using: :btree
+
+  create_table "cookbooks", force: true do |t|
+    t.string   "name",        null: false
+    t.string   "maintainer",  null: false
+    t.text     "description"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "curry_commit_authors", force: true do |t|
     t.string   "login"

--- a/spec/api/cookbooks_root_spec.rb
+++ b/spec/api/cookbooks_root_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe 'GET /api/v1/cookbooks' do
+
+  it 'returns a 200' do
+    get '/api/v1/cookbooks'
+
+    expect(response.status.to_i).to eql(200)
+  end
+
+  context 'when there are no cookbooks' do
+    it 'returns an empty JSON template' do
+      get '/api/v1/cookbooks'
+
+      expect(json_body).to eql({
+        'start' => 0,
+        'total' => 0,
+        'items' => []
+      })
+    end
+  end
+
+  context 'when there are cookbooks' do
+    let(:sashimi) do
+      {
+        'cookbook_description' => 'Sashimi that will make your heart melt',
+        'cookbook_maintainer' => 'Haru Maru',
+        'cookbook' => 'http://www.example.com/api/v1/cookbooks/sashimi',
+        'cookbook_name' => 'sashimi'
+      }
+    end
+
+    let(:slow_cooking) do
+      {
+        'cookbook_description' => 'The best recipes for your slow cooker',
+        'cookbook_maintainer' => 'Joe Doe',
+        'cookbook' => 'http://www.example.com/api/v1/cookbooks/slow_cooking',
+        'cookbook_name' => 'slow_cooking'
+      }
+    end
+
+    before do
+      create(
+        :cookbook,
+        description: 'The best recipes for your slow cooker',
+        maintainer: 'Joe Doe',
+        name: 'slow_cooking'
+      )
+
+      create(
+        :cookbook,
+        description: 'Sashimi that will make your heart melt',
+        maintainer: 'Haru Maru',
+        name: 'sashimi'
+      )
+    end
+
+    it 'returns a JSON template with the cookbooks' do
+      get '/api/v1/cookbooks'
+
+      expect(json_body).to eql({
+        'start' => 0,
+        'total' => 2,
+        'items' => [sashimi, slow_cooking]
+      })
+    end
+
+  end
+end

--- a/spec/controllers/api/v1/cookbooks_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbooks_controller_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe Api::V1::CookbooksController do
+
+  before do
+    create(:cookbook, name: 'slow_cooking')
+    create(:cookbook, name: 'sashimi')
+  end
+
+  describe '#index' do
+
+    it 'orders the cookbooks by their name' do
+      get :index, format: :json
+
+      cookbook_names = assigns[:cookbooks].map(&:name)
+
+      expect(cookbook_names).to eql(['sashimi', 'slow_cooking'])
+    end
+
+    it 'uses the start param to offset the cookbooks sent to the view' do
+      get :index, start: 1, format: :json
+
+      cookbook_names = assigns[:cookbooks].map(&:name)
+
+      expect(cookbook_names).to eql(['slow_cooking'])
+    end
+
+    it 'passes the start param to the view' do
+      get :index, start: 1, format: :json
+
+      expect(assigns[:start]).to eql(1)
+    end
+
+    it 'defaults the start param to 0' do
+      get :index, format: :json
+
+      expect(assigns[:start]).to eql(0)
+    end
+
+    it 'uses the items param to limit the cookbooks sent to the view' do
+      get :index, items: 1, format: :json
+
+      cookbook_names = assigns[:cookbooks].map(&:name)
+
+      expect(cookbook_names).to eql(['sashimi'])
+    end
+
+    it 'defaults the items param to 10' do
+      get :index, format: :json
+
+      expect(assigns[:items]).to eql(10)
+    end
+
+    it 'limits the number of items to 100' do
+      get :index, items: 101, format: :json
+
+      expect(assigns[:items]).to eql(100)
+    end
+
+    it 'handles the start and items param' do
+      get :index, items: 1, start: 1, format: :json
+
+      cookbook_names = assigns[:cookbooks].map(&:name)
+
+      expect(cookbook_names).to eql(['slow_cooking'])
+    end
+
+    it 'passes the total number of cookbooks to the view' do
+      get :index, format: :json
+
+      expect(assigns[:total]).to eql(2)
+    end
+  end
+
+end

--- a/spec/factories/cookbook.rb
+++ b/spec/factories/cookbook.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :cookbook do
+    description "An awesome cookbook!"
+    maintainer "Chef Software Inc"
+  end
+end

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe Cookbook do
+  describe '#to_param' do
+    it "returns the cookbook's name downcased and parameterized" do
+      cookbook = Cookbook.new(name: 'Spicy Curry')
+      expect(cookbook.to_param).to eql('spicy-curry')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,9 @@ RSpec.configure do |config|
   # Custom helper modules and extensions
   config.include RequestHelpers
 
+  config.include ApiSpecHelpers, type: :request
+  config.include ApiViewSpecHelpers, type: :view
+
   # Prohibit using the should syntax
   config.expect_with :rspec do |spec|
     spec.syntax = :expect

--- a/spec/support/api_spec_helpers.rb
+++ b/spec/support/api_spec_helpers.rb
@@ -1,0 +1,5 @@
+module ApiSpecHelpers
+  def json_body
+    JSON.parse(response.body)
+  end
+end

--- a/spec/support/api_view_spec_helpers.rb
+++ b/spec/support/api_view_spec_helpers.rb
@@ -1,0 +1,5 @@
+module ApiViewSpecHelpers
+  def json_body
+    JSON.parse(rendered)
+  end
+end

--- a/spec/views/api/v1/cookbooks/index.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/index.json.jbuilder_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'api/v1/cookbooks/index' do
+
+  it 'displays the starting offset' do
+    assign(:start, 0)
+
+    render
+
+    expect(json_body['start']).to eql(0)
+  end
+
+  it 'displays the total number of cookbooks' do
+    assign(:total, 666)
+
+    render
+
+    expect(json_body['total']).to eql(666)
+  end
+
+  it 'displays an array of cookbooks' do
+    assign(
+      :cookbooks,
+      [
+        create(
+          :cookbook,
+          name: 'test',
+          description: 'test cookbook',
+          maintainer: 'Chef Software, Inc.'
+        )
+      ]
+    )
+
+    render
+
+    cookbook = json_body['items'].first
+
+    expect(cookbook['cookbook_name']).to eql('test')
+    expect(cookbook['cookbook_maintainer']).to eql('Chef Software, Inc.')
+    expect(cookbook['cookbook_description']).to eql('test cookbook')
+    expect(cookbook['cookbook']).to eql('http://test.host/api/v1/cookbooks/test')
+  end
+
+end


### PR DESCRIPTION
:fork_and_knife:

The API can list cookbooks via /v1/cookbooks.
- The default number of cookbooks returned is 10
- The max number of cookbooks returned is 100
- The cookbooks are sorted alphabetically

Adds JBuilder and an initial skeleton Cookbook model.

http://docs.opscode.com/api_cookbooks_site.html#get
