### PR TITLE
Fix for Bash Install re: EOH

### DIFF
--- a/exec/supermarket-server
+++ b/exec/supermarket-server
@@ -54,6 +54,7 @@ if ! db_seeded; then
 fi
 
 bundle exec foreman start
-EOH)
+EOH
+)
 
 in_supermarket "$command"


### PR DESCRIPTION
Running ./bin/supermarket server fails on Ubuntu 13.10 / Bash 4.2-5ubuntu3
