### PR TITLE
Handle pg search ordering bug for cookbooks search

### DIFF
--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -31,13 +31,13 @@ class CookbooksController < ApplicationController
       @cookbooks = Cookbook.includes(:latest_cookbook_version)
     end
 
+    @cookbooks = @cookbooks.ordered_by(params[:order])
+
     if params[:q]
       @cookbooks = @cookbooks.search(params[:q])
     end
 
-    order, page = params[:order], params[:page]
-
-    @cookbooks = @cookbooks.ordered_by(order).page(page).per(20)
+    @cookbooks = @cookbooks.page(params[:page]).per(20)
 
     respond_to do |format|
       format.html

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -25,7 +25,7 @@ describe CookbooksController do
       let!(:cookbook_1) do
         create(
           :cookbook,
-          name: 'great',
+          name: 'mysql',
           updated_at: 1.year.ago,
           created_at: 1.year.ago,
           download_count: 100,
@@ -36,7 +36,7 @@ describe CookbooksController do
       let!(:cookbook_2) do
         create(
           :cookbook,
-          name: 'cookbook',
+          name: 'mysql-admin-tools',
           updated_at: 1.day.ago,
           created_at: 2.years.ago,
           download_count: 50,
@@ -61,6 +61,11 @@ describe CookbooksController do
 
       it 'orders @cookbooks by download_followers_count' do
         get :index, order: 'most_downloaded'
+        expect(assigns[:cookbooks].first).to eql(cookbook_1)
+      end
+
+      it 'correctly orders @cookbooks when also searching' do
+        get :index, order: 'most_followed', q: 'mysql'
         expect(assigns[:cookbooks].first).to eql(cookbook_1)
       end
     end


### PR DESCRIPTION
:fork_and_knife: There appears to be an issue with the pg search gem https://github.com/Casecommons/pg_search/issues/129 that breaks ordering after a search has been performed. This changes the controller flow so ordering is done before searching and also adds a spec originally used to reproduce the bug but seems handy to keep around in case pg search misbehaves again.
