### PR TITLE
Don't validate first/last name on user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,8 +11,7 @@ class User < ActiveRecord::Base
 
   # Validations
   # --------------------
-  validates_presence_of :first_name
-  validates_presence_of :last_name
+  validates_presence_of :email
 
   #
   # The commit author identities who have signed a CLA

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,8 +7,7 @@ describe User do
   end
 
   context 'validations' do
-    it { should validate_presence_of(:first_name) }
-    it { should validate_presence_of(:last_name) }
+    it { should validate_presence_of(:email) }
   end
 
   describe '#signed_icla?' do


### PR DESCRIPTION
:fork_and_knife: We cannot rely on oc-id returning first/last name but can and should rely on an email address always being on user so validate that and remove first/last name validations.
