### PR TITLE
Do not position the alert-box absolutely.

### DIFF
--- a/app/assets/stylesheets/libs/_alerts.scss
+++ b/app/assets/stylesheets/libs/_alerts.scss
@@ -1,7 +1,6 @@
 // Alerts, Notices and all that
 .alert-box {
   left: 0;
-  position: absolute;
   right: 0;
   top: 0;
 }


### PR DESCRIPTION
:fork_and_knife: 

This fixes the UI overlap when the alert-box is absolutely positioned at the top
of the application. It also places it above the content of the page, which feels
more uniform.

This attempts to fix a UI issue that is logged in https://trello.com/c/VxHM8JZg

Looks like:

![screenshot from 2014-04-09 15 26 05](https://cloud.githubusercontent.com/assets/928367/2660228/0653be16-c01d-11e3-9393-d8c7343cf793.png)
