### PR TITLE
Loosen tarball content type validation

### DIFF
--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -25,7 +25,14 @@ class CookbookVersion < ActiveRecord::Base
     :tarball,
     presence: true,
     content_type: {
-      content_type: ['application/x-gzip', 'application/octet-stream']
+      content_type: ['application/x-gzip', 'application/gzip',
+                     'application/octet-stream', 'application/x-tar',
+                     'application/x-compressed-tar', 'application/x-gtar',
+                     'application/x-bzip2', 'application/gzipped-tar',
+                     'application/x-compressed', 'application/download',
+                     'application/x-gtar-compressed', 'application/zip',
+                     'application/x-bzip', 'application/x-zip-compressed',
+                     'application/cap', 'application/x-tar-gz']
     }
   )
 


### PR DESCRIPTION
:fork_and_knife: 

The existing community site has no validation on content type, so the following content types exist in the database:
- application/x-gzip
- application/gzip
- application/octet-stream
- application/x-tar
- application/x-compressed-tar
- application/x-gtar
- application/x-bzip2
- application/gzipped-tar
- application/x-compressed
- application/download
- application/x-gtar-compressed
- application/zip
- application/x-bzip
- application/x-zip-compressed
- application/cap
- application/x-tar-gz

We can impose validation going forward, but in order to import the existing community site data, we'll need to relax our constraints.
