### PR TITLE
Move Cookbook maintainer, description to CookbookVersion

### DIFF
--- a/app/models/cookbook_upload.rb
+++ b/app/models/cookbook_upload.rb
@@ -85,7 +85,6 @@ class CookbookUpload
   def cookbook
     Cookbook.with_name(@params.metadata.name).first_or_initialize.tap do |book|
       book.name = @params.metadata.name
-      book.description = @params.metadata.description
       book.category = category
     end
   end

--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -12,6 +12,8 @@ class CookbookVersion < ActiveRecord::Base
   # Validations
   # --------------------
   validates :license, presence: true
+  validates :maintainer, presence: true
+  validates :description, presence: true
   validates :version, presence: true, uniqueness: { scope: :cookbook }
   validates_attachment(
     :tarball,

--- a/db/migrate/20140505141342_move_cookbook_maintainer_and_description_to_cookbook_versions.rb
+++ b/db/migrate/20140505141342_move_cookbook_maintainer_and_description_to_cookbook_versions.rb
@@ -1,0 +1,9 @@
+class MoveCookbookMaintainerAndDescriptionToCookbookVersions < ActiveRecord::Migration
+  def change
+    remove_column :cookbooks, :maintainer, :string
+    remove_column :cookbooks, :description, :text
+
+    add_column :cookbook_versions, :maintainer, :string
+    add_column :cookbook_versions, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140430213310) do
+ActiveRecord::Schema.define(version: 20140505141342) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,6 +131,8 @@ ActiveRecord::Schema.define(version: 20140430213310) do
     t.text     "readme",                default: "",    null: false
     t.string   "readme_extension",      default: "",    null: false
     t.boolean  "dependencies_imported", default: false
+    t.string   "maintainer"
+    t.text     "description"
   end
 
   add_index "cookbook_versions", ["version", "cookbook_id"], name: "index_cookbook_versions_on_version_and_cookbook_id", unique: true, using: :btree
@@ -138,8 +140,6 @@ ActiveRecord::Schema.define(version: 20140430213310) do
 
   create_table "cookbooks", force: true do |t|
     t.string   "name",                                     null: false
-    t.string   "maintainer",                               null: false
-    t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "source_url"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -125,8 +125,6 @@ if Rails.env.development?
     cookbook = Cookbook.where(
       name: name
     ).first_or_initialize(
-      maintainer: Faker::Name.name,
-      description: Faker::Lorem.sentences(1).first,
       source_url: 'http://example.com',
       issues_url: 'http://example.com',
       category: category,
@@ -138,6 +136,8 @@ if Rails.env.development?
     cookbook_version = cookbook.cookbook_versions.where(
       version: '0.1.0'
     ).first_or_create(
+      maintainer: Faker::Name.name,
+      description: Faker::Lorem.sentences(1).first,
       license: 'MIT',
       tarball: File.open('spec/support/cookbook_fixtures/redis-test-v1.tgz'),
       readme: File.read('README.md'),

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -82,8 +82,6 @@ describe CookbooksController do
         create(
           :cookbook,
           name: 'AmazingCookbook',
-          maintainer: 'john@example.com',
-          description: 'Makes you a pirate',
           category: create(:category, name: 'Databases')
         )
       end
@@ -92,35 +90,12 @@ describe CookbooksController do
         create(
           :cookbook,
           name: 'OKCookbook',
-          maintainer: 'jack@example.com',
-          description: 'Makes you a pigeon',
           category: create(:category, name: 'Other')
         )
       end
 
-      it 'only returns @cookbooks that match the name' do
+      it 'only returns @cookbooks that match the query parameter' do
         get :index, q: 'amazing'
-
-        expect(assigns[:cookbooks]).to include(amazing_cookbook)
-        expect(assigns[:cookbooks]).to_not include(ok_cookbook)
-      end
-
-      it 'only returns @cookbooks that match the maintainer' do
-        get :index, q: 'john'
-
-        expect(assigns[:cookbooks]).to include(amazing_cookbook)
-        expect(assigns[:cookbooks]).to_not include(ok_cookbook)
-      end
-
-      it 'only returns @cookbooks that match the description' do
-        get :index, q: 'pirate'
-
-        expect(assigns[:cookbooks]).to include(amazing_cookbook)
-        expect(assigns[:cookbooks]).to_not include(ok_cookbook)
-      end
-
-      it 'only returns @cookbooks that match the category' do
-        get :index, q: 'databases'
 
         expect(assigns[:cookbooks]).to include(amazing_cookbook)
         expect(assigns[:cookbooks]).to_not include(ok_cookbook)

--- a/spec/factories/cookbook.rb
+++ b/spec/factories/cookbook.rb
@@ -3,8 +3,6 @@ FactoryGirl.define do
     association :category
     association :owner, factory: :user
     sequence(:name) { |n| "redis-#{n}" }
-    description 'An awesome cookbook!'
-    maintainer 'Chef Software, Inc'
     source_url 'http://example.com'
     issues_url 'http://example.com/issues'
     deprecated false

--- a/spec/factories/cookbook_version.rb
+++ b/spec/factories/cookbook_version.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory :cookbook_version do
+    description 'An awesome cookbook!'
+    maintainer 'Chef Software, Inc'
     license 'MIT'
     sequence(:version) { |n| "1.2.#{n}" }
     tarball { File.open('spec/support/cookbook_fixtures/redis-test-v1.tgz') }

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -67,8 +67,6 @@ describe Cookbook do
     end
 
     it { should validate_presence_of(:name) }
-    it { should validate_presence_of(:maintainer) }
-    it { should validate_presence_of(:description) }
     it { should validate_presence_of(:cookbook_versions) }
     it { should validate_presence_of(:category) }
   end
@@ -111,7 +109,6 @@ describe Cookbook do
       create(
         :cookbook,
         name: 'kiwi',
-        maintainer: 'fruit',
         cookbook_versions_count: 0,
         cookbook_versions: [kiwi_0_2_0, kiwi_0_1_0]
       )
@@ -178,9 +175,15 @@ describe Cookbook do
       create(
         :cookbook,
         name: 'redis',
-        maintainer: 'tokein',
         category: create(:category, name: 'datastore'),
-        description: 'Redis: a fast, flexible datastore offering an extremely useful set of data structure primitives'
+        cookbook_versions: [
+          create(
+            :cookbook_version,
+            description: 'Redis: a fast, flexible datastore offering an extremely useful set of data structure primitives',
+            maintainer: 'tokein'
+          )
+        ],
+        cookbook_versions_count: 0
       )
     end
 
@@ -188,9 +191,15 @@ describe Cookbook do
       create(
         :cookbook,
         name: 'redisio',
-        maintainer: 'fruit',
         category: create(:category, name: 'datastore'),
-        description: 'Installs/Configures redis'
+        cookbook_versions: [
+          create(
+            :cookbook_version,
+            description: 'Installs/Configures redis',
+            maintainer: 'fruit'
+          )
+        ],
+        cookbook_versions_count: 0
       )
     end
 

--- a/spec/models/cookbook_version_spec.rb
+++ b/spec/models/cookbook_version_spec.rb
@@ -7,6 +7,8 @@ describe CookbookVersion do
 
   context 'validations' do
     it { should validate_presence_of(:license) }
+    it { should validate_presence_of(:maintainer) }
+    it { should validate_presence_of(:description) }
     it { should validate_presence_of(:version) }
     it { should validate_uniqueness_of(:version).scoped_to(:cookbook_id) }
 

--- a/spec/views/api/v1/cookbook_uploads/create.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbook_uploads/create.json.jbuilder_spec.rb
@@ -5,8 +5,6 @@ describe 'api/v1/cookbook_uploads/create' do
     create(
       :cookbook,
       name: 'redis',
-      maintainer: 'slime',
-      description: 'great cookbook',
       source_url: 'http://example.com',
       deprecated: false
     )

--- a/spec/views/api/v1/cookbooks/index.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/index.json.jbuilder_spec.rb
@@ -24,8 +24,14 @@ describe 'api/v1/cookbooks/index' do
         create(
           :cookbook,
           name: 'test',
-          description: 'test cookbook',
-          maintainer: 'Chef Software, Inc.'
+          cookbook_versions: [
+            create(
+              :cookbook_version,
+              description: 'test cookbook',
+              maintainer: 'Chef Software, Inc.'
+            )
+          ],
+          cookbook_versions_count: 0
         )
       ]
     )

--- a/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
@@ -5,8 +5,6 @@ describe 'api/v1/cookbooks/show' do
     create(
       :cookbook,
       name: 'redis',
-      maintainer: 'slime',
-      description: 'great cookbook',
       source_url: 'http://example.com',
       issues_url: 'http://example.com',
       deprecated: false
@@ -17,6 +15,8 @@ describe 'api/v1/cookbooks/show' do
     create(
       :cookbook_version,
       cookbook: cookbook,
+      maintainer: 'slime',
+      description: 'great cookbook',
       version: '1.1.0'
     )
   end
@@ -25,6 +25,8 @@ describe 'api/v1/cookbooks/show' do
     create(
       :cookbook_version,
       cookbook: cookbook,
+      maintainer: 'slime',
+      description: 'great cookbook',
       version: '1.1.0'
     )
   end

--- a/spec/views/cookbooks/index.atom.builder_spec.rb
+++ b/spec/views/cookbooks/index.atom.builder_spec.rb
@@ -8,14 +8,26 @@ describe 'cookbooks/index.atom.builder' do
         create(
           :cookbook,
           name: 'test',
-          description: 'test cookbook',
-          maintainer: 'Chef Software, Inc.'
+          cookbook_versions: [
+            create(
+              :cookbook_version,
+              description: 'test cookbook',
+              maintainer: 'Chef Software, Inc.'
+            )
+          ],
+          cookbook_versions_count: 0
         ),
         create(
           :cookbook,
           name: 'test-2',
-          description: 'test cookbook',
-          maintainer: 'Chef Software, Inc.'
+          cookbook_versions: [
+            create(
+              :cookbook_version,
+              description: 'test cookbook',
+              maintainer: 'Chef Software, Inc.'
+            )
+          ],
+          cookbook_versions_count: 0
         )
       ]
     )

--- a/spec/views/cookbooks/show.atom.builder_spec.rb
+++ b/spec/views/cookbooks/show.atom.builder_spec.rb
@@ -21,7 +21,6 @@ describe 'cookbooks/show.atom.builder' do
     create(
       :cookbook,
       name: 'Kiwi',
-      maintainer: 'fruit',
       cookbook_versions_count: 0,
       cookbook_versions: [kiwi_0_2_0, kiwi_0_1_0]
     )


### PR DESCRIPTION
:fork_and_knife: Since maintainer and description can be changed overtime with new versions there is no need to store these attributes on `Cookbook`. This moves both of these attributes from `Cookbook` to `CookbookVersion` but delegates `Cookbook#maintainer` and `Cookbook#description` to `Cookbook#latest_cookbook_version` for easy access.
