### PR TITLE
Skip specs that require secure env vars in forks

### DIFF
--- a/spec/features/curry/curry_management_spec.rb
+++ b/spec/features/curry/curry_management_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_feature_helper'
 
-describe 'Curry management' do
+describe 'Curry management', skip_travis: true do
   describe 'when a Chef Admin adds a GitHub repository to the Super Market watched repositories' do
     it 'subscribes to a repository' do
       sign_in(create(:admin))

--- a/spec/models/curry/pull_request_annotator_spec.rb
+++ b/spec/models/curry/pull_request_annotator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'vcr_helper'
 
-describe Curry::PullRequestAnnotator do
+describe Curry::PullRequestAnnotator, skip_travis: true do
   describe '#annotate' do
     let(:octokit) do
       Octokit::Client.new(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,12 @@ RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
 
+  # Skip specs that require secure environment variables when running them
+  # with Travis CI.
+  if ENV['TRAVIS_SECURE_ENV_VARS'] == false
+    c.filter_run_excluding skip_travis: true
+  end
+
   config.before do
     # Clear ActionMailer deliveries before each example
     ActionMailer::Base.deliveries.clear


### PR DESCRIPTION
:fork_and_knife: Since Travis CI doesn't have access to secure environment variables in forks we need to skip some specs that are dependent upon there being said environment variables to pass.
