### PR TITLE
Add page class to CCLA Signature show page.

### DIFF
--- a/app/views/ccla_signatures/show.html.erb
+++ b/app/views/ccla_signatures/show.html.erb
@@ -1,6 +1,6 @@
 <%= provide(:title, "CCLA Signature") %>
 
-<div class="cla">
+<div class="cla page">
   <h1>Corporate Contributor License Agreement for <%= @ccla_signature.organization.name %> <small>(CCLA)</small></h1>
     <dl class="tabs">
       <dd class="active"><%= link_to 'Signature', @ccla_signature %></dd>


### PR DESCRIPTION
The page class was missing, causing the page to look a little funky.

This PR is ready for review whenever.
