### PR TITLE
Support GET /api/v1/cookbooks/:cookbook/versions/:version

### DIFF
--- a/app/controllers/api/v1/cookbook_versions_controller.rb
+++ b/app/controllers/api/v1/cookbook_versions_controller.rb
@@ -1,0 +1,37 @@
+class Api::V1::CookbookVersionsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+
+  #
+  # GET /api/v1/cookbooks/:cookbook/versions/:version
+  #
+  # Return a specific CookbookVersion. Returns a 404 if the +Cookbook+ or
+  # +CookbookVersion+ does not exist. The version must be passed in with
+  # underscores in place of periods.
+  #
+  # @example
+  #   GET /api/v1/cookbooks/redis/versions/1_1_0
+  #
+  def show
+    @cookbook = Cookbook.find_by!(name: params[:cookbook])
+    @cookbook_version = @cookbook.get_version!(params[:version])
+  end
+
+  private
+
+  #
+  # Render the error message with a status of 404.
+  #
+  def render_404
+    render json: error_message, status: 404
+  end
+
+  #
+  # The error message for when a resources was not found.
+  #
+  def error_message
+    {
+      error_messages: ['Resource does not exist'],
+      error_code: 'NOT_FOUND'
+    }
+  end
+end

--- a/app/controllers/api/v1/cookbooks_controller.rb
+++ b/app/controllers/api/v1/cookbooks_controller.rb
@@ -1,10 +1,21 @@
 class Api::V1::CookbooksController < ApplicationController
-
+  #
+  # GET /api/v1/cookbooks
+  #
+  # Return all Cookbooks. Defaults to 10 at a time, starting at the first
+  # Cookbook when sorted alphabetically. The max number of Cookbooks that can be
+  # returned is 100.
+  #
+  # Pass in the start and items params to specify the index at which to start
+  # and how many to return.
+  #
+  # @example
+  #   GET /api/v1/cookbooks?start=5&items=15
+  #
   def index
     @start = params.fetch(:start, 0).to_i
     @items = [params.fetch(:items, 10).to_i, 100].min
     @total = Cookbook.count
     @cookbooks = Cookbook.all.order('name ASC').limit(@items).offset(@start)
   end
-
 end

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -1,7 +1,38 @@
 class Cookbook < ActiveRecord::Base
+  has_many :cookbook_versions
 
+  #
+  # Returns the name of the +Cookbook+ parameterized.
+  #
+  # @return [String] the name of the +Cookbook+ parameterized
+  #
   def to_param
-    name.downcase.parameterize
+    name.parameterize
   end
 
+  #
+  # Return the specified +CookbookVersion+. Raises an
+  # +ActiveRecord::RecordNotFound+ if the version does not exist. The first line
+  # of the method translates the version from a parameter friendly verison
+  # (2_0_1) to a dot version (2.0.1).
+  #
+  # @example
+  #   cookbook.get_version!("1_0_0")
+  #   cookbook.get_version!("latest")
+  #
+  # @param version [String] the version of the Cookbook to find. Pass in
+  #                         'latest' to return the latest version of the
+  #                         cookbook.
+  #
+  # @return [CookbookVersion] the +CookbookVersion+ with the version specified
+  #
+  def get_version!(version)
+    version.gsub!(/_/, '.')
+
+    if version == 'latest'
+      cookbook_versions.order('version DESC').first!
+    else
+      cookbook_versions.find_by!(version: version)
+    end
+  end
 end

--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -1,0 +1,8 @@
+class CookbookVersion < ActiveRecord::Base
+  belongs_to :cookbook
+
+  validates :license, presence: true
+  validates :version, presence: true
+  validates :description, presence: true
+  validates :cookbook_id, presence: true
+end

--- a/app/views/api/v1/cookbook_versions/show.json.jbuilder
+++ b/app/views/api/v1/cookbook_versions/show.json.jbuilder
@@ -1,0 +1,6 @@
+json.license @cookbook_version.license
+json.tarball_file_size nil
+json.version @cookbook_version.version
+json.average_rating nil
+json.cookbook api_v1_cookbook_url(@cookbook)
+json.file '/tarballs/original/missing.png'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,9 +11,11 @@ Supermarket::Application.routes.draw do
      get 'sign-up',  to: 'devise/registrations#new', as: 'sign_up'
    end
 
-  namespace :api do
+  namespace :api, defaults: { format: :json }  do
     namespace :v1 do
-      resources :cookbooks, only: [:index, :show], defaults: { format: :json }
+      get 'cookbooks' => 'cookbooks#index'
+      get 'cookbooks/:cookbook' => 'cookbooks#show', as: :cookbook
+      get 'cookbooks/:cookbook/versions/:version' => 'cookbook_versions#show'
     end
   end
 

--- a/db/migrate/20140226140858_create_cookbook_versions.rb
+++ b/db/migrate/20140226140858_create_cookbook_versions.rb
@@ -1,0 +1,14 @@
+class CreateCookbookVersions < ActiveRecord::Migration
+  def change
+    create_table :cookbook_versions do |t|
+      t.integer :cookbook_id
+      t.text :description
+      t.string :license
+      t.string :version
+      t.string :file_url
+      t.string :file_size
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140224215236) do
+ActiveRecord::Schema.define(version: 20140226140858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,17 @@ ActiveRecord::Schema.define(version: 20140224215236) do
 
   add_index "contributors", ["organization_id"], name: "index_contributors_on_organization_id", using: :btree
   add_index "contributors", ["user_id"], name: "index_contributors_on_user_id", using: :btree
+
+  create_table "cookbook_versions", force: true do |t|
+    t.integer  "cookbook_id"
+    t.text     "description"
+    t.string   "license"
+    t.string   "version"
+    t.string   "file_url"
+    t.string   "file_size"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "cookbooks", force: true do |t|
     t.string   "name",        null: false

--- a/spec/api/cookbook_version_spec.rb
+++ b/spec/api/cookbook_version_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe 'GET /api/v1/cookbooks/:cookbook/versions/:version' do
+
+  let(:error_404) do
+    {
+       'error_messages' => ['Resource does not exist'],
+       'error_code' => 'NOT_FOUND'
+    }
+  end
+
+  context 'for a cookbook that exists' do
+    before do
+      create(
+        :cookbook_version,
+        cookbook: create(
+          :cookbook,
+          description: 'Sashimi that will make your heart melt',
+          maintainer: 'Haru Maru',
+          name: 'sashimi'
+       ),
+       license: 'GPLv2',
+       version: '2.0.0'
+      )
+    end
+
+    let(:sashimi_version_signature) do
+      {
+        'license' => 'GPLv2',
+        'tarball_file_size' => nil,
+        'version' => '2.0.0',
+        'average_rating' => nil,
+        'cookbook' => 'http://www.example.com/api/v1/cookbooks/sashimi',
+        'file' => '/tarballs/original/missing.png'
+      }
+    end
+
+    def signature(resource)
+      resource.except('created_at', 'updated_at')
+    end
+
+    context 'for the latest version' do
+      it 'returns a 200' do
+        get '/api/v1/cookbooks/sashimi/versions/latest'
+
+        expect(response.status.to_i).to eql(200)
+      end
+
+      it 'returns a version of the cookbook' do
+        get '/api/v1/cookbooks/sashimi/versions/latest'
+
+        expect(signature(json_body)).to eql(sashimi_version_signature)
+      end
+    end
+
+    context 'for a version that exists' do
+      it 'returns a 200' do
+        get '/api/v1/cookbooks/sashimi/versions/2_0_0'
+
+        expect(response.status.to_i).to eql(200)
+      end
+
+      it 'returns a version of the cookbook' do
+        get '/api/v1/cookbooks/sashimi/versions/2_0_0'
+
+        expect(signature(json_body)).to eql(sashimi_version_signature)
+      end
+    end
+
+    context 'for a version that does not exist' do
+      it 'returns a 404' do
+        get '/api/v1/cookbooks/sashimi/versions/2_1_0'
+
+        expect(response.status.to_i).to eql(404)
+      end
+
+      it 'returns a 404 message' do
+        get '/api/v1/cookbooks/sashimi/versions/2_1_0'
+
+        expect(json_body).to eql(error_404)
+      end
+    end
+  end
+
+  context 'for a cookbook that does not exist' do
+    it 'returns a 404' do
+      get '/api/v1/cookbooks/mamimi/versions/1_3_0'
+
+      expect(response.status.to_i).to eql(404)
+    end
+
+    it 'returns a 404 message' do
+      get '/api/v1/cookbooks/mamimi/versions/1_333'
+
+      expect(json_body).to eql(error_404)
+    end
+  end
+end

--- a/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Api::V1::CookbookVersionsController do
+  describe '#show' do
+    let!(:redis) { create(:cookbook, name: 'redis') }
+
+    let!(:redis_1_0_0) do
+      create(:cookbook_version, cookbook: redis, version: '1.0.0')
+    end
+
+    let!(:redis_0_1_2) do
+      create(:cookbook_version, cookbook: redis, version: '0.1.2')
+    end
+
+    it 'responds with a 200' do
+      get :show, cookbook: 'redis', version: 'latest', format: :json
+
+      expect(response.status.to_i).to eql(200)
+    end
+
+    it 'sends the cookbook to the view' do
+      get :show, cookbook: 'redis', version: 'latest', format: :json
+
+      expect(assigns[:cookbook]).to eql(redis)
+    end
+
+    it 'sends the cookbook version to the view' do
+      get :show, cookbook: 'redis', version: '1.0.0', format: :json
+
+      expect(assigns[:cookbook_version]).to eql(redis_1_0_0)
+    end
+
+    it 'handles the latest version of a cookbook' do
+      get :show, cookbook: 'redis', version: 'latest', format: :json
+
+      expect(assigns[:cookbook_version]).to eql(redis_1_0_0)
+    end
+
+    it 'handles specific versions of a cookbook' do
+      get :show, cookbook: 'redis', version: '0_1_2', format: :json
+
+      expect(assigns[:cookbook_version]).to eql(redis_0_1_2)
+    end
+
+    it '404s if a cookbook version does not exist' do
+      get :show, cookbook: 'redis', version: '4_0_2', format: :json
+
+      expect(response.status.to_i).to eql(404)
+    end
+  end
+end

--- a/spec/factories/cookbook.rb
+++ b/spec/factories/cookbook.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :cookbook do
+    name 'redis'
     description "An awesome cookbook!"
     maintainer "Chef Software Inc"
   end

--- a/spec/factories/cookbook_version.rb
+++ b/spec/factories/cookbook_version.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :cookbook_version do
+    association :cookbook
+
+    description "An awesome cookbook!"
+    license "MIT"
+    version "1.2.0"
+    file_url '/tarballs/original/missing.png'
+    file_size '10KB'
+  end
+end

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -1,10 +1,48 @@
 require 'spec_helper'
 
 describe Cookbook do
+  context 'associations' do
+    it { should have_many(:cookbook_versions) }
+  end
+
   describe '#to_param' do
     it "returns the cookbook's name downcased and parameterized" do
       cookbook = Cookbook.new(name: 'Spicy Curry')
       expect(cookbook.to_param).to eql('spicy-curry')
+    end
+  end
+
+  describe '#get_version!' do
+    let!(:kiwi) { Cookbook.create(name: 'kiwi', maintainer: 'fruit') }
+    let!(:kiwi_0_1_0) do
+      kiwi.cookbook_versions.create(
+        cookbook: kiwi,
+        version: '0.1.0',
+        description: 'bird',
+        license: 'MIT'
+      )
+    end
+
+    let!(:kiwi_0_2_0) do
+      kiwi.cookbook_versions.create(
+        cookbook: kiwi,
+        version: '0.2.0',
+        description: 'better bird',
+        license: 'MIT'
+      )
+    end
+
+    it 'returns the cookbook version specified' do
+      expect(kiwi.get_version!('0_1_0')).to eql(kiwi_0_1_0)
+    end
+
+    it "returns the highest version when the version is 'latest'" do
+      expect(kiwi.get_version!('latest')).to eql(kiwi_0_2_0)
+    end
+
+    it 'raises ActiveRecord::RecordNotFound if the version does not exist' do
+      expect { kiwi.get_version!("0_4_0") }.
+        to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 end

--- a/spec/models/cookbook_version_spec.rb
+++ b/spec/models/cookbook_version_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe CookbookVersion do
+  context 'associations' do
+    it { should belong_to(:cookbook) }
+  end
+
+  context 'validations' do
+    it { should validate_presence_of(:license) }
+    it { should validate_presence_of(:version) }
+    it { should validate_presence_of(:description) }
+    it { should validate_presence_of(:cookbook_id) }
+  end
+end

--- a/spec/views/api/v1/cookbook_versions/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbook_versions/show.json.jbuilder_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'api/v1/cookbook_versions/show' do
+  let(:cookbook) { create(:cookbook, name: 'redis') }
+
+  before do
+    assign(
+      :cookbook,
+      cookbook
+    )
+
+    assign(
+      :cookbook_version,
+      create(
+        :cookbook_version,
+        cookbook: cookbook,
+        license: 'MIT',
+        version: '1.2.0'
+      )
+    )
+  end
+
+  it "displays the cookbook version's license" do
+    render
+
+    cookbook_version_license = json_body['license']
+    expect(cookbook_version_license).to eql('MIT')
+  end
+
+  it "displays the cookbook version's license" do
+    render
+
+    cookbook_version_version = json_body['version']
+    expect(cookbook_version_version).to eql('1.2.0')
+  end
+
+  it "displays the cookbook version's cookbook url" do
+    render
+
+    cookbook_url = json_body['cookbook']
+    expect(cookbook_url).to eql('http://test.host/api/v1/cookbooks/redis')
+  end
+
+  it "displays the cookbook version's tarball file size"
+  it "displays the cookbook version's file url"
+  it "displays the cookbook version's average rating"
+
+end

--- a/spec/views/api/v1/cookbooks/index.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/index.json.jbuilder_spec.rb
@@ -11,11 +11,11 @@ describe 'api/v1/cookbooks/index' do
   end
 
   it 'displays the total number of cookbooks' do
-    assign(:total, 666)
+    assign(:total, 9001)
 
     render
 
-    expect(json_body['total']).to eql(666)
+    expect(json_body['total']).to eql(9001)
   end
 
   it 'displays an array of cookbooks' do


### PR DESCRIPTION
:fork_and_knife: :poultry_leg:

Allow users to get a specific version of a cookbook through the API.

Docs: http://docs.opscode.com/api_cookbooks_site.html#cookbooks-version
