### PR TITLE
Do not autofocus the search input field.

### DIFF
--- a/app/views/cookbooks/_search.html.erb
+++ b/app/views/cookbooks/_search.html.erb
@@ -1,7 +1,7 @@
 <%= form_tag cookbooks_path, class: 'cookbook_search', method: :get do %>
   <i class="fa fa-search"></i>
   <div class="search_field">
-    <%= search_field_tag :q, params[:q], placeholder: 'Search Cookbooks', autofocus: 'true', class: 'cookbook_search_textfield' %>
+    <%= search_field_tag :q, params[:q], placeholder: 'Search Cookbooks', class: 'cookbook_search_textfield' %>
   </div>
   <div class="search_button">
     <%= button_tag(type: 'submit', class: 'cookbook_search_button') do %>


### PR DESCRIPTION
:fork_and_knife: 

Autofocusing on the search field hijacks page scrolling with arrows and page up
and page down. If the search bar was only on one page, I could see it being
useful to autofocus, but it being on every page makes it feel like less of the
focus.
