### PR TITLE
Scope simple cookbook listing styles

### DIFF
--- a/app/assets/stylesheets/libs/_cookbooks.scss
+++ b/app/assets/stylesheets/libs/_cookbooks.scss
@@ -240,7 +240,7 @@ input[type="search"].cookbook_search_textfield {
     display: none;
   }
 
-  li {
+  li.simple_cookbook {
     border-bottom: rem-calc(2) solid lighten($secondary_gray, 32%);
     vertical-align: bottom;
     display: table-row;


### PR DESCRIPTION
:fork_and_knife: The styles that apply to the simple cookbook listings need to be scoped to other .simple_cookbook class so it doesn't effect the regular cookbook listing.
