### PR TITLE
Remove unused columns from cookbook_versions

### DIFF
--- a/db/migrate/20140508191053_remove_unused_cookbook_versions_columns.rb
+++ b/db/migrate/20140508191053_remove_unused_cookbook_versions_columns.rb
@@ -1,0 +1,7 @@
+class RemoveUnusedCookbookVersionsColumns < ActiveRecord::Migration
+  def change
+    remove_column :cookbook_versions, :file_size
+    remove_column :cookbook_versions, :file_url
+    remove_column :cookbook_versions, :maintainer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140505164715) do
+ActiveRecord::Schema.define(version: 20140508191053) do
 
   create_table "accounts", force: true do |t|
     t.integer  "user_id"
@@ -119,8 +119,6 @@ ActiveRecord::Schema.define(version: 20140505164715) do
     t.integer  "cookbook_id"
     t.string   "license"
     t.string   "version"
-    t.string   "file_url"
-    t.string   "file_size"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "tarball_file_name"
@@ -131,7 +129,6 @@ ActiveRecord::Schema.define(version: 20140505164715) do
     t.text     "readme",                default: "",    null: false
     t.string   "readme_extension",      default: "",    null: false
     t.boolean  "dependencies_imported", default: false
-    t.string   "maintainer"
     t.text     "description"
     t.integer  "legacy_id"
   end


### PR DESCRIPTION
:fork_and_knife: 

The `file_size` and `file_url` columns were introduced only as placeholders to get a basic API in place, and `maintainer` was recently replaced by the owner's username.
