### PR TITLE
Make cookbook url validation stricter.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'paperclip'
 gem 'virtus', require: false
 gem 'kaminari'
 gem 'chef', require: ['chef/version_constraint', 'chef/exceptions']
+gem 'validate_url'
 
 gem 'sentry-raven', github: 'getsentry/raven-ruby'
 gem 'statsd-ruby', require: 'statsd'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,6 +379,8 @@ GEM
       rack
       unicorn
     uuidtools (2.1.4)
+    validate_url (0.2.0)
+      activemodel (>= 3.0.0)
     vcr (2.9.0)
     virtus (1.0.2)
       axiom-types (~> 0.1)
@@ -446,6 +448,7 @@ DEPENDENCIES
   uglifier (~> 2.2)
   unicorn
   unicorn-rails
+  validate_url
   vcr
   virtus
   webmock

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -47,17 +47,13 @@ class Cookbook < ActiveRecord::Base
   validates :description, presence: true
   validates :cookbook_versions, presence: true
   validates :category, presence: true
-
-  validates :source_url, format: {
-    with: URI.regexp(%w(http https)),
+  validates :source_url, url: {
     allow_blank: true,
-    case_sensitive: false
+    allow_nil: true
   }
-
-  validates :issues_url, format: {
-    with: URI.regexp(%w(http https)),
+  validates :issues_url, url: {
     allow_blank: true,
-    case_sensitive: false
+    allow_nil: true
   }
 
   #

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -14,22 +14,22 @@ describe Cookbook do
       expect(subject).to validate_uniqueness_of(:name).case_insensitive
     end
 
-    it 'validates the format of source_url' do
-      cookbook = create(:cookbook)
-      cookbook_version = create(:cookbook_version, cookbook: cookbook)
-      cookbook.source_url = 'com.http.com'
-
-      expect(cookbook).to_not be_valid
-      expect(cookbook.errors[:source_url]).to_not be_nil
-    end
-
-    it 'validates the format of issues_url' do
+    it 'validates that issues_url is a http(s) url' do
       cookbook = create(:cookbook)
       cookbook_version = create(:cookbook_version, cookbook: cookbook)
       cookbook.issues_url = 'com.http.com'
 
       expect(cookbook).to_not be_valid
       expect(cookbook.errors[:issues_url]).to_not be_nil
+    end
+
+    it 'validates that source_url is a http(s) url' do
+      cookbook = create(:cookbook)
+      cookbook_version = create(:cookbook_version, cookbook: cookbook)
+      cookbook.source_url = 'com.http.com'
+
+      expect(cookbook).to_not be_valid
+      expect(cookbook.errors[:source_url]).to_not be_nil
     end
 
     it { should validate_presence_of(:name) }


### PR DESCRIPTION
source_url and issues_url are validated with a stricter regex that is less lax
than URI.regexp.

@bcobb this is my attempt to address https://trello.com/c/T6MWRsI4, I would appreciate any feedback you have on this.
