### PR TITLE
Index accounts by UID and Provider

### DIFF
--- a/db/migrate/20140514200102_index_accounts_on_uid_and_provider.rb
+++ b/db/migrate/20140514200102_index_accounts_on_uid_and_provider.rb
@@ -1,0 +1,5 @@
+class IndexAccountsOnUidAndProvider < ActiveRecord::Migration
+  def change
+    add_index :accounts, [:uid, :provider], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140508191053) do
+ActiveRecord::Schema.define(version: 20140514200102) do
 
   create_table "accounts", force: true do |t|
     t.integer  "user_id"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20140508191053) do
     t.string   "provider"
   end
 
+  add_index "accounts", ["uid", "provider"], name: "index_accounts_on_uid_and_provider", unique: true, using: :btree
   add_index "accounts", ["user_id"], name: "index_accounts_on_user_id", using: :btree
   add_index "accounts", ["username", "provider"], name: "index_accounts_on_username_and_provider", unique: true, using: :btree
 


### PR DESCRIPTION
:fork_and_knife: 

We query by `uid` and `provider` every time a user authenticates. On my machine, with a database full of imported accounts, adding this index speeds up this query by  a factor of 100.
