### PR TITLE
Add development seed data for cookbooks

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,32 +1,66 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
-
 # The Default ICLA Document
 #
 # Get assign the head.md and body.md Markdown documents in the seeds directory
 # to their respective attributes and create an Icla with the configured
 # version.
+#
 attributes = {}
 
-%w[ head body ].each do |section|
+%w(head body).each do |section|
   attributes[section] = open(
     "#{File.dirname(__FILE__)}/seeds/icla/#{section}.md"
   ).read
 end
 
-Icla.find_or_create_by_version(Supermarket::Config.icla_version).
+Icla.where(version: Supermarket::Config.icla_version).
+  first_or_create!.
   update_attributes(attributes)
 
-%w[ head body ].each do |section|
+#
+# The Default CCLA Document
+#
+# Get assign the head.md and body.md Markdown documents in the seeds directory
+# to their respective attributes and create an Ccla with the configured
+# version.
+#
+%w(head body).each do |section|
   attributes[section] = open(
     "#{File.dirname(__FILE__)}/seeds/ccla/#{section}.md"
   ).read
 end
 
-Ccla.find_or_create_by_version(Supermarket::Config.ccla_version).
+Ccla.where(version: Supermarket::Config.ccla_version).
+  first_or_create!.
   update_attributes(attributes)
+
+if Rails.env.development?
+  #
+  # Default category for use in development.
+  #
+  category = Category.where(name: 'Other').first_or_create!
+
+  #
+  # Default cookbooks for use in development.
+  #
+  %w(redis postgres node ruby haskell clojure java mysql apache2 nginx yum apt).each do |name|
+    cookbook = Cookbook.where(
+      name: name
+    ).first_or_initialize(
+      maintainer: '...',
+      description: '...',
+      category: category
+    )
+
+    cookbook_version = cookbook.cookbook_versions.where(
+      version: '0.1.0'
+    ).first_or_initialize(
+      license: 'MIT',
+      cookbook: cookbook,
+      tarball: File.open('spec/support/cookbook_fixtures/redis-test-v1.tgz')
+    )
+
+    cookbook.cookbook_versions << cookbook_version
+    cookbook.save!
+  end
+end


### PR DESCRIPTION
:fork_and_knife: It's helpful to have some cookbook data in the database when working with Supermarket locally. This allows you to run `rake db:seed` in development and create a few dummy cookbooks.
