### PR TITLE
Implement the search API end-point.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'octokit', github: 'octokit/octokit.rb', require: false
 gem 'sidekiq'
 gem 'premailer-rails', group: [:development, :production]
 gem 'jbuilder'
+gem 'pg_search'
 
 gem 'sass-rails',   '~> 4.0.1'
 gem 'compass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,10 @@ GEM
       ast (~> 1.1)
       slop (~> 3.4, >= 3.4.5)
     pg (0.17.1)
+    pg_search (0.7.3)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
+      arel
     poltergeist (1.5.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -325,6 +329,7 @@ DEPENDENCIES
   omniauth-github
   omniauth-twitter
   pg
+  pg_search
   poltergeist
   premailer-rails
   pundit

--- a/app/controllers/api/v1/cookbooks_controller.rb
+++ b/app/controllers/api/v1/cookbooks_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::CookbooksController < Api::V1Controller
+  before_filter :init_params, only: [:index, :search]
+
   #
   # GET /api/v1/cookbooks
   #
@@ -13,8 +15,6 @@ class Api::V1::CookbooksController < Api::V1Controller
   #   GET /api/v1/cookbooks?start=5&items=15
   #
   def index
-    @start = params.fetch(:start, 0).to_i
-    @items = [params.fetch(:items, 10).to_i, 100].min
     @total = Cookbook.count
     @cookbooks = Cookbook.all.order('name ASC').limit(@items).offset(@start)
   end
@@ -35,6 +35,37 @@ class Api::V1::CookbooksController < Api::V1Controller
     end
 
     @latest_cookbook_version = @cookbook.get_version!('latest')
-    @latest_cookbook_version_url = api_v1_cookbook_version_url(@cookbook, @latest_cookbook_version)
+    @latest_cookbook_version_url = api_v1_cookbook_version_url(
+      @cookbook, @latest_cookbook_version
+    )
+  end
+
+  #
+  # GET /api/v1/search?q=QUERY
+  #
+  # Return cookbooks with a name that contains the specified query. Takes the
+  # +q+ parameter for the query. It also handles the start and items parameters
+  # for specify where to start the search and how many items to return. Start
+  # defaults to 0. Items defaults to 10. Items has an upper limit of 100.
+  #
+  # @example
+  #   GET /api/v1/search?q=redis
+  #   GET /api/v1/search?q=redis&start=3&items=5
+  #
+  def search
+    @results = Cookbook.search(
+      params.fetch(:q, nil)
+    ).offset(@start).limit(@items)
+  end
+
+  private
+
+  #
+  # This creates instance variables for +start+ and +items+, which are shared
+  # between the index and search methods.
+  #
+  def init_params
+    @start = params.fetch(:start, 0).to_i
+    @items = [params.fetch(:items, 10).to_i, 100].min
   end
 end

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -1,4 +1,19 @@
 class Cookbook < ActiveRecord::Base
+  include PgSearch
+
+  pg_search_scope(
+    :search,
+    against: {
+      name: 'A',
+      description: 'B',
+      category: 'C',
+      maintainer: 'D'
+    },
+    using: {
+      tsearch: { prefix: true, dictionary: 'english' }
+    }
+  )
+
   has_many :cookbook_versions, -> { order(created_at: :desc) }
 
   #

--- a/app/views/api/v1/cookbooks/search.json.jbuilder
+++ b/app/views/api/v1/cookbooks/search.json.jbuilder
@@ -1,0 +1,8 @@
+json.start @start
+json.total @results.count
+json.items @results do |cookbook|
+  json.cookbook_name cookbook.name
+  json.cookbook_maintainer cookbook.maintainer
+  json.cookbook_description cookbook.description
+  json.cookbook api_v1_cookbook_url(cookbook)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Supermarket::Application.routes.draw do
   namespace :api, defaults: { format: :json }  do
     namespace :v1 do
       get 'cookbooks' => 'cookbooks#index'
+      get 'search' => 'cookbooks#search'
       get 'cookbooks/:cookbook' => 'cookbooks#show', as: :cookbook
       get 'cookbooks/:cookbook/versions/:version' => 'cookbook_versions#show', as: :cookbook_version
     end

--- a/spec/api/cookbook_search_spec.rb
+++ b/spec/api/cookbook_search_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+
+describe 'GET /api/v1/search' do
+  before do
+    create(
+      :cookbook,
+      name: 'redis',
+      description: 'great cookbook',
+      maintainer: 'brett'
+    )
+
+    create(
+      :cookbook,
+      name: 'redisio',
+      description: 'greater cookbook',
+      maintainer: 'josh'
+    )
+  end
+
+  it 'returns a 200' do
+    get '/api/v1/search'
+
+    expect(response.status.to_i).to eql(200)
+  end
+
+  it 'returns cookbooks that match the search query' do
+    search_response = {
+      'items' => [
+        {
+          'cookbook_name' => 'redis',
+          'cookbook_description' => 'great cookbook',
+          'cookbook' => 'http://www.example.com/api/v1/cookbooks/redis',
+          'cookbook_maintainer' => 'brett'
+        },
+        {
+          'cookbook_name' => 'redisio',
+          'cookbook_description' => 'greater cookbook',
+          'cookbook' => 'http://www.example.com/api/v1/cookbooks/redisio',
+          'cookbook_maintainer' => 'josh'
+        }
+      ],
+      'total' => 2,
+      'start' => 0
+    }
+
+    get '/api/v1/search?q=redis'
+
+    expect(json_body).to eql(search_response)
+  end
+
+  it 'handles the start and items params' do
+    search_response = {
+      'items' => [
+        {
+          'cookbook_name' => 'redisio',
+          'cookbook_description' => 'greater cookbook',
+          'cookbook' => 'http://www.example.com/api/v1/cookbooks/redisio',
+          'cookbook_maintainer' => 'josh'
+        }
+      ],
+      'total' => 1,
+      'start' => 1
+    }
+
+    get '/api/v1/search?q=redis&start=1&items=1'
+
+    expect(json_body).to eql(search_response)
+  end
+end

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -45,4 +45,46 @@ describe Cookbook do
         to raise_error(ActiveRecord::RecordNotFound)
     end
   end
+
+  describe '.search' do
+    let!(:redis) do
+      Cookbook.create(
+        name: 'redis',
+        maintainer: 'tokein',
+        category: 'datastore',
+        description: 'Redis: a fast, flexible datastore offering an extremely useful set of data structure primitives'
+      )
+    end
+
+    let!(:redisio) do
+      Cookbook.create(
+        name: 'redisio',
+        maintainer: 'fruit',
+        category: 'datastore',
+        description: 'Installs/Configures redis'
+      )
+    end
+
+    it 'returns cookbooks with a similar name' do
+      expect(Cookbook.search('redis')).to include(redis)
+      expect(Cookbook.search('redis')).to include(redisio)
+    end
+
+    it 'returns cookbooks with a similar maintainer' do
+      expect(Cookbook.search('fruit')).to include(redisio)
+      expect(Cookbook.search('fruit')).to_not include(redis)
+      expect(Cookbook.search('tokein')).to include(redis)
+      expect(Cookbook.search('tokein')).to_not include(redisio)
+    end
+
+    it 'returns cookbooks with a similar category' do
+      expect(Cookbook.search('datastore')).to include(redisio)
+      expect(Cookbook.search('datastore')).to include(redis)
+    end
+
+    it 'returns cookbooks with a similar description' do
+      expect(Cookbook.search('fast')).to include(redis)
+      expect(Cookbook.search('fast')).to_not include(redisio)
+    end
+  end
 end

--- a/spec/views/api/v1/cookbooks/search.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/search.json.jbuilder_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'api/v1/cookbooks/search' do
+  let(:cookbook) { create(:cookbook, name: 'redis') }
+
+  before do
+    assign(:results, [cookbook])
+    assign(:start, 1)
+  end
+
+  it 'displays the total number of results' do
+    render
+
+    total = json_body['total']
+    expect(total).to eql(1)
+  end
+
+  it 'displays an array of the results' do
+    render
+
+    cookbook = json_body['items'].first
+
+    expect(cookbook['cookbook_name']).to eql('redis')
+    expect(cookbook['cookbook_maintainer']).to eql('Chef Software Inc')
+    expect(cookbook['cookbook_description']).to eql('An awesome cookbook!')
+    expect(cookbook['cookbook']).to eql('http://test.host/api/v1/cookbooks/redis')
+  end
+
+  it 'displays the start index of the search' do
+    render
+
+    start = json_body['start']
+    expect(start).to eql(1)
+  end
+end


### PR DESCRIPTION
:construction_worker:  Creates GET /api/v1/search&q=COOKBOOK_QUERY. Currently returns the cookbooks
with a similar name.

Paired with @tristanoneil and @raskchanky through this.

LeanKit Card: Super-20
https://chef.leankit.com/Boards/View/87539991/90240856

![screen shot 2014-03-03 at 5 25 48 pm](https://f.cloud.github.com/assets/928367/2315473/116f5410-a324-11e3-97c2-f34efa006093.png)
![screen shot 2014-03-03 at 5 26 02 pm](https://f.cloud.github.com/assets/928367/2315474/11770124-a324-11e3-84c6-f164c0aacfe0.png)
![image](https://f.cloud.github.com/assets/928367/2283128/1976b518-9fb9-11e3-80b4-152ce911ab53.png)

This has been tested with curl and dullknife. It currently searches Cookbook names, descriptions, maintainers and categories.
