### PR TITLE
Add a field to track dependency import status

### DIFF
--- a/db/migrate/20140423213806_add_dependencies_imported_column_to_cookbook_versions.rb
+++ b/db/migrate/20140423213806_add_dependencies_imported_column_to_cookbook_versions.rb
@@ -1,0 +1,5 @@
+class AddDependenciesImportedColumnToCookbookVersions < ActiveRecord::Migration
+  def change
+    add_column :cookbook_versions, :dependencies_imported, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140421212656) do
+ActiveRecord::Schema.define(version: 20140423213806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,9 +126,10 @@ ActiveRecord::Schema.define(version: 20140421212656) do
     t.string   "tarball_content_type"
     t.integer  "tarball_file_size"
     t.datetime "tarball_updated_at"
-    t.integer  "download_count",       default: 0
-    t.text     "readme",               default: "", null: false
-    t.string   "readme_extension",     default: "", null: false
+    t.integer  "download_count",        default: 0
+    t.text     "readme",                default: "",    null: false
+    t.string   "readme_extension",      default: "",    null: false
+    t.boolean  "dependencies_imported", default: false
   end
 
   add_index "cookbook_versions", ["version", "cookbook_id"], name: "index_cookbook_versions_on_version_and_cookbook_id", unique: true, using: :btree


### PR DESCRIPTION
:fork_and_knife: 

The data import task uses this column to keep track of which cookbook version records have had their dependency declarations (if any) imported. Once we're confident we're done importing data, we can remove this column.
