### PR TITLE
Check for Supermarket bucket config using string keys

### DIFF
--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -11,7 +11,7 @@ class CookbookVersion < ActiveRecord::Base
   # otherwise use local storage.
   #
   # --------------------
-  if Supermarket::Config.s3[:bucket].present?
+  if Supermarket::Config.s3['bucket'].present?
     has_attached_file :tarball, storage: 's3', s3_credentials: Supermarket::Config.s3
   else
     has_attached_file :tarball


### PR DESCRIPTION
:fork_and_knife: Magiconf uses string keys not symbol keys so this changes the CookbookVersion tarball logic to account for that so it works.
