### PR TITLE
Indicate when the current user is a CCLA admin

### DIFF
--- a/app/views/organization_invitations/index.html.erb
+++ b/app/views/organization_invitations/index.html.erb
@@ -67,7 +67,7 @@
                     <%= f.check_box :admin, class: 'auto trigger' %>
                   <% end %>
                 <% else %>
-                  <input type="checkbox" disabled>
+                  <%= tag(:input, type: 'checkbox', disabled: true, checked: contributor.admin?) %>
                 <% end %>
               </td>
               <td><%= "Active" %></td>


### PR DESCRIPTION
:fork_and_knife:

Fixes a bug where users who are CCLA admins would not see themselves as admins in the panel to manage CCLA signatories. Here I am, signed in, and marked as an admin:

![](https://cloud.githubusercontent.com/assets/35545/2895625/2ba6f156-d562-11e3-8724-efd94c74966d.png)
