### PR TITLE
Remove description from CookbookVersion

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -34,6 +34,7 @@ class Cookbook < ActiveRecord::Base
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :lowercase_name, presence: true, uniqueness: true
   validates :maintainer, presence: true
+  validates :description, presence: true
 
   #
   # Returns the name of the +Cookbook+ parameterized.
@@ -86,12 +87,12 @@ class Cookbook < ActiveRecord::Base
   def publish_version!(metadata, tarball)
     transaction do
       self.maintainer = metadata.maintainer
+      self.description = metadata.description
       save!
 
       cookbook_versions.create!(
         license: metadata.license,
         version: metadata.version,
-        description: metadata.description,
         tarball: tarball
       )
     end

--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -11,7 +11,6 @@ class CookbookVersion < ActiveRecord::Base
   # --------------------
   validates :license, presence: true
   validates :version, presence: true, uniqueness: { scope: :cookbook }
-  validates :description, presence: true
   validates :cookbook_id, presence: true
   validates_attachment(
     :tarball,

--- a/db/migrate/20140317133838_remove_description_from_cookbook_versions.rb
+++ b/db/migrate/20140317133838_remove_description_from_cookbook_versions.rb
@@ -1,0 +1,5 @@
+class RemoveDescriptionFromCookbookVersions < ActiveRecord::Migration
+  def change
+    remove_column :cookbook_versions, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140310195012) do
+ActiveRecord::Schema.define(version: 20140317133838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,7 +82,6 @@ ActiveRecord::Schema.define(version: 20140310195012) do
 
   create_table "cookbook_versions", force: true do |t|
     t.integer  "cookbook_id"
-    t.text     "description"
     t.string   "license"
     t.string   "version"
     t.string   "file_url"

--- a/spec/controllers/api/v1/cookbooks_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbooks_controller_spec.rb
@@ -80,16 +80,14 @@ describe Api::V1::CookbooksController do
           :cookbook_version,
           cookbook: sashimi,
           version: '1.1.0',
-          license: 'MIT',
-          description: 'great'
+          license: 'MIT'
         )
 
         create(
           :cookbook_version,
           cookbook: sashimi,
           version: '2.1.0',
-          license: 'MIT',
-          description: 'great'
+          license: 'MIT'
         )
       end
 

--- a/spec/factories/cookbook_version.rb
+++ b/spec/factories/cookbook_version.rb
@@ -2,7 +2,6 @@ FactoryGirl.define do
   factory :cookbook_version do
     association :cookbook
 
-    description 'An awesome cookbook!'
     license 'MIT'
     sequence(:version) { |n| "1.2.#{n}" }
     tarball { File.open('spec/support/cookbook_fixtures/redis-test-v1.tgz') }

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -15,6 +15,7 @@ describe Cookbook do
 
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:maintainer) }
+    it { should validate_presence_of(:description) }
   end
 
   describe '#lowercase_name' do
@@ -41,7 +42,6 @@ describe Cookbook do
         :cookbook_version,
         cookbook: kiwi,
         version: '0.1.0',
-        description: 'bird',
         license: 'MIT'
       )
     end
@@ -51,7 +51,6 @@ describe Cookbook do
         :cookbook_version,
         cookbook: kiwi,
         version: '0.2.0',
-        description: 'better bird',
         license: 'MIT'
       )
     end

--- a/spec/models/cookbook_version_spec.rb
+++ b/spec/models/cookbook_version_spec.rb
@@ -8,7 +8,6 @@ describe CookbookVersion do
   context 'validations' do
     it { should validate_presence_of(:license) }
     it { should validate_presence_of(:version) }
-    it { should validate_presence_of(:description) }
     it { should validate_presence_of(:cookbook_id) }
     it { should validate_uniqueness_of(:version).scoped_to(:cookbook_id) }
 
@@ -19,7 +18,6 @@ describe CookbookVersion do
       duplicate_version = CookbookVersion.new(
         cookbook: cookbook,
         license: cookbook_version.license,
-        description: cookbook_version.description,
         tarball: cookbook_version.tarball,
         version: cookbook_version.version
       )


### PR DESCRIPTION
:fork_and_knife: Description was added to Cookbook and CookbookVersion as it was initially unclear where it belonged. Looking at the source code for the current API it's clear description belongs to Cookbook and not CookbookVersion.
