### PR TITLE
Improve the cookbook manage spec.

### DIFF
--- a/spec/features/cookbook_manage_spec.rb
+++ b/spec/features/cookbook_manage_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_feature_helper'
 
-describe "updating a cookbook's issue and source urls" do
+describe "updating a cookbook's issues and source urls" do
   before { sign_in create(:user) }
 
-  it 'displays success message when saved' do
+  it 'saves the source and issues urls' do
     owner = create(:user)
     cookbook = create(:cookbook, owner: owner)
 
@@ -12,14 +12,15 @@ describe "updating a cookbook's issue and source urls" do
     within '.cookbook_show_sidebar' do
       follow_relation 'edit-cookbook-urls'
       fill_in 'cookbook_source_url', with: 'http://example.com/source'
-      fill_in 'cookbook_source_url', with: 'http://example.com/tissues'
+      fill_in 'cookbook_issues_url', with: 'http://example.com/tissues'
       submit_form
     end
 
-    expect(page).to have_selector('.source-url')
+    expect(find('.source-url')[:href]).to eql('http://example.com/source')
+    expect(find('.issues-url')[:href]).to eql('http://example.com/tissues')
   end
 
-  it 'displays a failure message when invalid urls are entered' do
+  it 'displays an error message when invalid urls are entered' do
     owner = create(:user)
     cookbook = create(:cookbook, owner: owner)
 
@@ -29,7 +30,8 @@ describe "updating a cookbook's issue and source urls" do
       follow_relation 'edit-cookbook-urls'
       fill_in 'cookbook_source_url', with: 'example'
       fill_in 'cookbook_source_url', with: 'example'
-      expect(page).to have_selector('.error')
     end
+
+    expect(find('.edit_cookbook').all('.error').count).to eql(2)
   end
 end


### PR DESCRIPTION
:fork_and_knife: 

This commit creates a more specific expectation for invalid URLs. It also
improves the language in the specs to better explain what is going on while
fixing some typos.
