### PR TITLE
Revert "Update Ruby specified in the Gemfile to 2.1.1."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
 rvm:
-  - 2.1.1
+  - 2.0.0
 before_script:
   - psql -c 'create database supermarket_test;' -U postgres
   - cp .env.example .env

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.1.1'
+ruby '2.0.0'
 
 gem 'rails', '~> 4.0.3'
 


### PR DESCRIPTION
This reverts commit 5d262d35a66a2153d0fe5d28fde7be070c14f779. For reasons to be determined, installing Ruby 2.1 packages is not putting `ruby2.1` binaries in the list of ruby alternatives, which makes it tough/impossible to actually use the new ruby. In the meantime, plain ol' 2.0 should be fine.
