### PR TITLE
Fix cookbook platform and dependency access scope

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -37,8 +37,6 @@ class Cookbook < ActiveRecord::Base
   # Associations
   # --------------------
   has_many :cookbook_versions, -> { order(id: :desc) }, dependent: :destroy
-  has_many :supported_platforms, through: :latest_cookbook_version
-  has_many :cookbook_dependencies, through: :latest_cookbook_version
   has_many :cookbook_followers, dependent: :destroy
   has_one :latest_cookbook_version, -> { order(id: :desc) }, class_name: 'CookbookVersion'
   belongs_to :category
@@ -157,6 +155,24 @@ class Cookbook < ActiveRecord::Base
   #
   def followed_by?(user)
     cookbook_followers.where(user: user).any?
+  end
+
+  #
+  # Returns the platforms supported by the latest version of this cookbook.
+  #
+  # @return [Array<SupportedVersion>]
+  #
+  def supported_platforms
+    latest_cookbook_version.supported_platforms
+  end
+
+  #
+  # Returns the dependencies of the latest version of this cookbook.
+  #
+  # @return [Array<CookbookDependency>]
+  #
+  def cookbook_dependencies
+    latest_cookbook_version.cookbook_dependencies
   end
 
   private

--- a/spec/features/cookbook_view_spec.rb
+++ b/spec/features/cookbook_view_spec.rb
@@ -32,7 +32,11 @@ describe 'viewing a cookbook' do
     cookbook = create(:cookbook) # TODO: give this cookbook a real maintainer
     apt = create(:cookbook, name: 'apt')
 
-    create(:cookbook_dependency, cookbook_version: cookbook.cookbook_versions.first, cookbook: apt)
+    create(
+      :cookbook_dependency,
+      cookbook_version: cookbook.latest_cookbook_version,
+      cookbook: apt
+    )
 
     visit cookbook_path(cookbook)
 

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -147,7 +147,7 @@ describe Cookbook do
         to match_array(['= 12.04', '>= 0.0.0'])
     end
 
-    it 'saves supported platform metadata' do
+    it 'creates cookbook dependencies from the metadata' do
       cookbook.publish_version!(metadata, tarball, readme)
 
       dependencies = cookbook.reload.cookbook_dependencies


### PR DESCRIPTION
Accessing these relations through a has_one relation results in displaying all `SupportedPlatform` and `CookbookDependency` records associated with _any_ version of the cookbook.

This feels like it could be a Rails bug, but for the time being, we can fix it by adding these two simple methods to `Cookbook`.
