### PR TITLE
SegmentIO constant is set in the Kernel namespace

### DIFF
--- a/config/unicorn/development.rb
+++ b/config/unicorn/development.rb
@@ -17,7 +17,7 @@ after_fork do |server, worker|
     puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT'
   end
 
-  SegmentIO = Supermarket::SegmentIoAgent.new(Supermarket::Config)
+  ::SegmentIO = Supermarket::SegmentIoAgent.new(Supermarket::Config)
 
   puts "=> SegmentIO is #{SegmentIO.enabled? ? 'enabled' : 'disabled'}"
 

--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -19,7 +19,7 @@ after_fork do |server, worker|
     puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT'
   end
 
-  SegmentIO = Supermarket::SegmentIoAgent.new(Supermarket::Config)
+  ::SegmentIO = Supermarket::SegmentIoAgent.new(Supermarket::Config)
 
   puts "=> SegmentIO is #{SegmentIO.enabled? ? 'enabled' : 'disabled'}"
 


### PR DESCRIPTION
:fork_and_knife: :bug:

`self` in `after_fork` is an instance of `Unicorn::Configurator`, so we were previously setting a constant in that namespace. Then, in controllers, we were unable to find the SegmentIO constant
