### PR TITLE
Don't send cookbook notifications to imported users

### DIFF
--- a/app/workers/cookbook_notify_worker.rb
+++ b/app/workers/cookbook_notify_worker.rb
@@ -3,15 +3,22 @@ class CookbookNotifyWorker
 
   #
   # Notify all followers that a new version of the specified +Cookbook+ has been updated.
+  # This will only email the follower if the user has email notifications turned on.
+  # This will not email users with an OCID oauth token of 'imported' to prevent migrated users
+  # from being sent emails until they've logged into Supermarket.
   #
   # @param [Integer] cookbook_id the id for the Cookbook
   #
   def perform(cookbook_id)
     cookbook = Cookbook.find(cookbook_id)
 
+    active_user_ids = User.joins(:accounts).
+      where('provider = ? AND oauth_token != ?', 'chef_oauth2', 'imported').
+      pluck(:id)
+
     emailable_cookbook_followers = cookbook.cookbook_followers.
       joins(:user).
-      where('users.email_notifications = ?', true)
+      where(users: { email_notifications: true, id: active_user_ids })
 
     emailable_cookbook_followers.each do |cookbook_follower|
       CookbookMailer.delay.follower_notification_email(cookbook_follower)

--- a/spec/workers/cookbook_notify_worker_spec.rb
+++ b/spec/workers/cookbook_notify_worker_spec.rb
@@ -3,11 +3,15 @@ require 'spec_helper'
 describe CookbookNotifyWorker do
   let(:cookbook) { create(:cookbook) }
 
-  it 'notifies each interested cookbook follower via email' do
-    create_list(:cookbook_follower, 2, cookbook: cookbook)
+  it 'notifies each interested non-imported cookbook follower via email' do
+    create_list(:cookbook_follower, 3, cookbook: cookbook)
 
     cookbook.cookbook_followers.last.user.tap do |disinterested_user|
       disinterested_user.update_attribute(:email_notifications, false)
+    end
+
+    cookbook.cookbook_followers.first.user.tap do |imported_user|
+      imported_user.chef_account.update_attribute(:oauth_token, 'imported')
     end
 
     worker = CookbookNotifyWorker.new


### PR DESCRIPTION
:fork_and_knife: Since we'll be running Supermarket in parallel with the current community site we don't want to send cookbook follower notifications from Supermarket until the user signs in, at least during the soft launch period. Imported users will have a `oauth_token` for their `chef_oauth2` account set to imported until they sign in so we can use that as an indicator for whether or not they are active on Supermarket.
