### PR TITLE
Implement cookbook following

### DIFF
--- a/app/helpers/cookbooks_helper.rb
+++ b/app/helpers/cookbooks_helper.rb
@@ -11,4 +11,46 @@ module CookbooksHelper
   def feed_title
     (params.fetch(:category, nil) || params.fetch(:order, nil) || 'All').titleize
   end
+
+  #
+  # Return the correct state for a cookbook follow/unfollow button.
+  #
+  # @example
+  #   <%= follow_button_for(@cookbook) %>
+  #
+  # @return [String] a link based on the following state for the current cookbook.
+  #
+  def follow_button_for(cookbook)
+    unless current_user
+      return link_to(
+        'Follow',
+        follow_cookbook_path(cookbook),
+        method: 'put',
+        rel: 'sign-in-to-follow',
+        class: 'button follow',
+        title: 'You must be signed in to follow a cookbook.',
+        'data-tooltip' => true
+      )
+    end
+
+    if cookbook.followed_by?(current_user)
+      link_to(
+        'Unfollow',
+        unfollow_cookbook_path(cookbook),
+        method: 'delete',
+        remote: true,
+        rel: 'unfollow',
+        class: 'button follow'
+      )
+    else
+      link_to(
+        'Follow',
+        follow_cookbook_path(cookbook),
+        method: 'put',
+        remote: true,
+        rel: 'follow',
+        class: 'button follow'
+      )
+    end
+  end
 end

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -34,8 +34,9 @@ class Cookbook < ActiveRecord::Base
   # Associations
   # --------------------
   has_many :cookbook_versions, -> { order(created_at: :desc) }, dependent: :destroy
-  has_one :latest_cookbook_version, -> { order(created_at: :desc) }, class_name: 'CookbookVersion'
   has_many :supported_platforms, through: :latest_cookbook_version
+  has_many :cookbook_followers, dependent: :destroy
+  has_one :latest_cookbook_version, -> { order(created_at: :desc) }, class_name: 'CookbookVersion'
   belongs_to :category
 
   # Validations
@@ -132,6 +133,17 @@ class Cookbook < ActiveRecord::Base
     end
 
     true
+  end
+
+  #
+  # Returns true if the user passed follows the cookbook.
+  #
+  # @return [TrueClass]
+  #
+  # @param user [User]
+  #
+  def followed_by?(user)
+    cookbook_followers.where(user: user).any?
   end
 
   private

--- a/app/models/cookbook_follower.rb
+++ b/app/models/cookbook_follower.rb
@@ -1,0 +1,12 @@
+class CookbookFollower < ActiveRecord::Base
+  # Associations
+  # --------------------
+  belongs_to :cookbook
+  belongs_to :user
+
+  # Validations
+  # --------------------
+  validates :cookbook, presence: true
+  validates :user, presence: true
+  validates :cookbook_id, uniqueness: { scope: :user_id }
+end

--- a/app/views/cookbooks/follow.js.erb
+++ b/app/views/cookbooks/follow.js.erb
@@ -1,0 +1,1 @@
+$('.follow').replaceWith('<%=j follow_button_for(@cookbook) %>');

--- a/app/views/cookbooks/show.html.erb
+++ b/app/views/cookbooks/show.html.erb
@@ -12,7 +12,7 @@
   <div class="small-12 medium-8 columns">
     <h1><%= @cookbook.name %></h1>
 
-    <div class="button">Follow</div>
+    <%= follow_button_for(@cookbook) %>
 
     <div><pre><code>knife cookbook site install <%= @cookbook.name %></code></pre></div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Supermarket::Application.routes.draw do
   resources :cookbooks, only: [:index, :show, :update] do
     member do
       get :download
+      put :follow
+      delete :unfollow
     end
 
     get 'versions/:version/download' => 'cookbook_versions#download', as: :version_download

--- a/db/migrate/20140324144915_create_cookbook_followers.rb
+++ b/db/migrate/20140324144915_create_cookbook_followers.rb
@@ -1,0 +1,12 @@
+class CreateCookbookFollowers < ActiveRecord::Migration
+  def change
+    create_table :cookbook_followers do |t|
+      t.integer :cookbook_id, null: false
+      t.integer :user_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :cookbook_followers, [:cookbook_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,6 +83,15 @@ ActiveRecord::Schema.define(version: 20140326154848) do
   add_index "contributors", ["organization_id"], name: "index_contributors_on_organization_id", using: :btree
   add_index "contributors", ["user_id"], name: "index_contributors_on_user_id", using: :btree
 
+  create_table "cookbook_followers", force: true do |t|
+    t.integer  "cookbook_id", null: false
+    t.integer  "user_id",     null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "cookbook_followers", ["cookbook_id", "user_id"], name: "index_cookbook_followers_on_cookbook_id_and_user_id", unique: true, using: :btree
+
   create_table "cookbook_versions", force: true do |t|
     t.integer  "cookbook_id"
     t.string   "license"

--- a/lib/supermarket/location_storage.rb
+++ b/lib/supermarket/location_storage.rb
@@ -4,11 +4,14 @@ module Supermarket
     # Stores the current request URL or the root URL
     # in a session variable.
     #
+    # @param [String] location the location to store
+    #
     # @example
     #   store_location!
+    #   store_location!(profile_path)
     #
-    def store_location!
-      session[storage_key] = request.url || root_url
+    def store_location!(location = request.path)
+      session[storage_key] = location || root_path
     end
 
     #

--- a/spec/factories/cookbook_follower.rb
+++ b/spec/factories/cookbook_follower.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :cookbook_follower do
+    association :cookbook
+    association :user
+  end
+end

--- a/spec/features/cookbook_folowing_spec.rb
+++ b/spec/features/cookbook_folowing_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_feature_helper'
+
+describe 'cookbook following' do
+  before do
+    sign_in(create(:user))
+    maintainer = create(:user)
+    cookbook = create(:cookbook) # TODO: give this cookbook a real maintainer
+
+    visit '/'
+    follow_relation 'cookbooks'
+
+    within '.recently-updated' do
+      follow_relation 'cookbook'
+    end
+  end
+
+  it 'allows a user to follow a cookbook' do
+    follow_relation 'follow'
+
+    expect(page).to have_xpath("//a[starts-with(@rel, 'unfollow')]")
+  end
+
+  it 'allows a user to unfollow a cookbook' do
+    follow_relation 'follow'
+    follow_relation 'unfollow'
+
+    expect(page).to have_xpath("//a[starts-with(@rel, 'follow')]")
+  end
+end

--- a/spec/features/cookbook_manage_spec.rb
+++ b/spec/features/cookbook_manage_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_feature_helper'
 
 describe "updating a cookbook's issue and source urls" do
+  before { sign_in create(:user) }
+
   it 'displays success message when saved' do
     maintainer = create(:user)
     cookbook = create(:cookbook) # TODO: give this cookbook a real maintainer

--- a/spec/helpers/cookbooks_helper_spec.rb
+++ b/spec/helpers/cookbooks_helper_spec.rb
@@ -17,4 +17,27 @@ describe CookbooksHelper do
       expect(helper.feed_title).to eql('All')
     end
   end
+
+  describe '#follow_button_for' do
+    it "returns a follow button if current user doesn't follow the given cookbook" do
+      cookbook = double(:cookbook, followed_by?: false)
+      helper.stub(:current_user) { true }
+
+      expect(helper.follow_button_for(cookbook)).to match(/follow/)
+    end
+
+    it 'returns an unfollow button if the current user follows the given cookbook' do
+      cookbook = double(:cookbook, followed_by?: true)
+      helper.stub(:current_user) { true }
+
+      expect(helper.follow_button_for(cookbook)).to match(/unfollow/)
+    end
+
+    it 'returns a call to action follow button if there is no current user' do
+      cookbook = double(:cookbook)
+      helper.stub(:current_user) { false }
+
+      expect(helper.follow_button_for(cookbook)).to match(/sign-in-to-follow/)
+    end
+  end
 end

--- a/spec/lib/supermarket/location_storage_spec.rb
+++ b/spec/lib/supermarket/location_storage_spec.rb
@@ -6,7 +6,7 @@ describe Supermarket::LocationStorage do
       include Supermarket::LocationStorage
 
       def request
-        Struct.new(:url).new('http://localhost:3000')
+        Struct.new(:path).new('/profile')
       end
 
       def session
@@ -19,7 +19,13 @@ describe Supermarket::LocationStorage do
     it 'store the current request location in the session' do
       subject.store_location!
 
-      expect(subject.stored_location).to eql('http://localhost:3000')
+      expect(subject.stored_location).to eql('/profile')
+    end
+
+    it 'stores the passed in location' do
+      subject.store_location!('/icla_signatures/new')
+
+      expect(subject.stored_location).to eql('/icla_signatures/new')
     end
   end
 

--- a/spec/models/cookbook_follower_spec.rb
+++ b/spec/models/cookbook_follower_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe CookbookFollower do
+  context 'associations' do
+    it { should belong_to(:cookbook) }
+    it { should belong_to(:user) }
+  end
+
+  context 'validations' do
+    it 'validates the uniquness of cookbook_id scoped to user_id' do
+      create(:cookbook_follower)
+
+      expect(subject).to validate_uniqueness_of(:cookbook_id).scoped_to(:user_id)
+    end
+
+    it { should validate_presence_of(:cookbook) }
+    it { should validate_presence_of(:user) }
+  end
+end

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Cookbook do
   context 'associations' do
     it { should have_many(:cookbook_versions) }
+    it { should have_many(:cookbook_followers) }
     it { should belong_to(:category) }
   end
 
@@ -189,6 +190,23 @@ describe Cookbook do
       create(:cookbook, name: 'neat')
 
       expect(Cookbook.ordered_by('recently_created').first.name).to eql('neat')
+    end
+  end
+
+  describe '#followed_by?' do
+    it 'returns true if the user passed follows the cookbook' do
+      user = create(:user)
+      cookbook = create(:cookbook)
+      create(:cookbook_follower, user: user, cookbook: cookbook)
+
+      expect(cookbook.followed_by?(user)).to be_true
+    end
+
+    it "returns falase if the user passed doesn't follow the cookbook" do
+      user = create(:user)
+      cookbook = create(:cookbook)
+
+      expect(cookbook.followed_by?(user)).to be_false
     end
   end
 end


### PR DESCRIPTION
:fork_and_knife: Implement the ability for users to follow and unfollow a cookbook. Users may click Follow from the cookbook show view and a remote request is sent to `/cookbooks/:id/follow` a 200 response is returned if it is successful. Once the user is following the cookbook they can click Unfollow on the cookbook show view and a remote request is sent to `/cookbooks/:id/unfollow`.

Unauthenticated users are still shown the follow button to entice more people to create community accounts but there is a tooltip that is added to the button that informs them in order to follow they must sign in. When they click the button they are prompted to sign in/up then redirected back to the cookbook they clicked Follow on.
