### PR TITLE
Cookbooks must have a category

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -36,6 +36,7 @@ class Cookbook < ActiveRecord::Base
   validates :maintainer, presence: true
   validates :description, presence: true
   validates :cookbook_versions, presence: true
+  validates :category, presence: true
 
   #
   # Returns the name of the +Cookbook+ parameterized.

--- a/db/migrate/20140319143432_change_category_id_on_cookbooks_to_not_nullable.rb
+++ b/db/migrate/20140319143432_change_category_id_on_cookbooks_to_not_nullable.rb
@@ -1,0 +1,5 @@
+class ChangeCategoryIdOnCookbooksToNotNullable < ActiveRecord::Migration
+  def change
+    change_column :cookbooks, :category_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140317133838) do
+ActiveRecord::Schema.define(version: 20140319143432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,7 +105,7 @@ ActiveRecord::Schema.define(version: 20140317133838) do
     t.datetime "updated_at"
     t.string   "external_url"
     t.boolean  "deprecated",     default: false
-    t.integer  "category_id"
+    t.integer  "category_id",                    null: false
     t.string   "lowercase_name"
   end
 

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -17,6 +17,7 @@ describe Cookbook do
     it { should validate_presence_of(:maintainer) }
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:cookbook_versions) }
+    it { should validate_presence_of(:category) }
   end
 
   describe '#lowercase_name' do


### PR DESCRIPTION
:fork_and_knife: It's an application requirement that cookbooks have a category so this adds validation and a database constraint to ensure this requirement.
