### PR TITLE
Move env specific config into production.rb

### DIFF
--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -6,16 +6,8 @@ class CookbookVersion < ActiveRecord::Base
   belongs_to :cookbook
 
   # Attachments
-  #
-  # If both a S3 bucket set in the application configuration use S3
-  # otherwise use local storage.
-  #
   # --------------------
-  if Supermarket::Config.s3['bucket'].present?
-    has_attached_file :tarball, storage: 's3', s3_credentials: Supermarket::Config.s3
-  else
-    has_attached_file :tarball
-  end
+  has_attached_file :tarball
 
   # Validations
   # --------------------

--- a/config/application.yml
+++ b/config/application.yml
@@ -46,10 +46,6 @@ development:
   curry:
     success_label: 'Signed CLA'
     cla_location: <%= ENV['CURRY_CLA_LOCATION'] || 'https://community.getchef.com' %>
-  s3:
-    bucket: <%= ENV['S3_BUCKET'] %>
-    access_key_id: <%= ENV['S3_ACCESS_KEY_ID'] %>
-    secret_access_key: <%= ENV['S3_SECRET_ACCESS_KEY'] %>
 
 production:
   icla_version: '99999-2621/LEGAL14767024.1'
@@ -119,7 +115,3 @@ test:
   curry:
     success_label: 'Signed CLA'
     cla_location: 'https://community.getchef.com'
-  s3:
-    bucket: <%= ENV['S3_BUCKET'] %>
-    access_key_id: <%= ENV['S3_ACCESS_KEY_ID'] %>
-    secret_access_key: <%= ENV['S3_SECRET_ACCESS_KEY'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,4 +92,9 @@ Supermarket::Application.configure do
   else
     config.action_mailer.delivery_method = :sendmail
   end
+
+  # Configure Paperclip storage options
+  if Supermarket::Config.s3
+    config.paperclip_defaults = { storage: 's3', s3_credentials: Supermarket::Config.s3 }
+  end
 end


### PR DESCRIPTION
:fork_and_knife: Having conditional paperclip attachments doesn't really work. Paperclip supports default configuration though so this takes advantage of that in production.rb and removes the ability to configure paperclip in development and test as you really shouldn't be using S3 in either environment.
