### PR TITLE
Add the Supermarket Beta banner.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require foundation.min
 //= require checkbox
 //= require cookbookShow
+//= require betaBanner
 //= require expandContributors
 //= require flash
 //= require select2.min

--- a/app/assets/javascripts/betaBanner.js
+++ b/app/assets/javascripts/betaBanner.js
@@ -1,0 +1,9 @@
+$(function() {
+  $(".beta_banner_header").click(function() {
+    if ($(".beta_banner_content").is(":hidden")) {
+      $(".beta_banner_content").slideDown(300);
+    } else {
+      $(".beta_banner_content").slideUp(240);
+    }
+  });
+});

--- a/app/assets/stylesheets/libs/_appheader.scss
+++ b/app/assets/stylesheets/libs/_appheader.scss
@@ -239,3 +239,57 @@
     }
   }
 }
+
+// styles for the beta banner
+
+.beta_banner_header {
+  background-color: $secondary-blue;
+  cursor: pointer;
+  height: rem-calc(60);
+  padding: rem-calc(12 0);
+  text-align: center;
+  transition: background-color 100ms ease-out 0s;
+
+  &:hover,
+  &:focus {
+    background-color: darken($secondary-blue, 20%);
+  }
+
+  h3 {
+    color: white;
+  }
+}
+
+.beta_banner_content {
+  @include grid-row();
+  background-color: lighten($primary_blue, 10%);
+  display: none;
+}
+
+.beta_info {
+  @include grid-column(6, $collapse: true);
+  padding: rem-calc(8 64 8 64);
+
+
+  a {
+    color: white;
+    text-decoration: underline;
+  }
+
+  h3 {
+    color: white;
+    margin: rem-calc(14 0);
+    text-transform: uppercase;
+  }
+
+  p {
+    color: white;
+  }
+}
+
+@media #{$mobile-only} {
+  .beta_info{
+    @include grid-column(12, $collapse: true);
+    padding: rem-calc(4 32);
+  }
+}

--- a/app/views/application/_beta_banner.html.erb
+++ b/app/views/application/_beta_banner.html.erb
@@ -1,0 +1,16 @@
+<div class="beta_banner">
+  <div class="beta_banner_header">
+    <h3>Supermarket is currently in Beta. Here is what you should know.</h3>
+  </div>
+
+  <div class="beta_banner_content">
+    <div class="beta_info beta_dragons">
+      <h3>Here Be Dragons</h3>
+      <p>Supermarket is the new Chef community site and is under active development. Things are changing and being added. Actions on Supermarket will not be synced with the previous community site. Knife and Berkshelf have not yet been updated to use the Supermarket API endpoints.</p>
+    </div>
+    <div class="beta_info beta_help">
+      <h3>How You Can Help</h3>
+      <p>Thank you for using Supermarket. We would appreciate any feedback. The codebase is <a href="https://github.com/opscode/supermarket">open source</a>, and development is transparent. Feel free <a href="https://github.com/opscode/supermarket/issues/new">open an issue on GitHub</a>, <a href="https://trello.com/b/IGLbkBWL/supermarket">follow along in Trello</a>, <a href="https://gitter.im/opscode/supermarket">chat with us in Gitter</a> or <a href="https://groups.google.com/forum/#!forum/chef-supermarket">post to the Supermarket mailing list</a>.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,6 +45,7 @@
         </header>
         <div class="container">
           <%= render partial: 'flash' %>
+          <%= render partial: 'beta_banner' %>
           <%= render partial: 'cookbooks/search' %>
 
           <%= yield %>


### PR DESCRIPTION
:fork_and_knife: The Supermarket Beta banner is a global drop down that contains information
surrounding the Supermarket Beta. This banner will only be around until the Beta
ends.
- Trello card for this: https://trello.com/c/G88oZ2KE
- Invision mock-ups for this:
  - [collapsed banner](https://projects.invisionapp.com/share/WXTGY83T#/screens/22551982)
  - [expanded banner](https://projects.invisionapp.com/share/WXTGY83T#/screens/22551980)

The content contains two key pieces that are displayed side-by-side:
- what users should expect
- how users can get involved

The banner features a slide toggle when pressed and emulates the look and feel
of buttons throughout the application. On mobile, the two pieces of content
collapse into one stacked column.

![beta-banner-toggle](https://cloud.githubusercontent.com/assets/928367/2907181/78daa96a-d619-11e3-8e70-8d8be775ed9c.gif)

I would totally appreciate feedback on the design, implementation and copy!
