### PR TITLE
Fix cookbook_manage_spec

### DIFF
--- a/spec/features/cookbook_manage_spec.rb
+++ b/spec/features/cookbook_manage_spec.rb
@@ -31,7 +31,8 @@ describe "updating a cookbook's issues and source urls" do
       follow_relation 'edit-cookbook-urls'
       fill_in 'cookbook_source_url', with: 'example'
       fill_in 'cookbook_source_url', with: 'example'
-      expect(page).to have_selector('.error')
     end
+
+    expect(find('.edit_cookbook').all('.error').count).to eql(2)
   end
 end


### PR DESCRIPTION
:fork_and_knife:

I have noticed [the cookbook_manage_spec](https://github.com/opscode/supermarket/blob/master/spec/features/cookbook_manage_spec.rb#L6) fails every once and a while, but I have not been able to pin point what is causing it and why. #291 is a PR for something totally unrelated the cookbook_manage_spec, yet [the travis ci build failed](https://travis-ci.org/opscode/supermarket/builds/23084075) because of it.

I ran rspec with the seed from that travis build (51121), and it only fails once in a while. I xited out the other test in this file to see if it has to do with the order of the specs being run. It still fails. I put a `save_and_open_page` in the failing spec at different places, and it shows the browser at example.com, which sees odd. I changed out the fill ins and expectations to not be example.com to rule out that being the cause of it, but still the same issue.

I am not able to reproduce this every time the spec runs, only some of the time. Does anyone have any thoughts on what might be causing this and why?

An aside: I noticed that the spec description was no longer accurate, and the expectation was did not seem useful. I changed it to test that the anchor href changes when the form is submitted.
