### PR TITLE
Paperclip uses backwards-compatible URLs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,9 +92,4 @@ Supermarket::Application.configure do
   else
     config.action_mailer.delivery_method = :sendmail
   end
-
-  # Configure Paperclip storage options
-  if Supermarket::Config.s3
-    config.paperclip_defaults = { storage: 's3', s3_credentials: Supermarket::Config.s3 }
-  end
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -1,0 +1,21 @@
+Paperclip.interpolates(:compatible_id) do |attachment, style|
+  attachment.instance.legacy_id || attachment.instance.id
+end
+
+':class/:attachment/:compatible_id/:style/:basename.:extension'.tap do |path|
+  if Supermarket::Config.s3
+    ::Paperclip::Attachment.default_options.update(
+      storage: 's3',
+      s3_credentials: Supermarket::Config.s3,
+      url: ':s3_path_url',
+      path: path,
+      bucket: Supermarket::Config.s3['bucket']
+    )
+  else
+    ::Paperclip::Attachment.default_options.update(
+      storage: :filesystem,
+      path: ':rails_root/public:url',
+      url: "/system/#{path}"
+    )
+  end
+end

--- a/spec/models/cookbook_version_spec.rb
+++ b/spec/models/cookbook_version_spec.rb
@@ -40,4 +40,25 @@ describe CookbookVersion do
       expect(cookbook_version.to_param).to eql('1_1_0')
     end
   end
+
+  context 'the tarball URL' do
+    it 'contains the community site ID if it is present' do
+      cookbook_version = create(:cookbook_version, legacy_id: 101)
+
+      url = URI(cookbook_version.tarball.url)
+
+      expect(url.path).
+        to end_with('cookbook_versions/tarballs/101/original/redis-test-v1.tgz')
+    end
+
+    it 'contains the Supermarket ID if it is a Supermarket-only version' do
+      cookbook_version = create(:cookbook_version, legacy_id: nil)
+
+      url = URI(cookbook_version.tarball.url)
+      id = cookbook_version.id
+
+      expect(url.path).
+        to end_with("cookbook_versions/tarballs/#{id}/original/redis-test-v1.tgz")
+    end
+  end
 end


### PR DESCRIPTION
:fork_and_knife:

We're not going to re-upload every cookbook currently stored on S3, so we need to make sure that Paperclip generates URLs the same way as before. I've setup the non-S3 configuration to contain the S3 path, and added a test to make sure this path uses the old CookbookVersion ID if it's present. 

After running the import locally and configuring Paperclip to generate S3 URLs, imported CookbookVersion tarball URLs are identical to their community site counterparts.
