### PR TITLE
Query by cookbook name in a consistent manner

### DIFF
--- a/app/controllers/api/v1/cookbook_versions_controller.rb
+++ b/app/controllers/api/v1/cookbook_versions_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::CookbookVersionsController < Api::V1Controller
   #   GET /api/v1/cookbooks/redis/versions/1_1_0
   #
   def show
-    @cookbook = Cookbook.find_by!(name: params[:cookbook])
+    @cookbook = Cookbook.with_name(params[:cookbook]).first!
     @cookbook_version = @cookbook.get_version!(params[:version])
   end
 end

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -1,7 +1,25 @@
 class Cookbook < ActiveRecord::Base
   include PgSearch
 
-  scope :with_name, ->(name) { where('lower(name) = ?', name.to_s.downcase) }
+  #
+  # Query cookbooks by case-insensitive name.
+  #
+  # @param name [String, Array<String>] a single name, or a collection of names
+  #
+  # @example
+  #   Cookbook.with_name('redis').first
+  #     #<Cookbook name: "redis"...>
+  #   Cookbook.with_name(['redis', 'apache2']).to_a
+  #     [#<Cookbook name: "redis"...>, #<Cookbook name: "apache2"...>]
+  #
+  # @todo: query and index by +LOWER(name)+ when ruby schema dumps support such
+  #   a thing.
+  #
+  scope :with_name, lambda { |names|
+    lowercase_names = Array(names).map { |name| name.to_s.downcase }
+
+    where(lowercase_name: lowercase_names)
+  }
   scope :recently_updated, -> { where('updated_at > ?', Time.now - 2.weeks) }
 
   scope :ordered_by, lambda { |ordering|
@@ -111,7 +129,7 @@ class Cookbook < ActiveRecord::Base
   #
   def publish_version!(metadata, tarball, readme)
     dependency_names = metadata.dependencies.keys
-    existing_cookbooks = Cookbook.where(name: dependency_names)
+    existing_cookbooks = Cookbook.with_name(dependency_names)
 
     transaction do
       self.maintainer = metadata.maintainer

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -243,6 +243,26 @@ describe Cookbook do
     end
   end
 
+  describe '.with_name' do
+    it 'is case-insensitive' do
+      cookbook = create(:cookbook, name: 'CookBook')
+
+      expect(Cookbook.with_name('Cookbook')).to include(cookbook)
+    end
+
+    it 'can locate multiple cookbooks at once' do
+      cookbook = create(:cookbook, name: 'CookBook')
+      mybook = create(:cookbook, name: 'MYBook')
+
+      scope = Cookbook.with_name(%w(Cookbook MyBook))
+
+      bad_scope = Cookbook.where(name: %w(cookbook mybook)).count
+
+      expect(scope).to include(cookbook)
+      expect(scope).to include(mybook)
+    end
+  end
+
   describe '#followed_by?' do
     it 'returns true if the user passed follows the cookbook' do
       user = create(:user)


### PR DESCRIPTION
:fork_and_knife: 

This addresses two bugs found while running imports locally:
1. Querying cookbooks by case-sensitive name in the cookbook versions API caused 404s for some cookbooks.
2. Querying cookbooks by case-sensitive name when publishing a new version of a cookbook would occasionally miss cookbook dependencies whose names were specified in a different case than the cookbook record.

Note: We could continue to query by LOWER(name), but Rails's Ruby schema language does not preserve Postgres expression indices, and building in support for such things does not seem like a high priority at the moment. SQL schema dumping is not a viable option, either.
