### PR TITLE
Split cookbook into roles

### DIFF
--- a/chef/cookbooks/supermarket/.kitchen.yml
+++ b/chef/cookbooks/supermarket/.kitchen.yml
@@ -13,5 +13,8 @@ platforms:
 suites:
   - name: default
     data_bags_path: ../../data_bags
+    role_path: roles
     run_list:
-      - recipe[supermarket::default]
+      - role[redis]
+      - role[database]
+      - role[web]

--- a/chef/cookbooks/supermarket/Berksfile.lock
+++ b/chef/cookbooks/supermarket/Berksfile.lock
@@ -4,4 +4,4 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  supermarket (1.2.3)
+  supermarket (1.2.5)

--- a/chef/cookbooks/supermarket/README.md
+++ b/chef/cookbooks/supermarket/README.md
@@ -1,6 +1,18 @@
-# supermarket
+# Supermarket
 
 This cookbook deploys the [Supermarket application](https://github.com/opscode/supermarket).
+
+## About
+
+This cookbook is split up into three different roles. Web, redis and database if you plan on running Supermarket
+on a single node you'll want to add all three of these roles to the run list. By default with all three roles applied
+to a single node Supermarket relies on Postgres peer authentication so there is no database password set.
+
+In the scenario that you need to connect to another Postgres database server you may override Supermarket's database
+configuration within the app/supermarket.json databag to configure a host, username and password.
+
+In the scenario that you need to connect to another Redis server you may override Supermarket's Sidekiq configuration
+within the app/supermarket.json databag.
 
 # License and Authors
 

--- a/chef/cookbooks/supermarket/metadata.rb
+++ b/chef/cookbooks/supermarket/metadata.rb
@@ -1,5 +1,5 @@
 name 'supermarket'
-version '1.2.4'
+version '1.2.5'
 maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@getchef.com'
 license 'Apache v2.0'

--- a/chef/cookbooks/supermarket/recipes/_application.rb
+++ b/chef/cookbooks/supermarket/recipes/_application.rb
@@ -41,7 +41,9 @@ deploy_revision node['supermarket']['home'] do
       end
     end
 
-    template "#{release_path}/config/database.yml"
+    template "#{release_path}/config/database.yml" do
+      variables(app: app)
+    end
 
     template "#{node['supermarket']['home']}/shared/.env" do
       variables(app: app)

--- a/chef/cookbooks/supermarket/roles/database.json
+++ b/chef/cookbooks/supermarket/roles/database.json
@@ -1,0 +1,7 @@
+{
+  "name": "database",
+  "description": "This role sets up postgres for use by Supermarket.",
+  "run_list": [
+    "recipe[supermarket::_postgres]"
+   ]
+}

--- a/chef/cookbooks/supermarket/roles/redis.json
+++ b/chef/cookbooks/supermarket/roles/redis.json
@@ -1,0 +1,7 @@
+{
+  "name": "redis",
+  "description": "This role sets up redis for Supermarket Sidekiq jobs.",
+  "run_list": [
+    "recipe[supermarket::_redis]"
+   ]
+}

--- a/chef/cookbooks/supermarket/roles/web.json
+++ b/chef/cookbooks/supermarket/roles/web.json
@@ -1,0 +1,14 @@
+{
+  "name": "web",
+  "description": "This role sets up node, ruby, nginx, unicorn and is responsible for deploying and running Supermarket.",
+  "run_list": [
+    "recipe[supermarket::_node]",
+    "recipe[supermarket::_sidekiq]",
+    "recipe[supermarket::_git]",
+    "recipe[supermarket::_ruby]",
+    "recipe[supermarket::_nginx]",
+    "recipe[supermarket::_runit]",
+    "recipe[supermarket::_users]",
+    "recipe[supermarket::_application]"
+   ]
+}

--- a/chef/cookbooks/supermarket/templates/default/.env.erb
+++ b/chef/cookbooks/supermarket/templates/default/.env.erb
@@ -36,3 +36,6 @@ CLA_SIGNATURE_NOTIFICATION_EMAIL=<%= node['supermarket']['cla_signature_notifica
 FROM_EMAIL=<%= node['supermarket']['from_email'] %>
 HOST=<%= node['supermarket']['host'] %>
 PORT=<%= node['supermarket']['port'] %>
+<% if @app['redis_url'] %>
+REDIS_URL=<%= @app['redis_url'] %>
+<% end %>

--- a/chef/cookbooks/supermarket/templates/default/database.yml.erb
+++ b/chef/cookbooks/supermarket/templates/default/database.yml.erb
@@ -1,5 +1,11 @@
 production:
-  username: <%= node['postgres']['user'] %>
+  <% if @app['database']['host'] %>
+  host: <%= @app['database']['host'] %>
+  <% end %>
+  username: <%= @app['database']['username'] || node['postgres']['user'] %>
+  <% if @app['database']['password'] %>
+  password: <%= @app['database']['password'] %>
+  <% end %>
   adapter: postgresql
-  database: <%= node['postgres']['database'] %>
-  pool: <%= node['supermarket']['database']['pool'] %>
+  database: <%= @app['database']['name'] || node['postgres']['database'] %>
+  pool: <%= @app['database']['pool'] || node['supermarket']['database']['pool'] %>

--- a/chef/data_bags/apps/supermarket.json
+++ b/chef/data_bags/apps/supermarket.json
@@ -4,6 +4,9 @@
   "secret_key_base": "someSecret",
   "revision": "master",
   "sentry_url": "someSentryUrl",
+  "redis_url": "redis://127.0.0.1:6379",
+  "database": {
+  },
   "smtp": {
     "address": "someaddress.com",
     "port": 123,


### PR DESCRIPTION
:fork_and_knife: This splits the Supermarket cookbook into 3 roles: web, database and redis. In addition it allows you to configure Supermarket with an external database and redis server using the apps supermarket databag. By default supermarket will use localhost for both though if nothing is specified in the apps supermarket databag.

@cwebberOps This should take care of all three of those cards if you want to give this a review. You'll be able to now configure the database host, username, password and a redis url within the supermarket apps databag.
