### PR TITLE
Change recently_created to recently_added

### DIFF
--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -57,7 +57,7 @@ class CookbooksController < ApplicationController
       limit(3)
     @recently_added_cookbooks = Cookbook.
       includes(:latest_cookbook_version).
-      ordered_by('recently_created').
+      ordered_by('recently_added').
       limit(3)
     @most_downloaded_cookbooks = Cookbook.
       includes(:latest_cookbook_version).

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -6,7 +6,7 @@ class Cookbook < ActiveRecord::Base
   scope :ordered_by, lambda { |ordering|
     order({
       'recently_updated' => 'updated_at DESC',
-      'recently_created' => 'created_at DESC',
+      'recently_added' => 'created_at DESC',
       'most_downloaded' => 'download_count DESC',
       'most_followed' => 'cookbook_followers_count DESC'
     }.fetch(ordering, 'name ASC'))

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -50,7 +50,7 @@ describe CookbooksController do
       end
 
       it 'orders @cookbooks by created at' do
-        get :index, order: 'recently_created'
+        get :index, order: 'recently_added'
         expect(assigns[:cookbooks].first).to eql(cookbook_1)
       end
 

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -184,10 +184,10 @@ describe Cookbook do
         to eql(%w(great cookbook))
     end
 
-    it 'orders by created_at descending when given "recently_created"' do
+    it 'orders by created_at descending when given "recently_added"' do
       create(:cookbook, name: 'neat')
 
-      expect(Cookbook.ordered_by('recently_created').first.name).to eql('neat')
+      expect(Cookbook.ordered_by('recently_added').first.name).to eql('neat')
     end
 
     it 'orders by download_count descending when given "most_downloaded"' do


### PR DESCRIPTION
:fork_and_knife: Both recently_created and recently_added terminology was being used throughout the application for ordering cookbooks. This changes it to only be recently_added as that's consistent with the UI.
