### PR TITLE
The chevron should always go to the directory

### DIFF
--- a/app/views/cookbooks/_main.html.erb
+++ b/app/views/cookbooks/_main.html.erb
@@ -25,7 +25,6 @@
     <small class="followbutton">
       <%= follow_button_for(cookbook) %>
     </small>
-    <%= link_to "<i class='fa fa-chevron-left previouspage'></i>".html_safe, cookbooks_directory_path %>
   </h1>
 
   <code><pre>knife cookbook site install <%= cookbook.name %></pre></code>


### PR DESCRIPTION
:fork_and_knife: 

This is for https://trello.com/c/8IchgnEH/29-only-cookbook-maintainers-and-contributors-can-manage-cookbook-urls and corrects an issue where after editing URLs, the chevron took the user to the wrong place.
