### PR TITLE
Use correct path for sidekiq logs

### DIFF
--- a/chef/cookbooks/supermarket/metadata.rb
+++ b/chef/cookbooks/supermarket/metadata.rb
@@ -1,5 +1,5 @@
 name 'supermarket'
-version '1.2.0'
+version '1.2.1'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@getchef.com'
 license 'Apache v2.0'

--- a/chef/cookbooks/supermarket/templates/default/sidekiq.sv.erb
+++ b/chef/cookbooks/supermarket/templates/default/sidekiq.sv.erb
@@ -2,4 +2,4 @@
 exec 2>&1
 
 cd <%= node['supermarket']['home'] %>/current
-exec chpst -usupermarket -P bundle exec sidekiq -C /etc/sidekiq/sidekiq.yml -e production -t 30 -L <%= node['supermarket']['home'] %>/shared/logs/sidekiq.log
+exec chpst -usupermarket -P bundle exec sidekiq -C /etc/sidekiq/sidekiq.yml -e production -t 30 -L <%= node['supermarket']['home'] %>/shared/log/sidekiq.log


### PR DESCRIPTION
:fork_and_knife: The log path was incorrect for sidekiq in production, this corrects that.
