### PR TITLE
Allow for configurable asset host

### DIFF
--- a/chef/cookbooks/supermarket/attributes/default.rb
+++ b/chef/cookbooks/supermarket/attributes/default.rb
@@ -27,4 +27,5 @@ default['supermarket']['cla_signature_notification_email'] = 'notifications@exam
 default['supermarket']['from_email'] = 'donotreply@example.com'
 default['supermarket']['home'] = '/srv/supermarket'
 default['supermarket']['host'] = 'supermarket.getchef.com'
+default['supermarket']['asset_host'] = 'https://supermarket.getchef.com'
 default['supermarket']['sidekiq']['concurrency'] = '25'

--- a/chef/cookbooks/supermarket/metadata.rb
+++ b/chef/cookbooks/supermarket/metadata.rb
@@ -1,5 +1,5 @@
 name 'supermarket'
-version '1.2.0'
+version '1.2.1'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@getchef.com'
 license 'Apache v2.0'

--- a/chef/cookbooks/supermarket/templates/default/.env.erb
+++ b/chef/cookbooks/supermarket/templates/default/.env.erb
@@ -27,3 +27,4 @@ CLA_SIGNATURE_NOTIFICATION_EMAIL=<%= node['supermarket']['cla_signature_notifica
 FROM_EMAIL=<%= node['supermarket']['from_email'] %>
 HOST=<%= node['supermarket']['host'] %>
 PORT=<%= node['supermarket']['port'] %>
+ASSET_HOST=<%= node['supermarket']['asset_host'] %>

--- a/chef/cookbooks/supermarket/templates/default/sidekiq.sv.erb
+++ b/chef/cookbooks/supermarket/templates/default/sidekiq.sv.erb
@@ -2,4 +2,4 @@
 exec 2>&1
 
 cd <%= node['supermarket']['home'] %>/current
-exec chpst -usupermarket -P bundle exec sidekiq -C /etc/sidekiq/sidekiq.yml -e production -t 30 -L <%= node['supermarket']['home'] %>/shared/logs/sidekiq.log
+exec chpst -usupermarket -P bundle exec sidekiq -C /etc/sidekiq/sidekiq.yml -e production -t 30 -L <%= node['supermarket']['home'] %>/shared/log/sidekiq.log

--- a/config/application.yml
+++ b/config/application.yml
@@ -55,6 +55,7 @@ production:
   secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
   host: <%= ENV['HOST'] %>
   port: <%= ENV['PORT'] %>
+  asset_host: <%= ENV['ASSET_HOST'] %>
   sentry_url: <%= ENV['SENTRY_URL'] %>
   statsd:
     host: <%= ENV['STATSD_HOST'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,8 @@ Supermarket::Application.configure do
   # config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = "http://assets.example.com"
+  config.action_controller.asset_host = Supermarket::Config.asset_host
+  config.action_mailer.asset_host = Supermarket::Config.asset_host
 
   # Precompile additional assets.
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.


### PR DESCRIPTION
:construction: We'll want to define a per node asset host for the production environment to both prevent premailer-rails from breaking but also so image paths are absolute for mailers. In the future this will also allow us to host assets on another server entirely if the need arrises.
