### PR TITLE
Order cookbook_versions by created_at DESC.

### DIFF
--- a/app/controllers/api/v1/cookbooks_controller.rb
+++ b/app/controllers/api/v1/cookbooks_controller.rb
@@ -29,12 +29,12 @@ class Api::V1::CookbooksController < Api::V1Controller
   #
   def show
     @cookbook = Cookbook.find_by!(name: params[:cookbook])
-    cookbook_versions = @cookbook.cookbook_versions.order('version ASC')
+    cookbook_versions = @cookbook.cookbook_versions
     @cookbook_versions_urls = cookbook_versions.map do |version|
       api_v1_cookbook_version_url(@cookbook, version)
     end
 
-    @latest_cookbook_version = cookbook_versions.last
+    @latest_cookbook_version = @cookbook.get_version!('latest')
     @latest_cookbook_version_url = api_v1_cookbook_version_url(@cookbook, @latest_cookbook_version)
   end
 end

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -1,5 +1,5 @@
 class Cookbook < ActiveRecord::Base
-  has_many :cookbook_versions
+  has_many :cookbook_versions, -> { order(created_at: :desc) }
 
   #
   # Returns the name of the +Cookbook+ parameterized.
@@ -30,7 +30,7 @@ class Cookbook < ActiveRecord::Base
     version.gsub!(/_/, '.')
 
     if version == 'latest'
-      cookbook_versions.order('version DESC').first!
+      cookbook_versions.first!
     else
       cookbook_versions.find_by!(version: version)
     end

--- a/spec/api/cookbook_show_spec.rb
+++ b/spec/api/cookbook_show_spec.rb
@@ -13,8 +13,8 @@ describe 'GET /api/v1/cookbooks/:cookbook' do
         'external_url' => nil,
         'versions' =>
           [
-            'http://www.example.com/api/v1/cookbooks/apache/versions/1_0',
-            'http://www.example.com/api/v1/cookbooks/apache/versions/2_0'
+            'http://www.example.com/api/v1/cookbooks/apache/versions/2_0',
+            'http://www.example.com/api/v1/cookbooks/apache/versions/1_0'
           ],
         'description' => 'installs apache.',
         'average_rating' => nil,

--- a/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
@@ -4,12 +4,12 @@ describe Api::V1::CookbookVersionsController do
   describe '#show' do
     let!(:redis) { create(:cookbook, name: 'redis') }
 
-    let!(:redis_1_0_0) do
-      create(:cookbook_version, cookbook: redis, version: '1.0.0')
-    end
-
     let!(:redis_0_1_2) do
       create(:cookbook_version, cookbook: redis, version: '0.1.2')
+    end
+
+    let!(:redis_1_0_0) do
+      create(:cookbook_version, cookbook: redis, version: '1.0.0')
     end
 
     it 'responds with a 200' do

--- a/spec/controllers/api/v1/cookbooks_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbooks_controller_spec.rb
@@ -81,7 +81,7 @@ describe Api::V1::CookbooksController do
         create(
           :cookbook_version,
           cookbook: sashimi,
-          version: '2.1.0',
+          version: '1.1.0',
           license: 'MIT',
           description: 'great'
         )
@@ -89,7 +89,7 @@ describe Api::V1::CookbooksController do
         create(
           :cookbook_version,
           cookbook: sashimi,
-          version: '1.1.0',
+          version: '2.1.0',
           license: 'MIT',
           description: 'great'
         )
@@ -112,8 +112,8 @@ describe Api::V1::CookbooksController do
 
         expect(assigns[:cookbook_versions_urls]).to eql(
           [
-            "http://test.host/api/v1/cookbooks/sashimi/versions/1_1_0",
-            "http://test.host/api/v1/cookbooks/sashimi/versions/2_1_0"
+            "http://test.host/api/v1/cookbooks/sashimi/versions/2_1_0",
+            "http://test.host/api/v1/cookbooks/sashimi/versions/1_1_0"
           ]
         )
       end


### PR DESCRIPTION
:fork_and_knife: This pull request has some ups and downs. At first take, I thought it made sense to order cookbooks by their version. However, [when looking at the current community site](https://github.com/opscode/opscode-community-site/blob/master/app/models/cookbook.rb#L24), it looks like they are orded by created_at DESC. I can see why this makes sense in some ways, which is fine. The mental issue I am having is [the API docs](http://docs.opscode.com/api_cookbooks_site.html#id1) show the versions ordered by version ASC or created_at ASC (does not specify). The current community site code seems to conflict with the docs at first glance.

In this PR, I have updated the association to order by created_at DESC, just like the current community site. Should I stick with that and assume the docs are wrong or does this warrant a bigger discussion surrounding the ordering of `CookbookVersions`?

Logic path of finding the ordering:

[`latest_version` is an instance method on `Cookbook`](https://github.com/opscode/opscode-community-site/blob/master/app/controllers/api/v1/cookbooks_controller.rb#L94).  [Checking that out, it is just the first `cookbook_version`](https://github.com/opscode/opscode-community-site/blob/master/app/models/cookbook.rb#L54), [which are ordered by `created_at DESC`](https://github.com/opscode/opscode-community-site/blob/master/app/models/cookbook.rb#L24).

Thanks!
