### PR TITLE
Display omniauth provider in flash when linking account.

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -12,10 +12,10 @@ class AccountsController < ApplicationController
 
     if account.save
       redirect_to after_link_location, notice: "Successfully
-        connected #{params[:provider]}."
+        connected #{request.env['omniauth.auth']['provider']}."
     else
       redirect_to edit_profile_path(current_user), alert: "Something went wrong
-        while connecting #{params[:provider]}"
+        while connecting #{request.env['omniauth.auth']['provider']}"
     end
   end
 


### PR DESCRIPTION
:fork_and_knife: There was no provider param, which left the flash message when connecting an
account a little empty. This adjusts the flash message to use the provider from
the omniauth hash.
