### PR TITLE
Add vendor stylesheets to the asset pipeline

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,6 +41,7 @@ module Supermarket
 
     # Include vendor fonts in the asset pipeline
     config.assets.paths << Rails.root.join('vendor', 'assets', 'fonts')
+    config.assets.paths << Rails.root.join('vendor', 'assets', 'stylesheets')
 
     # Ensure fonts are precompiled during asset compilation
     config.assets.precompile += %w(*.svg *.eot *.woff *.ttf)


### PR DESCRIPTION
:fork_and_knife: 

Disclaimer:  When it comes to stylesheets and the Rails asset pipeline, I have no idea what I'm doing.

The main issue we're trying to solve for can be illustrated by the following screenshot:

![lol](http://dl.dropboxusercontent.com/s/0fmzm2hh292hq3o/2014-05-14%20at%202.33%20PM.png)

There is an image called "select2.png" that's part of the select2 library, and is referenced inside of the select2 stylesheet.  When running locally, it shows up fine.  On staging, it doesn't show up.  My thought that was perhaps by adding the `vendor/stylesheet` directory to the asset pipeline paths, the image would get included in asset compilation.  I considered just copying the images (there's more than just this png) into `app/assets/images` but I thought if we ever upgrade this plugin, it'd be nice to just copy the files into vendor and be done, rather than having to remember to copy a bunch of random images around to various directories.

To test this out, I ran `bundle exec rake assets:precompile`, which generated a bunch of stuff in `public/assets`.  Then I edited `config/environments/development.rb` and set `config.assets.debug = false`, which according to my reading, should force Rails to use precompiled assets while in development mode.  Then I killed foreman and restarted it, and this is the result:

![lol](http://dl.dropboxusercontent.com/s/mjbiydhsewtd0wh/2014-05-14%20at%202.29%20PM%20%281%29.png)

So, maybe this works?  I have no real idea if I'm even testing this correctly.  I'm hoping one of you fine gentlemen will have some feedback. @bcobb @tristanoneil @brettchalupa 
