### PR TITLE
Cookbook versions atom feed

### DIFF
--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -75,6 +75,11 @@ class CookbooksController < ApplicationController
     @maintainer = User.first
     @collaborators = [User.first]
     @supported_platforms = @cookbook.supported_platforms
+
+    respond_to do |format|
+      format.atom
+      format.html
+    end
   end
 
   #

--- a/app/views/cookbooks/show.atom.builder
+++ b/app/views/cookbooks/show.atom.builder
@@ -1,0 +1,11 @@
+atom_feed language: 'en-US' do |feed|
+  feed.title "#{@cookbook.name} versions"
+  feed.updated @cookbook_versions.max_by(&:updated_at).updated_at
+
+  @cookbook_versions.each do |v|
+    feed.entry(v, url: cookbook_version_url(@cookbook, v)) do |entry|
+      entry.title v.version
+      entry.license v.license
+    end
+  end
+end

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -169,6 +169,12 @@ describe CookbooksController do
       expect(response).to render_template('show')
     end
 
+    it 'renders an atom feed of cookbook versions' do
+      get :show, id: cookbook.name, format: :atom
+
+      expect(response).to render_template('show')
+    end
+
     it 'sends the cookbook to the view' do
       get :show, id: cookbook.name
 

--- a/spec/views/cookbooks/show.atom.builder_spec.rb
+++ b/spec/views/cookbooks/show.atom.builder_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'cookbooks/show.atom.builder' do
+  let!(:kiwi_0_1_0) do
+    create(
+      :cookbook_version,
+      version: '0.1.0',
+      license: 'MIT'
+    )
+  end
+
+  let!(:kiwi_0_2_0) do
+    create(
+      :cookbook_version,
+      version: '0.2.0',
+      license: 'MIT'
+    )
+  end
+
+  let!(:kiwi) do
+    create(
+      :cookbook,
+      name: 'Kiwi',
+      maintainer: 'fruit',
+      cookbook_versions_count: 0,
+      cookbook_versions: [kiwi_0_2_0, kiwi_0_1_0]
+    )
+  end
+
+  before do
+    assign(:cookbook_versions, kiwi.cookbook_versions)
+    assign(:cookbook, kiwi)
+  end
+
+  it 'displays the feed title' do
+    render
+
+    expect(xml_body['feed']['title']).to eql('Kiwi versions')
+  end
+
+  it 'displays when the feed was updated' do
+    render
+
+    expect(Date.parse(xml_body['feed']['updated'])).to_not be_nil
+  end
+
+  it 'displays cookbook version entries' do
+    render
+
+    expect(xml_body['feed']['entry'].count).to eql(2)
+  end
+
+  it 'displays information about a cookbook' do
+    render
+
+    cookbook = xml_body['feed']['entry'].first
+
+    expect(cookbook['title']).to eql('0.2.0')
+    expect(cookbook['license']).to eql('MIT')
+  end
+end


### PR DESCRIPTION
:fork_and_knife: 

Adds an atom feed of the cookbook versions to the cookbook show page.
