### PR TITLE
Search UI adjustments

### DIFF
--- a/app/helpers/cookbooks_helper.rb
+++ b/app/helpers/cookbooks_helper.rb
@@ -20,19 +20,6 @@ module CookbooksHelper
   end
 
   #
-  # Return a title for cookbook feeds based on the parameters
-  # that are currently set.
-  #
-  # @example
-  #   <%= feed_title %>
-  #
-  # @return [String] a title based on the current paramters or All
-  #
-  def feed_title
-    (params.fetch(:category, nil) || params.fetch(:order, nil) || 'All').titleize
-  end
-
-  #
   # Return the correct state for a cookbook follow/unfollow button.
   #
   # @example
@@ -102,9 +89,10 @@ module CookbooksHelper
   # @return [String] the generated anchor tag
   #
   def link_to_sorted_cookbooks(linked_text, ordering)
-    class_name = params[:order] == ordering ? 'active ' : ''
-    class_name += 'button radius secondary'
-
-    link_to linked_text, params.merge(order: ordering), class: class_name
+    if params[:order] == ordering
+      link_to linked_text, params.except(:order), class: 'button radius secondary active'
+    else
+      link_to linked_text, params.merge(order: ordering), class: 'button radius secondary'
+    end
   end
 end

--- a/app/views/cookbooks/_cookbook.html.erb
+++ b/app/views/cookbooks/_cookbook.html.erb
@@ -2,8 +2,7 @@
   <div class="cookbook">
     <div class="cookbook_partial_content">
       <span class="cookbook_dates">
-        <i class="fa fa-clock-o"></i> Updated <%= cookbook.updated_at.to_s(:long) %><br />
-        <small>Created <%= cookbook.created_at.to_s(:long) %></small>
+        <i class="fa fa-clock-o"></i> Updated <%= cookbook.updated_at.to_s(:longish) %><br />
       </span>
 
       <h2 class="cookbook_title">

--- a/app/views/cookbooks/index.html.erb
+++ b/app/views/cookbooks/index.html.erb
@@ -5,13 +5,13 @@
 
   <section class="cookbook_body">
     <div class="order_cookbooks_by right">
-      Filter by
+      Sort by
       <%= link_to_sorted_cookbooks 'Most Downloaded', 'most_downloaded' %>
       <%= link_to_sorted_cookbooks 'Most Followed', 'most_followed' %>
 
     </div>
     <h1 class="cookbook_content_heading">
-      <%= feed_title %>
+      <%= pluralize(@cookbooks.count, 'Cookbook') %>
       <small>
         <%= link_to '<i class="fa fa-rss"></i> RSS'.html_safe, params.merge(format: 'atom'), :class => 'rss_feed_link show-for-medium-up' %>
       </small>

--- a/spec/helpers/cookbooks_helper_spec.rb
+++ b/spec/helpers/cookbooks_helper_spec.rb
@@ -2,23 +2,6 @@ require 'spec_helper'
 require 'nokogiri'
 
 describe CookbooksHelper do
-  describe '#feed_title_for' do
-    it 'returns a title for a category' do
-      helper.stub(:params) { { category: 'other' } }
-      expect(helper.feed_title).to eql('Other')
-    end
-
-    it 'returns a title for a sort order' do
-      helper.stub(:params) { { order: 'updated_at' } }
-      expect(helper.feed_title).to eql('Updated At')
-    end
-
-    it 'returns a fallback title' do
-      helper.stub(:params) { {} }
-      expect(helper.feed_title).to eql('All')
-    end
-  end
-
   describe '#follow_button_for' do
     it "returns a follow button if current user doesn't follow the given cookbook" do
       cookbook = double(
@@ -62,7 +45,7 @@ describe CookbooksHelper do
         helper.link_to_sorted_cookbooks('Excellent', 'excellent')
       ).css('a').first
 
-      expect(link['class']).to eql('active button radius secondary')
+      expect(link['class']).to match(/active/)
     end
 
     it 'returns a non-active link if the :order param is not the given ordering' do


### PR DESCRIPTION
:fork_and_knife: This changes a few minor UI items when searching for cookbooks.
- Change filter by to sort by
- Remove created at date from cookbook search results
- Allow users to unselect a search filter by clicking on the filter again
- Change search title to number of cookbooks returned
- Use longish time format for updated at date for cookbook search results

![screen shot 2014-05-05 at 4 46 19 pm](https://cloud.githubusercontent.com/assets/316507/2883061/60ba9270-d496-11e3-9fc4-1087f528c5c8.png)
