### PR TITLE
Allow .env changes without redeploy

### DIFF
--- a/chef/cookbooks/supermarket/metadata.rb
+++ b/chef/cookbooks/supermarket/metadata.rb
@@ -1,5 +1,5 @@
 name 'supermarket'
-version '1.2.2'
+version '1.2.3'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@getchef.com'
 license 'Apache v2.0'

--- a/chef/cookbooks/supermarket/recipes/_application.rb
+++ b/chef/cookbooks/supermarket/recipes/_application.rb
@@ -33,6 +33,12 @@ user 'supermarket' do
   shell '/bin/false'
 end
 
+template "#{node['supermarket']['home']}/shared/.env" do
+  variables(app: app)
+  notifies :restart, 'service[unicorn]'
+  notifies :restart, 'service[sidekiq]'
+end
+
 deploy_revision node['supermarket']['home'] do
   repo 'https://github.com/opscode/supermarket.git'
   revision app['revision']
@@ -50,10 +56,6 @@ deploy_revision node['supermarket']['home'] do
         mode 0777
         recursive true
       end
-    end
-
-    template "#{node['supermarket']['home']}/shared/.env" do
-      variables(app: app)
     end
 
     execute 'bundle install' do


### PR DESCRIPTION
:fork_and_knife: Currently since the .env template resource lives in the deploy resource you need to redeploy in order to change any of the .env values. This moves the .env template resource outside of the deploy resource and haves it notify the unicorn and sidekiq resource if any values change.
