### PR TITLE
Display a cookbook's owner as its maintainer

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -22,7 +22,8 @@ class Cookbook < ActiveRecord::Base
     },
     associated_against: {
       category: :name,
-      latest_cookbook_version: [:description, :maintainer]
+      latest_cookbook_version: :description,
+      chef_account: :username
     },
     using: {
       tsearch: { prefix: true, dictionary: 'english' }
@@ -40,13 +41,14 @@ class Cookbook < ActiveRecord::Base
   has_one :latest_cookbook_version, -> { order(id: :desc) }, class_name: 'CookbookVersion'
   belongs_to :category
   belongs_to :owner, class_name: 'User', foreign_key: :user_id
+  has_one :chef_account, through: :owner
   belongs_to :replacement, class_name: 'Cookbook', foreign_key: :replacement_id
   has_many :cookbook_collaborators
   has_many :collaborators, through: :cookbook_collaborators, source: :user
 
   # Delegations
   # --------------------
-  delegate :maintainer, :description, to: :latest_cookbook_version
+  delegate :description, to: :latest_cookbook_version
 
   # Validations
   # --------------------
@@ -120,7 +122,6 @@ class Cookbook < ActiveRecord::Base
     transaction do
       cookbook_version = cookbook_versions.build(
         cookbook: self,
-        maintainer: metadata.maintainer,
         description: metadata.description,
         license: metadata.license,
         version: metadata.version,
@@ -177,6 +178,15 @@ class Cookbook < ActiveRecord::Base
   #
   def cookbook_dependencies
     latest_cookbook_version.cookbook_dependencies
+  end
+
+  #
+  # The username of this cookbook's owner
+  #
+  # @return [String]
+  #
+  def maintainer
+    owner.username
   end
 
   private

--- a/app/models/cookbook_upload/metadata.rb
+++ b/app/models/cookbook_upload/metadata.rb
@@ -32,11 +32,6 @@ class CookbookUpload
     #
 
     #
-    # @!attribute [r] maintainer
-    #   @return [String] The cookbook maintainer's name(s)
-    #
-
-    #
     # @!attribute [r] license
     #   @return [String] The cookbook license
     #
@@ -60,7 +55,6 @@ class CookbookUpload
       attribute :name, String, default: ''
       attribute :version, String, default: ''
       attribute :description, String, default: ''
-      attribute :maintainer, String, default: ''
       attribute :license, String, default: ''
       attribute :platforms, Hash[String => String]
       attribute :dependencies, Hash[String => String]

--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -12,7 +12,6 @@ class CookbookVersion < ActiveRecord::Base
   # Validations
   # --------------------
   validates :license, presence: true
-  validates :maintainer, presence: true
   validates :description, presence: true
   validates :version, presence: true, uniqueness: { scope: :cookbook }
   validates_attachment(

--- a/spec/api/cookbook_destroy_spec.rb
+++ b/spec/api/cookbook_destroy_spec.rb
@@ -7,7 +7,7 @@ describe 'DELETE /api/v1/cookbooks/:cookbook' do
     let(:cookbook_metadata_signature) do
       {
         'name' => 'redis-test',
-        'maintainer' => 'Chef Software, Inc',
+        'maintainer' => user.username,
         'external_url' => nil,
         'description' => 'Installs/Configures redis-test',
         'average_rating' => nil,

--- a/spec/api/cookbook_search_spec.rb
+++ b/spec/api/cookbook_search_spec.rb
@@ -1,12 +1,14 @@
 require 'spec_helper'
 
 describe 'GET /api/v1/search' do
+  let(:user) { create(:user) }
+
   let(:redis_test_signature) do
     {
       'cookbook_name' => 'redis-test',
       'cookbook_description' => 'Installs/Configures redis-test',
       'cookbook' => 'http://www.example.com/api/v1/cookbooks/redis-test',
-      'cookbook_maintainer' => 'Chef Software, Inc'
+      'cookbook_maintainer' => user.username
     }
   end
 
@@ -15,13 +17,11 @@ describe 'GET /api/v1/search' do
       'cookbook_name' => 'redisio-test',
       'cookbook_description' => 'Installs/Configures redisio-test',
       'cookbook' => 'http://www.example.com/api/v1/cookbooks/redisio-test',
-      'cookbook_maintainer' => 'Chef Software, Inc'
+      'cookbook_maintainer' => user.username
     }
   end
 
   before do
-    user = create(:user)
-
     share_cookbook('redis-test', user)
     share_cookbook('redisio-test', user)
   end

--- a/spec/api/cookbook_show_spec.rb
+++ b/spec/api/cookbook_show_spec.rb
@@ -2,11 +2,13 @@ require 'spec_helper'
 
 describe 'GET /api/v1/cookbooks/:cookbook' do
   context 'when the cookbook exists' do
+    let(:user) { create(:user) }
+
     let(:cookbook_signature) do
       {
         'name' => 'redis-test',
         'category' => 'Other',
-        'maintainer' => 'Chef Software, Inc',
+        'maintainer' => user.username,
         'latest_version' => 'http://www.example.com/api/v1/cookbooks/redis-test/versions/0_2_0',
         'external_url' => nil,
         'versions' =>
@@ -21,8 +23,6 @@ describe 'GET /api/v1/cookbooks/:cookbook' do
     end
 
     before do
-      user = create(:user)
-
       share_cookbook('redis-test', user, custom_metadata: { version: '0.1.0' })
       share_cookbook('redis-test', user, custom_metadata: { version: '0.2.0' })
 

--- a/spec/api/cookbooks_root_spec.rb
+++ b/spec/api/cookbooks_root_spec.rb
@@ -21,7 +21,7 @@ describe 'GET /api/v1/cookbooks' do
     let(:redis_test_signature) do
       {
         'cookbook_name' => 'redis-test',
-        'cookbook_maintainer' => 'Chef Software, Inc',
+        'cookbook_maintainer' => user.username,
         'cookbook_description' => 'Installs/Configures redis-test',
         'cookbook' => 'http://www.example.com/api/v1/cookbooks/redis-test'
       }
@@ -30,15 +30,15 @@ describe 'GET /api/v1/cookbooks' do
     let(:redisio_test_signature) do
       {
         'cookbook_name' => 'redisio-test',
-        'cookbook_maintainer' => 'Chef Software, Inc',
+        'cookbook_maintainer' => user.username,
         'cookbook_description' => 'Installs/Configures redisio-test',
         'cookbook' => 'http://www.example.com/api/v1/cookbooks/redisio-test'
       }
     end
 
-    before do
-      user = create(:user)
+    let(:user) { create(:user) }
 
+    before do
       share_cookbook('redis-test', user)
       share_cookbook('redisio-test', user)
     end

--- a/spec/factories/cookbook_version.rb
+++ b/spec/factories/cookbook_version.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :cookbook_version do
     description 'An awesome cookbook!'
-    maintainer 'Chef Software, Inc'
     license 'MIT'
     sequence(:version) { |n| "1.2.#{n}" }
     tarball { File.open('spec/support/cookbook_fixtures/redis-test-v1.tgz') }

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -138,7 +138,6 @@ describe Cookbook do
         license: 'MIT',
         version: cookbook.latest_cookbook_version.version + '-beta',
         description: 'Description',
-        maintainer: 'Jane Doe',
         platforms: {
           'ubuntu' => '= 12.04',
           'debian' => '>= 0.0.0'
@@ -179,8 +178,7 @@ describe Cookbook do
         cookbook_versions: [
           create(
             :cookbook_version,
-            description: 'Redis: a fast, flexible datastore offering an extremely useful set of data structure primitives',
-            maintainer: 'tokein'
+            description: 'Redis: a fast, flexible datastore offering an extremely useful set of data structure primitives'
           )
         ],
         cookbook_versions_count: 0
@@ -195,8 +193,7 @@ describe Cookbook do
         cookbook_versions: [
           create(
             :cookbook_version,
-            description: 'Installs/Configures redis',
-            maintainer: 'fruit'
+            description: 'Installs/Configures redis'
           )
         ],
         cookbook_versions_count: 0
@@ -209,10 +206,8 @@ describe Cookbook do
     end
 
     it 'returns cookbooks with a similar maintainer' do
-      expect(Cookbook.search('fruit')).to include(redisio)
-      expect(Cookbook.search('fruit')).to_not include(redis)
-      expect(Cookbook.search('tokein')).to include(redis)
-      expect(Cookbook.search('tokein')).to_not include(redisio)
+      expect(Cookbook.search('johndoe')).to include(redisio)
+      expect(Cookbook.search('janesmith')).to_not include(redisio)
     end
 
     it 'returns cookbooks with a similar category' do

--- a/spec/models/cookbook_upload/parameters_spec.rb
+++ b/spec/models/cookbook_upload/parameters_spec.rb
@@ -31,8 +31,7 @@ describe CookbookUpload::Parameters do
         name: 'redis-test',
         version: '0.1.0',
         license: 'All rights reserved',
-        description: 'Installs/Configures redis-test',
-        maintainer: 'YOUR_COMPANY_NAME'
+        description: 'Installs/Configures redis-test'
       )
 
       expect(params.metadata).to eql(redis_metadata)

--- a/spec/models/cookbook_version_spec.rb
+++ b/spec/models/cookbook_version_spec.rb
@@ -7,7 +7,6 @@ describe CookbookVersion do
 
   context 'validations' do
     it { should validate_presence_of(:license) }
-    it { should validate_presence_of(:maintainer) }
     it { should validate_presence_of(:description) }
     it { should validate_presence_of(:version) }
     it { should validate_uniqueness_of(:version).scoped_to(:cookbook_id) }

--- a/spec/support/api_spec_helpers.rb
+++ b/spec/support/api_spec_helpers.rb
@@ -97,7 +97,6 @@ module ApiSpecHelpers
       name: cookbook_name,
       version: '1.0.0',
       description: "Installs/Configures #{cookbook_name}",
-      maintainer: 'Chef Software, Inc',
       license: 'MIT',
       platforms: {
         'ubuntu' => '>= 12.0.0'

--- a/spec/views/api/v1/cookbooks/index.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/index.json.jbuilder_spec.rb
@@ -17,31 +17,29 @@ describe 'api/v1/cookbooks/index' do
     expect(json_body['total']).to eql(9001)
   end
 
-  it 'displays an array of cookbooks' do
-    assign(
-      :cookbooks,
-      [
+  let(:cookbook_record) do
+    create(
+      :cookbook,
+      name: 'test',
+      cookbook_versions: [
         create(
-          :cookbook,
-          name: 'test',
-          cookbook_versions: [
-            create(
-              :cookbook_version,
-              description: 'test cookbook',
-              maintainer: 'Chef Software, Inc.'
-            )
-          ],
-          cookbook_versions_count: 0
+          :cookbook_version,
+          description: 'test cookbook'
         )
-      ]
+      ],
+      cookbook_versions_count: 0
     )
+  end
+
+  it 'displays an array of cookbooks' do
+    assign(:cookbooks, [cookbook_record])
 
     render
 
     cookbook = json_body['items'].first
 
     expect(cookbook['cookbook_name']).to eql('test')
-    expect(cookbook['cookbook_maintainer']).to eql('Chef Software, Inc.')
+    expect(cookbook['cookbook_maintainer']).to eql(cookbook_record.owner.username)
     expect(cookbook['cookbook_description']).to eql('test cookbook')
     expect(cookbook['cookbook']).to eql('http://test.host/api/v1/cookbooks/test')
   end

--- a/spec/views/api/v1/cookbooks/search.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/search.json.jbuilder_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe 'api/v1/cookbooks/search' do
-  let(:cookbook) { create(:cookbook, name: 'redis') }
+  let(:cookbook_record) { create(:cookbook, name: 'redis') }
 
   before do
-    assign(:results, [cookbook])
+    assign(:results, [cookbook_record])
     assign(:start, 1)
   end
 
@@ -21,7 +21,7 @@ describe 'api/v1/cookbooks/search' do
     cookbook = json_body['items'].first
 
     expect(cookbook['cookbook_name']).to eql('redis')
-    expect(cookbook['cookbook_maintainer']).to eql('Chef Software, Inc')
+    expect(cookbook['cookbook_maintainer']).to eql(cookbook_record.owner.username)
     expect(cookbook['cookbook_description']).to eql('An awesome cookbook!')
     expect(cookbook['cookbook']).to eql('http://test.host/api/v1/cookbooks/redis')
   end

--- a/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
@@ -15,7 +15,6 @@ describe 'api/v1/cookbooks/show' do
     create(
       :cookbook_version,
       cookbook: cookbook,
-      maintainer: 'slime',
       description: 'great cookbook',
       version: '1.1.0'
     )
@@ -25,7 +24,6 @@ describe 'api/v1/cookbooks/show' do
     create(
       :cookbook_version,
       cookbook: cookbook,
-      maintainer: 'slime',
       description: 'great cookbook',
       version: '1.1.0'
     )
@@ -67,7 +65,7 @@ describe 'api/v1/cookbooks/show' do
     render
 
     cookbook_maintainer = json_body['maintainer']
-    expect(cookbook_maintainer).to eql('slime')
+    expect(cookbook_maintainer).to eql(cookbook.owner.username)
   end
 
   it "displays the cookbook's description" do

--- a/spec/views/cookbooks/index.atom.builder_spec.rb
+++ b/spec/views/cookbooks/index.atom.builder_spec.rb
@@ -1,36 +1,30 @@
 require 'spec_helper'
 
 describe 'cookbooks/index.atom.builder' do
-  before do
-    assign(
-      :cookbooks,
-      [
-        create(
-          :cookbook,
-          name: 'test',
-          cookbook_versions: [
-            create(
-              :cookbook_version,
-              description: 'test cookbook',
-              maintainer: 'Chef Software, Inc.'
-            )
-          ],
-          cookbook_versions_count: 0
-        ),
-        create(
-          :cookbook,
-          name: 'test-2',
-          cookbook_versions: [
-            create(
-              :cookbook_version,
-              description: 'test cookbook',
-              maintainer: 'Chef Software, Inc.'
-            )
-          ],
-          cookbook_versions_count: 0
-        )
-      ]
+  let(:test_cookbook) do
+    create(
+      :cookbook,
+      name: 'test',
+      cookbook_versions: [
+        create(:cookbook_version, description: 'test cookbook')
+      ],
+      cookbook_versions_count: 0
     )
+  end
+
+  let(:test_cookbook2) do
+    create(
+      :cookbook,
+      name: 'test-2',
+      cookbook_versions: [
+        create(:cookbook_version, description: 'test cookbook')
+      ],
+      cookbook_versions_count: 0
+    )
+  end
+
+  before do
+    assign(:cookbooks, [test_cookbook, test_cookbook2])
   end
 
   it 'displays the feed title' do
@@ -57,7 +51,7 @@ describe 'cookbooks/index.atom.builder' do
     cookbook = xml_body['feed']['entry'].first
 
     expect(cookbook['title']).to eql('test')
-    expect(cookbook['maintainer']).to eql('Chef Software, Inc.')
+    expect(cookbook['maintainer']).to eql(test_cookbook.owner.username)
     expect(cookbook['description']).to eql('test cookbook')
     expect(cookbook['link']['href']).to eql('http://test.host/cookbooks/test')
   end


### PR DESCRIPTION
:fork_and_knife:

A cookbook's `metadata.rb` allows cookbook authors to specify maintainer name and email address. The community site API does not use those values as the cookbook's maintainer attribute, and instead shows the username of the owner of the cookbook.
