### PR TITLE
Use Faker for development seed data.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ group :development do
   gem 'license_finder'
   gem 'spring'
   gem 'spring-commands-rspec'
+  gem 'faker'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
     execjs (2.0.2)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
+    faker (1.3.0)
+      i18n (~> 0.5)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
     foreman (0.63.0)
@@ -409,6 +411,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   factory_girl
+  faker
   foreman
   jbuilder
   jquery-rails

--- a/app/views/cookbooks/show.html.erb
+++ b/app/views/cookbooks/show.html.erb
@@ -9,7 +9,7 @@
 
     <div><pre><code>knife cookbook site install <%= @cookbook.name %></code></pre></div>
 
-    <div><%= @cookbook.description %></div>
+    <div><p><%= @cookbook.description %></p></div>
 
     <div><%= render_readme(@latest_version.readme, @latest_version.readme_extension) %></div>
   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,8 +47,8 @@ if Rails.env.development?
     cookbook = Cookbook.where(
       name: name
     ).first_or_initialize(
-      maintainer: '...',
-      description: '...',
+      maintainer: Faker::Name.name,
+      description: Faker::Lorem.sentences(1).first,
       category: category
     )
 


### PR DESCRIPTION
:fork_and_knife: This also wraps cookbook show descriptions in p tags. It is p cool.

Maintainer and and description are no longer '...', but a fake name and lorem ipsum. Once users are cookbook maintainers, we will want to build that association instead of it being a fake name.
