### PR TITLE
Sort versions by number

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,5 @@ Documentation:
   Enabled: false
 DotPosition:
   Enabled: false
+RedundantBegin:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'chef', require: false
 gem 'mixlib-authentication'
 gem 'aws-sdk'
 gem 'newrelic_rpm'
+gem 'semverse'
 
 gem 'sentry-raven', '~> 0.8.0', require: false
 gem 'statsd-ruby', require: 'statsd'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,6 +312,7 @@ GEM
     sawyer (0.5.4)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
+    semverse (1.1.0)
     sentry-raven (0.8.0)
       faraday (>= 0.7.6)
       hashie (>= 1.1.0)
@@ -429,6 +430,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails (~> 4.0.1)
+  semverse
   sentry-raven (~> 0.8.0)
   shoulda-matchers
   sidekiq

--- a/app/controllers/api/v1/cookbooks_controller.rb
+++ b/app/controllers/api/v1/cookbooks_controller.rb
@@ -33,7 +33,7 @@ class Api::V1::CookbooksController < Api::V1Controller
       @cookbook, @cookbook.latest_cookbook_version
     )
 
-    @cookbook_versions_urls = @cookbook.cookbook_versions.map do |version|
+    @cookbook_versions_urls = @cookbook.sorted_cookbook_versions.map do |version|
       api_v1_cookbook_version_url(@cookbook, version)
     end
   end

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -24,11 +24,11 @@ class CookbooksController < ApplicationController
   def index
     if params[:category]
       @cookbooks = Cookbook.
-        includes(:latest_cookbook_version).
+        includes(:cookbook_versions).
         joins(:category).
         where('categories.slug = ?', params[:category])
     else
-      @cookbooks = Cookbook.includes(:latest_cookbook_version)
+      @cookbooks = Cookbook.includes(:cookbook_versions)
     end
 
     @cookbooks = @cookbooks.ordered_by(params[:order])
@@ -52,15 +52,15 @@ class CookbooksController < ApplicationController
   #
   def directory
     @recently_updated_cookbooks = Cookbook.
-      includes(:latest_cookbook_version).
+      includes(:cookbook_versions).
       ordered_by('recently_updated').
       limit(5)
     @most_downloaded_cookbooks = Cookbook.
-      includes(:latest_cookbook_version).
+      includes(:cookbook_versions).
       ordered_by('most_downloaded').
       limit(5)
     @most_followed_cookbooks = Cookbook.
-      includes(:latest_cookbook_version).
+      includes(:cookbook_versions).
       ordered_by('most_followed').
       limit(5)
 
@@ -76,7 +76,7 @@ class CookbooksController < ApplicationController
   #
   def show
     @latest_version = @cookbook.latest_cookbook_version
-    @cookbook_versions = @cookbook.cookbook_versions
+    @cookbook_versions = @cookbook.sorted_cookbook_versions
     @owner = @cookbook.owner
     @collaborators = @cookbook.collaborators
     @supported_platforms = @cookbook.supported_platforms

--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -14,6 +14,7 @@ class CookbookVersion < ActiveRecord::Base
   validates :license, presence: true
   validates :description, presence: true
   validates :version, presence: true, uniqueness: { scope: :cookbook }
+  validate :semantic_version
   validates_attachment(
     :tarball,
     presence: true,
@@ -41,5 +42,19 @@ class CookbookVersion < ActiveRecord::Base
   #
   def to_param
     version.gsub(/\./, '_')
+  end
+
+  private
+
+  #
+  # Ensure that the version string we've been given conforms to semantic
+  # versioning at http://semver.org
+  #
+  def semantic_version
+    begin
+      Semverse::Version.new(version)
+    rescue Semverse::InvalidVersionFormat
+      errors.add(:version, 'is formatted incorrectly')
+    end
   end
 end

--- a/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
@@ -31,9 +31,10 @@ describe Api::V1::CookbookVersionsController do
     end
 
     it 'handles the latest version of a cookbook' do
+      latest_version = redis.latest_cookbook_version
       get :show, cookbook: 'redis', version: 'latest', format: :json
 
-      expect(assigns[:cookbook_version]).to eql(redis_1_0_0)
+      expect(assigns[:cookbook_version]).to eql(latest_version)
     end
 
     it 'handles specific versions of a cookbook' do

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -33,6 +33,30 @@ describe Cookbook do
     end
   end
 
+  context 'ordering versions' do
+    let(:toast) { create(:cookbook) }
+
+    before do
+      toast.cookbook_versions.each(&:destroy)
+      create(:cookbook_version, cookbook: toast, version: '0.1.0')
+      create(:cookbook_version, cookbook: toast, version: '10.0.0')
+      create(:cookbook_version, cookbook: toast, version: '9.9.9')
+      create(:cookbook_version, cookbook: toast, version: '9.10.0')
+      create(:cookbook_version, cookbook: toast, version: '0.2.0')
+      toast.reload
+    end
+
+    it 'should order versions based on the version number' do
+      versions = toast.sorted_cookbook_versions.map(&:version)
+      expect(toast.cookbook_versions.size).to eql(5)
+      expect(versions).to eql(['10.0.0', '9.10.0', '9.9.9', '0.2.0', '0.1.0'])
+    end
+
+    it 'should use the one with the largest version number for #latest_cookbook_version' do
+      expect(toast.latest_cookbook_version.version).to eql('10.0.0')
+    end
+  end
+
   context 'validations' do
     it 'validates the uniqueness of name' do
       create(:cookbook)
@@ -159,7 +183,7 @@ describe Cookbook do
     let(:metadata) do
       CookbookUpload::Metadata.new(
         license: 'MIT',
-        version: cookbook.latest_cookbook_version.version + '-beta',
+        version: '9.9.9',
         description: 'Description',
         platforms: {
           'ubuntu' => '= 12.04',

--- a/spec/models/cookbook_version_spec.rb
+++ b/spec/models/cookbook_version_spec.rb
@@ -26,6 +26,16 @@ describe CookbookVersion do
         duplicate_version.save(validate: false)
       end.to raise_error(ActiveRecord::RecordNotUnique)
     end
+
+    it 'validates that the version number is semantically correct' do
+      cookbook = create(:cookbook)
+      cookbook_version = build(:cookbook_version, cookbook: cookbook, version: 'hahano')
+      expect(cookbook_version).to_not be_valid
+      expect(cookbook_version.errors[:version]).to_not be_empty
+      cookbook_version.version = '8.7.6'
+      expect(cookbook_version).to be_valid
+      expect(cookbook_version.errors[:version]).to be_empty
+    end
   end
 
   context 'attachments' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,10 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     Dir.mkdir('tmp') unless File.exists?('tmp')
+    extensions = %w(pg_trgm plpgsql)
+    extensions.each do |ext|
+      ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS #{ext}")
+    end
   end
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
@@ -11,21 +11,21 @@ describe 'api/v1/cookbooks/show' do
     )
   end
 
-  let(:cookbook_version_1_0_0) do
+  let(:cookbook_version_2_0_0) do
     create(
       :cookbook_version,
       cookbook: cookbook,
       description: 'great cookbook',
-      version: '1.1.0'
+      version: '2.0.0'
     )
   end
 
-  let(:cookbook_version_1_1_0) do
+  let(:cookbook_version_2_1_0) do
     create(
       :cookbook_version,
       cookbook: cookbook,
       description: 'great cookbook',
-      version: '1.1.0'
+      version: '2.1.0'
     )
   end
 
@@ -36,22 +36,19 @@ describe 'api/v1/cookbooks/show' do
     )
 
     assign(
-      :latest_cookbook_version,
-      cookbook_version_1_1_0
-    )
-
-    assign(
       :latest_cookbook_version_url,
-      'http://test.host/api/v1/cookbooks/redis/versions/1_1_0'
+      'http://test.host/api/v1/cookbooks/redis/versions/2_1_0'
     )
 
     assign(
       :cookbook_versions_urls,
       [
-        'http://test.host/api/v1/cookbooks/redis/versions/1_0_0',
-        'http://test.host/api/v1/cookbooks/redis/versions/1_1_0'
+        'http://test.host/api/v1/cookbooks/redis/versions/2_0_0',
+        'http://test.host/api/v1/cookbooks/redis/versions/2_1_0'
       ]
     )
+
+    cookbook.stub(:latest_cookbook_version) { cookbook_version_2_1_0 }
   end
 
   it "displays the cookbook's name" do
@@ -87,7 +84,7 @@ describe 'api/v1/cookbooks/show' do
 
     latest_version_url = json_body['latest_version']
     expect(latest_version_url).
-      to eql('http://test.host/api/v1/cookbooks/redis/versions/1_1_0')
+      to eql('http://test.host/api/v1/cookbooks/redis/versions/2_1_0')
   end
 
   it "displays the cookbook's external url" do
@@ -110,8 +107,8 @@ describe 'api/v1/cookbooks/show' do
     versions = json_body['versions']
     expect(versions).to eql(
         [
-          'http://test.host/api/v1/cookbooks/redis/versions/1_0_0',
-          'http://test.host/api/v1/cookbooks/redis/versions/1_1_0'
+          'http://test.host/api/v1/cookbooks/redis/versions/2_0_0',
+          'http://test.host/api/v1/cookbooks/redis/versions/2_1_0'
         ]
     )
   end


### PR DESCRIPTION
:fork_and_knife: 

This changes versions to be ordered according to [the semver spec](http://semver.org) instead of by `id`, as they were previously.  I used a semver extension for Postgres, which is located [here](https://github.com/theory/pg-semver).  I'm guessing we'll want to make some modifications to our cookbook to compile and use this new extension.

Relevant Trello card:  https://trello.com/c/Pmq2x3VJ/139-sort-a-cookbook-s-versions-by-version-number
