### PR TITLE
Cookbook names must pass a whitelist format

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -41,7 +41,7 @@ class Cookbook < ActiveRecord::Base
 
   # Validations
   # --------------------
-  validates :name, presence: true, uniqueness: { case_sensitive: false }
+  validates :name, presence: true, uniqueness: { case_sensitive: false }, format: /\A[\w_-]+\z/i
   validates :lowercase_name, presence: true, uniqueness: true
   validates :maintainer, presence: true
   validates :description, presence: true

--- a/spec/controllers/api/v1/cookbooks_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbooks_controller_spec.rb
@@ -129,7 +129,7 @@ describe Api::V1::CookbooksController do
 
   describe '#search' do
     let!(:redis) { create(:cookbook, name: 'redis') }
-    let!(:redis_2) { create(:cookbook, name: 'redis 2') }
+    let!(:redis_2) { create(:cookbook, name: 'redis-2') }
     let!(:postgres) { create(:cookbook, name: 'postgres') }
 
     it 'responds with a 200' do
@@ -168,7 +168,7 @@ describe Api::V1::CookbooksController do
 
       cookbook_names = assigns[:results].map(&:name)
 
-      expect(cookbook_names).to eql(['redis 2'])
+      expect(cookbook_names).to eql(['redis-2'])
     end
 
     it 'handles the items param' do

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -52,7 +52,7 @@ describe CookbooksController do
       let!(:amazing_cookbook) do
         create(
           :cookbook,
-          name: 'Amazing Cookbook',
+          name: 'AmazingCookbook',
           maintainer: 'john@example.com',
           description: 'Makes you a pirate',
           category: create(:category, name: 'Databases')
@@ -62,7 +62,7 @@ describe CookbooksController do
       let!(:ok_cookbook) do
         create(
           :cookbook,
-          name: 'OK Cookbook',
+          name: 'OKCookbook',
           maintainer: 'jack@example.com',
           description: 'Makes you a pigeon',
           category: create(:category, name: 'Other')

--- a/spec/features/cookbook_feed_spec.rb
+++ b/spec/features/cookbook_feed_spec.rb
@@ -28,7 +28,7 @@ describe 'cookbook feed' do
   end
 
   it 'lists cookbooks by a metadata search term' do
-    create(:cookbook, name: 'Amazing Cookbook')
+    create(:cookbook, name: 'AmazingCookbook')
 
     visit '/'
     click_link 'Cookbooks'

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -32,6 +32,25 @@ describe Cookbook do
       expect(cookbook.errors[:issues_url]).to_not be_nil
     end
 
+    it 'does not allow spaces in cookbook names' do
+      cookbook = Cookbook.new(name: 'great cookbook')
+      cookbook.valid?
+
+      expect(cookbook.errors[:name]).to_not be_empty
+
+      cookbook = Cookbook.new(name: 'great-cookbook')
+      cookbook.valid?
+
+      expect(cookbook.errors[:name]).to be_empty
+    end
+
+    it 'allows letters, numbers, dashes, and underscores in cookbook names' do
+      cookbook = Cookbook.new(name: 'Cookbook_-1')
+      cookbook.valid?
+
+      expect(cookbook.errors[:name]).to be_empty
+    end
+
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:maintainer) }
     it { should validate_presence_of(:description) }


### PR DESCRIPTION
:fork_and_knife:

In particular, they may only contain letters, numbers, dashes or underscores. No spaces allowed. Knife currently enforces this (I think by coincidence) but we should make it official. If cookbooks whose names contain spaces creep in, it breaks stuff.
