### PR TITLE
Handle no specified cookbook supported platforms.

### DIFF
--- a/app/assets/stylesheets/libs/_cookbooks.scss
+++ b/app/assets/stylesheets/libs/_cookbooks.scss
@@ -1008,3 +1008,34 @@ li.cookbook_platform_icon {
     }
   }
 }
+
+li.cookbook_no_platform_icon {
+  float: left;
+  font: {
+    size: rem-calc(18);
+    weight: $normal;
+  }
+  height: rem-calc(16);
+  line-height: rem-calc(18);
+  margin: rem-calc(0 10 10 0);
+  width: rem-calc(16);
+  color: $primary_gray;
+
+  &:hover {
+    color: $primary_gray;
+  }
+
+  &:last-child {
+    margin-bottom: rem-calc(10);
+  }
+
+  &.has-tip { border: none; }
+
+  .cookbook_show_sidebar & {
+    font-size: rem-calc(20);
+
+    &[data-icon]:before {
+      color: adjust-lightness($primary_gray, 20%);
+    }
+  }
+}

--- a/app/views/cookbooks/_cookbook.html.erb
+++ b/app/views/cookbooks/_cookbook.html.erb
@@ -39,9 +39,15 @@
   <div class="cookbook_footer">
     <div class="cookbook_partial_content_footer">
       <ul class="cookbook_platforms show-for-medium-up">
-        <% cookbook.supported_platforms.each do |platform| %>
-          <li class="cookbook_platform_icon has-tip" title="<%= platform.name %> <%= platform.version_constraint %>" data-tooltip data-icon="<%= supported_platform_icon(platform) %>">
-            <span><%= platform.name %></span>
+        <% if cookbook.supported_platforms.present? %>
+          <% cookbook.supported_platforms.each do |platform| %>
+            <li class="cookbook_platform_icon has-tip" title="<%= platform.name %> <%= platform.version_constraint %>" data-tooltip data-icon="<%= supported_platform_icon(platform) %>">
+              <span><%= platform.name %></span>
+            </li>
+          <% end %>
+        <% else %>
+          <li data-tooltip class="has-tip cookbook_no_platform_icon" title="Not specified">
+            <span class="fa fa-question-circle"></span>
           </li>
         <% end %>
       </ul>

--- a/app/views/cookbooks/_sidebar.html.erb
+++ b/app/views/cookbooks/_sidebar.html.erb
@@ -46,9 +46,15 @@
 
     <h4><i class="fa fa-desktop"></i> Platforms</h4>
     <ul class="cookbook_platforms">
-      <% supported_platforms.each do |platform| %>
-        <li class="cookbook_platform_icon has-tip" title="<%= platform.name %> <%= platform.version_constraint %>" data-tooltip data-icon="<%= supported_platform_icon(platform) %>">
-          <span><%= platform.name %></span>
+      <% if cookbook.supported_platforms.present? %>
+        <% supported_platforms.each do |platform| %>
+          <li class="cookbook_platform_icon has-tip" title="<%= platform.name %> <%= platform.version_constraint %>" data-tooltip data-icon="<%= supported_platform_icon(platform) %>">
+            <span><%= platform.name %></span>
+          </li>
+        <% end %>
+      <% else %>
+        <li data-tooltip class="has-tip cookbook_no_platform_icon" title="Not specified">
+          <span class="fa fa-question-circle"></span>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
:fork_and_knife:

In the UI, if there are no supported platforms specified for a cookbook, let the
user know.

This displays an icon and tooltip message on the cookbook partial and cookbook show.

This aims to fix feedback on: https://trello.com/c/JLSmCuuh
