### PR TITLE
The nginx service supports reloading

### DIFF
--- a/chef/cookbooks/supermarket/Berksfile.lock
+++ b/chef/cookbooks/supermarket/Berksfile.lock
@@ -4,4 +4,4 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  supermarket (1.0.0)
+  supermarket (1.2.3)

--- a/chef/cookbooks/supermarket/metadata.rb
+++ b/chef/cookbooks/supermarket/metadata.rb
@@ -1,5 +1,5 @@
 name 'supermarket'
-version '1.2.2'
+version '1.2.3'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@getchef.com'
 license 'Apache v2.0'

--- a/chef/cookbooks/supermarket/recipes/_nginx.rb
+++ b/chef/cookbooks/supermarket/recipes/_nginx.rb
@@ -27,5 +27,6 @@ template '/etc/nginx/sites-available/default' do
 end
 
 service 'nginx' do
+  supports reload: true
   action [:enable, :start]
 end

--- a/chef/cookbooks/supermarket/spec/nginx_spec.rb
+++ b/chef/cookbooks/supermarket/spec/nginx_spec.rb
@@ -1,0 +1,13 @@
+require_relative 'spec_helper'
+
+describe 'supermarket::_nginx' do
+  let(:chef_run) do
+    ChefSpec::Runner.new.converge(described_recipe)
+  end
+
+  it 'reloads the service when the default sites-available conf changes' do
+    resource = chef_run.template('/etc/nginx/sites-available/default')
+
+    expect(resource).to notify('service[nginx]').to(:reload)
+  end
+end


### PR DESCRIPTION
:fork_and_knife: 

In order for the reload notification to reload nginx, the nginx must specify that it supports being reloaded. I added a ChefSpec to verify that changing the template sends the correct notification, but I'm not sure of the best way to test that the nginx resource supports reload correctly. Maybe it's not necessary to do so? I need to do some more reading on the matter.
