### PR TITLE
Remove the pending cookbook rating API specs.

### DIFF
--- a/spec/views/api/v1/cookbook_versions/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbook_versions/show.json.jbuilder_spec.rb
@@ -57,6 +57,4 @@ describe 'api/v1/cookbook_versions/show' do
     expect(file_url.relative?).to eql(false)
     expect(file_url.to_s).to include('cookbooks/redis/versions/1_2_0/download')
   end
-
-  it "displays the cookbook version's average rating"
 end

--- a/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
@@ -130,7 +130,4 @@ describe 'api/v1/cookbooks/show' do
     expect(DateTime.parse(json_body['created_at']).to_i).
       to be_within(1).of(cookbook.created_at.to_i)
   end
-
-  # TODO: add this when ratings are implemented
-  it "displays the cookbook's average rating"
 end


### PR DESCRIPTION
:fork_and_knife:

Ratings are not yet implemented, and they are not going to be implemented in the
same fashion as before, so there is no need for the pending specs to be there.
