### PR TITLE
Allow multiple users to sign into Supermarket.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -208,13 +208,11 @@ class User < ActiveRecord::Base
     end
 
     if account.user.nil?
-      user = User.first_or_initialize(
-        email: extractor.email,
-        public_key: extractor.public_key
+      user = User.where(email: extractor.email).first_or_create(
+        public_key: extractor.public_key,
+        first_name: extractor.first_name,
+        last_name: extractor.last_name
       )
-
-      user.first_name = extractor.first_name
-      user.last_name  = extractor.last_name
 
       account.user = user
       account.save


### PR DESCRIPTION
:fork_and_knife: This fixes a bug when the user is initialized when signing in with oc-id. I made
the where params only email because I do not think there can be multiple users
with the same email.
