### PR TITLE
Remove mediaquery stylesheet import.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -19,6 +19,5 @@
 @import "libs/cookbooks";
 @import "libs/tabs";
 @import "libs/alerts";
-@import "libs/mediaqueries";
 
 @import "select2";


### PR DESCRIPTION
The mediaqueries file was removed, so it can no longer be imported. This adjusts for that.
