### PR TITLE
Use correct data for cookbook version show.

### DIFF
--- a/app/controllers/cookbook_versions_controller.rb
+++ b/app/controllers/cookbook_versions_controller.rb
@@ -26,9 +26,10 @@ class CookbookVersionsController < ApplicationController
   #
   def show
     @cookbook_versions = @cookbook.cookbook_versions
-    @maintainer = User.first
-    @collaborators = [User.first]
+    @owner = @cookbook.owner
+    @collaborators = @cookbook.collaborators
     @supported_platforms = @version.supported_platforms
+    @owner_collaborator = CookbookCollaborator.new cookbook: @cookbook, user: @owner
   end
 
   private

--- a/app/views/cookbook_versions/show.html.erb
+++ b/app/views/cookbook_versions/show.html.erb
@@ -4,5 +4,5 @@
 <div class="cookbook_show">
   <%= render 'cookbooks/breadcrumbs', cookbook: @cookbook %>
   <%= render 'cookbooks/main', cookbook: @cookbook, version: @version, cookbook_versions: @cookbook_versions %>
-  <%= render 'cookbooks/sidebar', cookbook: @cookbook, version: @version, supported_platforms: @supported_platforms, maintainer: @maintainer, collaborators: @collaborators %>
+  <%= render 'cookbooks/sidebar', cookbook: @cookbook, version: @version, supported_platforms: @supported_platforms, owner: @owner, collaborators: @collaborators %>
 </div>

--- a/spec/controllers/cookbook_versions_controller_spec.rb
+++ b/spec/controllers/cookbook_versions_controller_spec.rb
@@ -64,11 +64,9 @@ describe CookbookVersionsController do
     end
 
     it "provides the cookbook's maintainer to the view" do
-      create(:user) # TODO: replace with real maintainer
-
       get :show, cookbook_id: cookbook.name, version: version.version
 
-      expect(assigns(:maintainer)).to_not be_nil
+      expect(assigns(:owner)).to_not be_nil
     end
 
     it "provides the cookbook's collaborators to the view" do


### PR DESCRIPTION
:fork_and_knife:

The controller action CookbookVersion#show was using temporary data and was not
updated with the Cookbook#show to use the actual owner and collaborator data.
This changes that.

This addresses https://app.getsentry.com/chef/supermarket/group/18722669/
