### PR TITLE
Ensure the 'tmp' dir exists before running tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,10 @@ RSpec.configure do |config|
     )
   end
 
+  config.before(:suite) do
+    Dir.mkdir('tmp') unless File.exists?('tmp')
+  end
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
:fork_and_knife: 

The `Tempfile` line in the `CookbookUpload` spec assumes the existence of a `./tmp` directory. The project does not include such a directory, but a handful of tests create it, and it's not uncommon for a development machine to have such a directory to hold local cache stuff. All of this combined to form a sneaky ordering bug, where if the `CookbookUpload` spec ran too early, it would fail, but only if the `./tmp` directory didn't already exist.

Now we create the `tmp` dir if it doesn't exist before the test suite runs and avoid this problem. We could also add an empty 'tmp' directory to the project, thought that feels bad.
