### PR TITLE
Use hardcoded platform/icon key

### DIFF
--- a/app/helpers/supported_platforms_helper.rb
+++ b/app/helpers/supported_platforms_helper.rb
@@ -6,9 +6,26 @@ module SupportedPlatformsHelper
   #   platform = SupportedPlatform.new(name: 'ubuntu')
   #   supported_platform_icon(platform) == 'U'
   #
+  # TODO: Add fallback icon key, currently it just falls back to empty string.
+  #
   # @return [String] the icon
   #
   def supported_platform_icon(platform)
-    platform.name[0].upcase
+    {
+      'aws' => 'A',
+      'centos' => 'B',
+      'debian' => 'C',
+      'fedora' => 'D',
+      'freebsd' => 'E',
+      'linux_mint' => 'F',
+      'mac_osx' => 'G',
+      'oracle' => 'H',
+      'red_hat' => 'I',
+      'scientific' => 'J',
+      'smartos' => 'K',
+      'suse' => 'L',
+      'ubuntu' => 'M',
+      'windows' => 'N'
+    }.fetch(platform.name.parameterize('_'), '')
   end
 end

--- a/spec/helpers/supported_platforms_helper_spec.rb
+++ b/spec/helpers/supported_platforms_helper_spec.rb
@@ -2,10 +2,10 @@ require 'spec_helper'
 
 describe SupportedPlatformsHelper do
   describe '#supported_platform_icon' do
-    it 'returns the first character of the platform name, uppercased' do
+    it 'returns the corresponding platform icon character' do
       platform = SupportedPlatform.new(name: 'ubuntu')
 
-      expect(helper.supported_platform_icon(platform)).to eql('U')
+      expect(helper.supported_platform_icon(platform)).to eql('M')
     end
   end
 end


### PR DESCRIPTION
:fork_and_knife: Since we're using an icon font for platform icons we need to return the corresponding character for a given platform.
