### PR TITLE
Skip specs that require secure env vars in forks

### DIFF
--- a/spec/features/curry/curry_management_spec.rb
+++ b/spec/features/curry/curry_management_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_feature_helper'
 
-describe 'Curry management', skip_travis: true do
+describe 'Curry management', uses_secrets: true do
   describe 'when a Chef Admin adds a GitHub repository to the Super Market watched repositories' do
     it 'subscribes to a repository' do
       sign_in(create(:admin))

--- a/spec/models/curry/pull_request_annotator_spec.rb
+++ b/spec/models/curry/pull_request_annotator_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'vcr_helper'
 
-describe Curry::PullRequestAnnotator, skip_travis: true do
+describe Curry::PullRequestAnnotator, uses_secrets: true do
   describe '#annotate' do
     let(:octokit) do
       Octokit::Client.new(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,8 +49,8 @@ RSpec.configure do |config|
 
   # Skip specs that require secure environment variables when running them
   # with Travis CI.
-  if ENV['TRAVIS_SECURE_ENV_VARS'] == false
-    c.filter_run_excluding skip_travis: true
+  if ENV['TRAVIS_SECURE_ENV_VARS'] == 'false'
+    config.filter_run_excluding uses_secrets: true
   end
 
   config.before do


### PR DESCRIPTION
:fork_and_knife: Since Travis CI doesn't have access to secure environment variables in forks we need to skip some specs that are dependent upon there being said environment variables to pass.
