### PR TITLE
Users can manage cookbook url data

### DIFF
--- a/app/assets/javascripts/cookbookShow.js
+++ b/app/assets/javascripts/cookbookShow.js
@@ -1,0 +1,8 @@
+$(function() {
+  $(".show-cookbook-urls-manage").click(function(event) {
+    event.preventDefault();
+    $(".manage-cookbook-urls").show();
+    $(".show-cookbook-urls-manage").hide();
+    $(".cookbook-urls").hide();
+  });
+});

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -87,9 +87,26 @@ class CookbooksController < ApplicationController
     redirect_to cookbook_version_download_url(cookbook, latest_version)
   end
 
+  #
+  # PATCH /cookbooks/:id
+  #
+  # Update a the specified cookbook. This currently only supports updating the
+  # cookbook's URLs. It also only returns JSON.
+  #
+  # NOTE: :id must be the name of the cookbook.
+  #
+  def update
+    @cookbook = Cookbook.find_by(name: params[:id])
+    @cookbook.update_attributes(cookbook_urls_params)
+  end
+
   private
 
   def assign_categories
     @categories ||= Category.all
+  end
+
+  def cookbook_urls_params
+    params.require(:cookbook).permit(:source_url, :issues_url)
   end
 end

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -47,6 +47,18 @@ class Cookbook < ActiveRecord::Base
   validates :cookbook_versions, presence: true
   validates :category, presence: true
 
+  validates :source_url, format: {
+    with: URI.regexp(%w(http https)),
+    allow_blank: true,
+    case_sensitive: false
+  }
+
+  validates :issues_url, format: {
+    with: URI.regexp(%w(http https)),
+    allow_blank: true,
+    case_sensitive: false
+  }
+
   #
   # Returns the name of the +Cookbook+ parameterized.
   #

--- a/app/views/api/v1/cookbooks/_cookbook.json.jbuilder
+++ b/app/views/api/v1/cookbooks/_cookbook.json.jbuilder
@@ -3,7 +3,7 @@ json.maintainer @cookbook.maintainer
 json.description @cookbook.description
 json.category @cookbook.category.name
 json.latest_version @latest_cookbook_version_url
-json.external_url @cookbook.external_url
+json.external_url @cookbook.source_url
 json.average_rating nil
 json.created_at @cookbook.created_at
 json.updated_at @cookbook.updated_at

--- a/app/views/cookbooks/_cookbook_urls.html.erb
+++ b/app/views/cookbooks/_cookbook_urls.html.erb
@@ -1,0 +1,7 @@
+<% if cookbook.source_url.present? %>
+  <%= link_to 'View Source', cookbook.source_url, class: 'button source-url' %>
+<% end %>
+
+<% if cookbook.issues_url.present? %>
+  <%= link_to 'View Issues', cookbook.issues_url, class: 'button issues-url' %>
+<% end %>

--- a/app/views/cookbooks/show.html.erb
+++ b/app/views/cookbooks/show.html.erb
@@ -22,17 +22,36 @@
     <%= @cookbook.download_count %> total downloads<br />
     <%= @latest_version.download_count %> latest version downloads
 
-    <% if @cookbook.external_url.present? %>
-      <%= link_to 'View Source', @cookbook.external_url, class: 'button' %>
-    <% end %>
+    <div class="cookbook-details">
+      <h4>Cookbook Details</h4>
+      <%= link_to 'Edit', '#', class: 'button tiny show-cookbook-urls-manage', rel: 'edit-cookbook-urls' %>
 
-    <div>
+      <div class="cookbook-urls">
+        <%= render 'cookbook_urls', cookbook: @cookbook %>
+      </div>
+
+      <div class="manage-cookbook-urls hide">
+        <%= form_for @cookbook, remote: true, data: { abide: true } do |f| %>
+          <div class="source-url-field">
+            <%= f.label :source_url, 'Source URL' %>
+            <%= f.text_field :source_url, placeholder: 'http://example.com', pattern: 'url' %>
+            <small class="error">Must be formatted as a URL.</small>
+          </div>
+
+          <div class="issues-url-field">
+            <%= f.label :issues_url, 'Issues URL' %>
+            <%= f.text_field :issues_url, placeholder: 'http://example.com', pattern: 'url' %>
+            <small class="error">Must be formatted as a URL.</small>
+          </div>
+
+          <%= f.submit 'Save', class: 'button tiny submit-urls', data: { disable_with: 'Saving...' } %>
+        <% end %>
+      </div>
+
       <h4><i class="fa fa-money"></i> Updated <%= @latest_version.updated_at.strftime('%B %-d, %Y') %></h4>
 
       <div>Created on <%= @cookbook.created_at.strftime('%B %-d, %Y') %></div>
-    </div>
 
-    <div>
       <h4><i class="fa fa-money"></i> Versions</h4>
       <ul>
         <% @cookbook_versions.each_with_index do |version, index| %>
@@ -43,9 +62,7 @@
           <% end %>
         <% end %>
       </ul>
-    </div>
 
-    <div>
       <h4><i class="fa fa-money"></i> Platforms</h4>
       <ul>
         <% @supported_platforms.each do |platform| %>
@@ -54,9 +71,7 @@
           </li>
         <% end %>
       </ul>
-    </div>
 
-    <div>
       <h4><i class="fa fa-money"></i> License</h4>
       <p><%= @latest_version.license %></p>
     </div>

--- a/app/views/cookbooks/update.js.erb
+++ b/app/views/cookbooks/update.js.erb
@@ -1,0 +1,18 @@
+<% if @cookbook.valid? %>
+  $('.cookbook-urls').html('<%=j render "cookbook_urls", cookbook: @cookbook %>');
+  $('.cookbook-urls').show();
+  $('.show-cookbook-urls-manage').show();
+  $('.manage-cookbook-urls').hide();
+
+  $('.page').append(
+    '<div data-alert class="alert-box success"><div><%=j t("cookbook.update.success") %></div> <a href="#" class="close">&times;</a></div>'
+  );
+
+  $(document).foundation();
+<% else %>
+  $('.page').append(
+    '<div data-alert class="alert-box alert"><div><%=j t("cookbook.update.failure") %></div> <a href="#" class="close">&times;</a></div>'
+  );
+
+  $(document).foundation();
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,10 @@ en:
   user:
     signed_in:  "Welcome back %{name}!"
     signed_out: "Goodbye"
+  cookbook:
+    update:
+      success: "The cookbook URLs were successfully saved."
+      failure: "There was an error saving the cookbook URLs."
   requires_linked_github: "You need to link your GitHub account."
   organization_invitations:
     invite:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Supermarket::Application.routes.draw do
   get 'cookbooks(/categories/:category)' => 'cookbooks#index', as: :cookbooks_category
   get 'cookbooks/categories', to: redirect('/cookbooks')
 
-  resources :cookbooks, only: [:index, :show] do
+  resources :cookbooks, only: [:index, :show, :update] do
     member do
       get :download
     end

--- a/db/migrate/20140324135007_adjust_cookbook_urls.rb
+++ b/db/migrate/20140324135007_adjust_cookbook_urls.rb
@@ -1,0 +1,6 @@
+class AdjustCookbookUrls < ActiveRecord::Migration
+  def change
+    rename_column :cookbooks, :external_url, :source_url
+    add_column :cookbooks, :issues_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -109,11 +109,12 @@ ActiveRecord::Schema.define(version: 20140326154848) do
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "external_url"
+    t.string   "source_url"
     t.boolean  "deprecated",     default: false
     t.integer  "category_id",                    null: false
     t.string   "lowercase_name"
     t.integer  "download_count", default: 0
+    t.string   "issues_url"
   end
 
   add_index "cookbooks", ["lowercase_name"], name: "index_cookbooks_on_lowercase_name", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,6 +49,8 @@ if Rails.env.development?
     ).first_or_initialize(
       maintainer: Faker::Name.name,
       description: Faker::Lorem.sentences(1).first,
+      source_url: 'http://example.com',
+      issues_url: 'http://example.com',
       category: category
     )
 

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -99,6 +99,48 @@ describe CookbooksController do
     end
   end
 
+  describe 'PATCH #update' do
+    let(:cookbook) { create(:cookbook) }
+
+    it 'updates the cookbook' do
+      patch :update, id: cookbook, format: :js, cookbook: {
+        source_url: 'http://example.com/cookbook',
+        issues_url: 'http://example.com/cookbook/issues'
+      }
+
+      cookbook.reload
+
+      expect(cookbook.source_url).to eql('http://example.com/cookbook')
+      expect(cookbook.issues_url).to eql('http://example.com/cookbook/issues')
+    end
+
+    it 'returns a 200 on success'  do
+      patch :update, id: cookbook, format: :js, cookbook: {
+        source_url: 'http://example.com/cookbook',
+        issues_url: 'http://example.com/cookbook/issues'
+      }
+
+      expect(response.status.to_i).to eql(200)
+    end
+
+    it 'updates the dom with update.js.erb'  do
+      patch :update, id: cookbook, format: :js, cookbook: {
+        source_url: 'http://example.com/cookbook',
+        issues_url: 'http://example.com/cookbook/issues'
+      }
+
+      expect(response).to render_template('update')
+    end
+
+    it 'should make @cookbook invalid for invalid attributes' do
+      patch :update, id: cookbook, format: :js, cookbook: {
+        source_url: 'test'
+      }
+
+      expect(assigns[:cookbook].valid?).to be_false
+    end
+  end
+
   describe 'GET #directory' do
     before { get :directory }
 
@@ -117,7 +159,7 @@ describe CookbooksController do
 
   describe '#show' do
     let(:cookbook) do
-      cookbook = create(:cookbook)
+      create(:cookbook)
     end
 
     it 'renders the show template' do

--- a/spec/factories/cookbook.rb
+++ b/spec/factories/cookbook.rb
@@ -4,7 +4,8 @@ FactoryGirl.define do
     sequence(:name) { |n| "redis-#{n}" }
     description 'An awesome cookbook!'
     maintainer 'Chef Software, Inc'
-    external_url 'http://example.com'
+    source_url 'http://example.com'
+    issues_url 'http://example.com/issues'
     deprecated false
 
     ignore do

--- a/spec/features/cookbook_manage_spec.rb
+++ b/spec/features/cookbook_manage_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_feature_helper'
+
+describe "updating a cookbook's issue and source urls" do
+  it 'displays success message when saved' do
+    maintainer = create(:user)
+    cookbook = create(:cookbook) # TODO: give this cookbook a real maintainer
+
+    visit cookbook_path(cookbook)
+
+    within '.cookbook-details' do
+      follow_relation 'edit-cookbook-urls'
+      fill_in 'Source URL', with: 'http://example.com/source'
+      fill_in 'Issues URL', with: 'http://example.com/tissues'
+      submit_form
+    end
+
+    expect_to_see_success_message
+  end
+
+  it 'displays a failure message when invalid urls are entered' do
+    maintainer = create(:user)
+    cookbook = create(:cookbook) # TODO: give this cookbook a real maintainer
+
+    visit cookbook_path(cookbook)
+
+    within '.cookbook-details' do
+      follow_relation 'edit-cookbook-urls'
+      fill_in 'Source URL', with: 'example'
+      fill_in 'Issues URL', with: 'example'
+      expect(page).to have_selector('.error')
+    end
+  end
+end

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -13,6 +13,24 @@ describe Cookbook do
       expect(subject).to validate_uniqueness_of(:name).case_insensitive
     end
 
+    it 'validates the format of source_url' do
+      cookbook = create(:cookbook)
+      cookbook_version = create(:cookbook_version, cookbook: cookbook)
+      cookbook.source_url = 'com.http.com'
+
+      expect(cookbook).to_not be_valid
+      expect(cookbook.errors[:source_url]).to_not be_nil
+    end
+
+    it 'validates the format of issues_url' do
+      cookbook = create(:cookbook)
+      cookbook_version = create(:cookbook_version, cookbook: cookbook)
+      cookbook.issues_url = 'com.http.com'
+
+      expect(cookbook).to_not be_valid
+      expect(cookbook.errors[:issues_url]).to_not be_nil
+    end
+
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:maintainer) }
     it { should validate_presence_of(:description) }

--- a/spec/views/api/v1/cookbook_uploads/create.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbook_uploads/create.json.jbuilder_spec.rb
@@ -7,7 +7,7 @@ describe 'api/v1/cookbook_uploads/create' do
       name: 'redis',
       maintainer: 'slime',
       description: 'great cookbook',
-      external_url: 'http://example.com',
+      source_url: 'http://example.com',
       deprecated: false
     )
   end

--- a/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
@@ -7,7 +7,8 @@ describe 'api/v1/cookbooks/show' do
       name: 'redis',
       maintainer: 'slime',
       description: 'great cookbook',
-      external_url: 'http://example.com',
+      source_url: 'http://example.com',
+      issues_url: 'http://example.com',
       deprecated: false
     )
   end


### PR DESCRIPTION
:fork_and_knife: 
- Rename 'external_url' to 'source_url' on Cookbook.
- Add 'issue_url' attribute to Cookbook.
- Create form and JS for handling ajax:success and ajax:failure for the form

todo:
- [x] write feature spec
- [x] create the update action for cookbooks
- [x] make sure the UI is good to go
- [x] add url validation
- [x] hide buttons if urls are removed after save
- [x] show buttons if urls are added after save
