### PR TITLE
Beta banner copy revisions

### DIFF
--- a/app/assets/stylesheets/libs/_appheader.scss
+++ b/app/assets/stylesheets/libs/_appheader.scss
@@ -267,8 +267,8 @@
 }
 
 .beta_info {
-  @include grid-column(6, $collapse: true);
-  padding: rem-calc(8 64 8 64);
+  @include grid-column(4, $collapse: true);
+  padding: rem-calc(8 32 8 32);
 
 
   a {

--- a/app/views/application/_beta_banner.html.erb
+++ b/app/views/application/_beta_banner.html.erb
@@ -15,16 +15,21 @@
         Supermarket is <a href="https://github.com/opscode/supermarket">open source</a> and enthusiastically welcomes new contributors.
       </p>
     </div>
-    <div class="beta_info beta_switch">
-      <h3>You can try it out</h3>
+    <div class="beta_info beta_meaning">
+      <h3>It's meant to be used</h3>
       <p>
         Using Supermarket instead of <a href="http://community.opscode.com">community.opscode.com</a>
         will help us improve Supermarket. For API consumers, <code>supermarket.getchef.com/api/v1</code> can replace <code>community.opscode.com/api/v1</code>.
         Knife users can test out Supermarket by installing the <a href="https://github.com/cwebberOps/knife-supermarket">knife supermarket</a> plugin.
       </p>
+    </div>
+    <div class="beta_info beta_data">
+      <h3>Your stuff is already here</h3>
       <p>
-        While we won't be backporting any data from Supermarket to <a href="http://community.opscode.com">community.opscode.com</a>,
-        we will be migrating data from <a href="http://community.opscode.com">community.opscode.com</a> to Supermarket throughout the beta.
+        We've imported everything from <a href="http://community.opscode.com">community.opscode.com</a> to Supermarket
+        and will continue to keep Supermarket up-to-date until the beta period is over.
+        During the beta, we will not backport data from Supermarket to <a href="http://community.opscode.com">community.opscode.com</a>.
+        For example, if you share a cookbook on Supermarket, it will not exist on the Opscode Community Site.
       </p>
     </div>
   </div>


### PR DESCRIPTION
:fork_and_knife: 

@brettchalupa - I was running on fumes yesterday afternoon and started playing around with the beta banner copy. It's a bit wordier than before, but if you like the direction, perhaps we can whittle it down to something more compact.

One thing I tried and then scrapped was putting the second paragraph in the right-hand column in a third column. However, I could not think of a heading for such a column.

ETA: I also styled the links to contrast with the text a bit more. It could very well just be me that likes that sort of contrast, and I wouldn't push back if you or @danvolkens vetoed such a change.

![beta banner](https://cloud.githubusercontent.com/assets/35545/2916263/4ce56e9e-d6b9-11e3-925d-3eddd0f6a248.png)
