### PR TITLE
Don't 500 when CCLA signature is invalid

### DIFF
--- a/app/models/ccla_signature.rb
+++ b/app/models/ccla_signature.rb
@@ -38,9 +38,8 @@ class CclaSignature < ActiveRecord::Base
 
   #
   # Creates an associated organization and an admin contributor for said
-  # organization then saves the signature.
-  #
-  # @return [Boolean]
+  # organization then saves the signature. Raises an exception and rolls
+  # the database back if any record is unable to save.
   #
   def sign!
     transaction do

--- a/app/views/ccla_signatures/_fields.html.erb
+++ b/app/views/ccla_signatures/_fields.html.erb
@@ -22,7 +22,8 @@
 <fieldset class="contact">
   <legend>Contact</legend>
   <div class="company-field">
-    <%= f.text_field :company, placeholder: 'Company', title: 'Company' %>
+    <%= f.text_field :company, placeholder: 'Company *', title: 'Company', required: '' %>
+    <small class="error">Company is required.</small>
   </div>
   <div class="phone-field">
     <%= f.telephone_field :phone, placeholder: 'Phone *', title: 'Phone', required: '', pattern: 'alpha_numeric' %>


### PR DESCRIPTION
:fork_and_knife: For some reason it was assumed that `CclaSignature#sign!` returned a boolean if the transaction failed, this was incorrect. It raises an invalid record exception so we must rescue this in the controller then render 'new' with any validation errors. This also adds abide validation to the company field as that's what originally caused the bug.
