### PR TITLE
Display versions count on cookbook show.

### DIFF
--- a/app/assets/stylesheets/libs/_cookbooks.scss
+++ b/app/assets/stylesheets/libs/_cookbooks.scss
@@ -403,6 +403,16 @@ input[type="search"].cookbook_search_textfield {
   }
 }
 
+.versions_count {
+  color: darken($primary_gray, 10%);
+  font: {
+    size: rem-calc(12);
+    weight: $bold;
+  }
+  @include inline-block;
+  margin: rem-calc(0 20 0 0);
+}
+
 .rss_feed_link {
   color: darken($primary_gray, 10%);
   font: {

--- a/app/views/cookbooks/_main.html.erb
+++ b/app/views/cookbooks/_main.html.erb
@@ -14,6 +14,9 @@
         <% end %>
       </ul>
     </small>
+    <small class="versions_count">
+      <%= pluralize cookbook_versions.count, 'Version' %>
+    </small>
     <small>
       <a href="#" class="rss_feed_link"><i class="fa fa-rss"></i> RSS</a>
     </small>


### PR DESCRIPTION
This should give the user a better indication that there have been X released
versions and let the know that they can select the dropdown to view a different
version.

This should wrap up https://trello.com/c/4jhWRvuG

Looks like:

![screenshot from 2014-04-07 09 08 08](https://cloud.githubusercontent.com/assets/928367/2631189/ae594f3c-be55-11e3-95dd-b1bb79e56e5d.png)

@danvolkens that screenshot looks not polished and not aligned because I just tossed the element in there. Would you prefer that I tighten it up with some sort of class that adjusts the size or would you want to?
