### PR TITLE
Visually denote hardcoded markup elements.

### DIFF
--- a/app/assets/stylesheets/libs/_structure.scss
+++ b/app/assets/stylesheets/libs/_structure.scss
@@ -36,6 +36,10 @@ body {
   text-align: center;
 }
 
+.hardcoded {
+  border: 2px solid #E00404;
+}
+
 // User Elements
 .user {
   table { width: 100%; }

--- a/app/views/cookbooks/_cookbook.html.erb
+++ b/app/views/cookbooks/_cookbook.html.erb
@@ -14,7 +14,7 @@
           <li>
             <i class="fa fa-download"></i> <%= cookbook.download_count %>
           </li>
-          <li>
+          <li class="hardcoded">
             <i class="fa fa-users"></i> 2
           </li>
         </ul>

--- a/app/views/cookbooks/_main.html.erb
+++ b/app/views/cookbooks/_main.html.erb
@@ -18,7 +18,7 @@
       <a href="#" class="rss_feed_link"><i class="fa fa-rss"></i> RSS</a>
     </small>
     <small class="followbutton">
-      <i class="fa fa-users"></i> 349
+      <span class="hardcoded"><i class="fa fa-users"></i> 349<span>
       <%= follow_button_for(cookbook) %>
     </small>
     <%= link_to "<i class='fa fa-chevron-left previouspage'></i>".html_safe, :back %>

--- a/app/views/cookbooks/_sidebar.html.erb
+++ b/app/views/cookbooks/_sidebar.html.erb
@@ -57,14 +57,14 @@
     <p><%= version.license %></p>
 
     <h3>Maintainer &amp; Collaborators</h3>
-    <div class="owner_avatar">
+    <div class="owner_avatar hardcoded">
       <%= link_to maintainer do %>
         <%= gravatar_for maintainer, size: 144 %>
         <%= maintainer.username %>
         <small><%= maintainer.name %></small>
       <% end %>
     </div>
-    <div class="collaborators_avatar">
+    <div class="collaborators_avatar hardcoded">
       <% collaborators.each do |collaborator| %>
         <%= link_to gravatar_for(collaborator, size: 80), collaborator %>
       <% end %>

--- a/app/views/cookbooks/directory.html.erb
+++ b/app/views/cookbooks/directory.html.erb
@@ -6,16 +6,16 @@
   <section class="cookbooks_stats show-for-medium-up">
     <ul>
       <li>
-        <h3>56 <small>Recently Updated</small></h3>
+        <h3 class="hardcoded">56 <small>Recently Updated</small></h3>
       </li>
       <li>
-        <h3>1,465 <small>Cookbooks</small></h3>
+        <h3 class="hardcoded">1,465 <small>Cookbooks</small></h3>
       </li>
       <li>
-        <h3>325,292 <small>Downloads</small></h3>
+        <h3 class="hardcoded">325,292 <small>Downloads</small></h3>
       </li>
       <li>
-        <h3>2,000 <small>Collaborators</small></h3>
+        <h3 class="hardcoded">2,000 <small>Collaborators</small></h3>
       </li>
     </ul>
   </section>


### PR DESCRIPTION
:fork_and_knife:

This adds a red border around HTML elements with the class "hardcoded" to let
users know which data is currently hardcoded in. While this solution is not
ideal for code being merged into master post-release, it works well for
pre-release development.

The main goal of this is to let product owners and QA folks know which stuff to
ignore. :smile:

@danvolkens I would appreciate you checking this out to make sure it is what
we are thinking. I think I called out most of the hardcoded stuff that I am aware of.

Here is a taste of what it looks like:

![screenshot from 2014-04-07 08 33 54](https://cloud.githubusercontent.com/assets/928367/2630883/39c1f420-be51-11e3-909f-67cbc05ff26f.png)
