### PR TITLE
Use specific tag for sentry-raven

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'validate_url'
 gem 'chef', require: false
 gem 'aws-sdk'
 
-gem 'sentry-raven', github: 'getsentry/raven-ruby', require: false
+gem 'sentry-raven', '~> 0.8.0', require: false
 gem 'statsd-ruby', require: 'statsd'
 gem 'analytics-ruby', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: git://github.com/getsentry/raven-ruby.git
-  revision: ff92a06ff6d0378bd4ab8e0ae6fe92b0fa643275
-  specs:
-    sentry-raven (0.7.1)
-      faraday (>= 0.7.6)
-      hashie (>= 1.1.0)
-      uuidtools
-
-GIT
   remote: git://github.com/octokit/octokit.rb.git
   revision: 79ea382f0d9159aafe346a07c6a9a77526efd2f3
   specs:
@@ -320,6 +311,10 @@ GEM
     sawyer (0.5.4)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
+    sentry-raven (0.8.0)
+      faraday (>= 0.7.6)
+      hashie (>= 1.1.0)
+      uuidtools
     sequel (4.9.0)
     shoulda-matchers (2.5.0)
       activesupport (>= 3.0.0)
@@ -431,7 +426,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails (~> 4.0.1)
-  sentry-raven!
+  sentry-raven (~> 0.8.0)
   shoulda-matchers
   sidekiq
   spring


### PR DESCRIPTION
:fork_and_knife: There was a bug in sentry-raven that was causing exceptions to not be captured. This specifies a specific tag of sentry-raven where the bug is resolved.
