### PR TITLE
Update user info when signing in via OAuth

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,7 +16,7 @@ class SessionsController < ApplicationController
   # Creates a new session for the user from the OmniAuth Auth hash.
   #
   def create
-    user = User.find_or_create_from_oauth(request.env['omniauth.auth'])
+    user = User.find_or_create_from_chef_oauth(request.env['omniauth.auth'])
     session[:user_id] = user.id
     redirect_to redirect_path, notice: t('user.signed_in', name: user.name)
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -5,12 +5,12 @@ describe SessionsController do
     let(:auth_hash) { OmniAuth.config.mock_auth[:chef_oauth2] }
 
     before do
-      User.stub(:find_or_create_from_oauth).and_return(double(id: 1, name: 'John Doe'))
+      User.stub(:find_or_create_from_chef_oauth).and_return(double(id: 1, name: 'John Doe'))
       request.env['omniauth.auth'] = auth_hash
     end
 
     it 'loads or creates the user from the OAuth hash' do
-      expect(User).to receive(:find_or_create_from_oauth).with(auth_hash)
+      expect(User).to receive(:find_or_create_from_chef_oauth).with(auth_hash)
       post :create, provider: 'chef_oauth2'
     end
 


### PR DESCRIPTION
:fork_and_knife: 

When a user signs in, we'll update their info. Note that the code's a little defensive around updating `public_key`. This is because the `.find_or_create_from_oauth` method is designed to be used with any OAuth hash, most of which will not contain a `public_key`. Perhaps there should be two methods? Or perhaps this method should not be so generic? Your thoughts, @raskchanky, @tristanoneil, @brettchalupa?
