### PR TITLE
Validate CookbookVersion on Cookbook

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -35,6 +35,7 @@ class Cookbook < ActiveRecord::Base
   validates :lowercase_name, presence: true, uniqueness: true
   validates :maintainer, presence: true
   validates :description, presence: true
+  validates :cookbook_versions, presence: true
 
   #
   # Returns the name of the +Cookbook+ parameterized.
@@ -65,7 +66,7 @@ class Cookbook < ActiveRecord::Base
     version.gsub!(/_/, '.')
 
     if version == 'latest'
-      cookbook_versions.first!
+      cookbook_versions.first
     else
       cookbook_versions.find_by!(version: version)
     end
@@ -88,13 +89,15 @@ class Cookbook < ActiveRecord::Base
     transaction do
       self.maintainer = metadata.maintainer
       self.description = metadata.description
-      save!
 
-      cookbook_versions.create!(
+      cookbook_versions.build(
+        cookbook: self,
         license: metadata.license,
         version: metadata.version,
         tarball: tarball
       )
+
+      save!
     end
 
     true

--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -11,7 +11,7 @@ class CookbookVersion < ActiveRecord::Base
   # --------------------
   validates :license, presence: true
   validates :version, presence: true, uniqueness: { scope: :cookbook }
-  validates :cookbook_id, presence: true
+  validates :cookbook, presence: true
   validates_attachment(
     :tarball,
     presence: true,

--- a/spec/controllers/api/v1/cookbooks_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbooks_controller_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe Api::V1::CookbooksController do
   let!(:slow_cooking) do
-    create(:cookbook, name: 'slow_cooking', cookbook_versions_count: 0)
+    create(:cookbook, name: 'slow_cooking')
   end
 
   let!(:sashimi) do
-    create(:cookbook, name: 'sashimi', cookbook_versions_count: 0)
+    create(:cookbook, name: 'sashimi')
   end
 
   describe '#index' do
@@ -106,12 +106,8 @@ describe Api::V1::CookbooksController do
       it 'sends the cookbook_versions_urls to the view' do
         get :show, cookbook: 'sashimi', format: :json
 
-        expect(assigns[:cookbook_versions_urls]).to eql(
-          [
-            'http://test.host/api/v1/cookbooks/sashimi/versions/2_1_0',
-            'http://test.host/api/v1/cookbooks/sashimi/versions/1_1_0'
-          ]
-        )
+        expect(assigns[:cookbook_versions_urls]).to include('http://test.host/api/v1/cookbooks/sashimi/versions/2_1_0')
+        expect(assigns[:cookbook_versions_urls]).to include('http://test.host/api/v1/cookbooks/sashimi/versions/1_1_0')
       end
 
       it 'sends the latest_cookbook_version_url to the view' do

--- a/spec/factories/cookbook.rb
+++ b/spec/factories/cookbook.rb
@@ -11,8 +11,8 @@ FactoryGirl.define do
       cookbook_versions_count 2
     end
 
-    after(:create) do |cookbook, evaluator|
-      create_list(:cookbook_version, evaluator.cookbook_versions_count, cookbook: cookbook)
+    before(:create) do |cookbook, evaluator|
+      cookbook.cookbook_versions << build_list(:cookbook_version, evaluator.cookbook_versions_count, cookbook: cookbook)
     end
   end
 end

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -16,6 +16,7 @@ describe Cookbook do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:maintainer) }
     it { should validate_presence_of(:description) }
+    it { should validate_presence_of(:cookbook_versions) }
   end
 
   describe '#lowercase_name' do
@@ -36,11 +37,9 @@ describe Cookbook do
   end
 
   describe '#get_version!' do
-    let!(:kiwi) { create(:cookbook, name: 'kiwi', maintainer: 'fruit') }
     let!(:kiwi_0_1_0) do
       create(
         :cookbook_version,
-        cookbook: kiwi,
         version: '0.1.0',
         license: 'MIT'
       )
@@ -49,9 +48,18 @@ describe Cookbook do
     let!(:kiwi_0_2_0) do
       create(
         :cookbook_version,
-        cookbook: kiwi,
         version: '0.2.0',
         license: 'MIT'
+      )
+    end
+
+    let!(:kiwi) do
+      create(
+        :cookbook,
+        name: 'kiwi',
+        maintainer: 'fruit',
+        cookbook_versions_count: 0,
+        cookbook_versions: [kiwi_0_2_0, kiwi_0_1_0]
       )
     end
 

--- a/spec/models/cookbook_version_spec.rb
+++ b/spec/models/cookbook_version_spec.rb
@@ -8,7 +8,7 @@ describe CookbookVersion do
   context 'validations' do
     it { should validate_presence_of(:license) }
     it { should validate_presence_of(:version) }
-    it { should validate_presence_of(:cookbook_id) }
+    it { should validate_presence_of(:cookbook) }
     it { should validate_uniqueness_of(:version).scoped_to(:cookbook_id) }
 
     it 'seriously validates the uniqueness of cookbook version numbers' do


### PR DESCRIPTION
:fork_and_knife: A Cookbook should not be allowed to exist if it doesn't have a CookbookVersion. This adds validation to satisfy this requirement. Some specs and logic are required to change to account for this new requirement as we cannot allow Cookbook to get into a persisted state without having a CookbookVersion. As Cookbook and CookbookVersion are now circular dependencies this requires a bit of odd dancing around the validations in some cases, there may be a better solution to this but this at least protects us from the giant hurt of invalid data.

<!---
@huboard:{"order":199.0,"custom_state":""}
-->
