### PR TITLE
remove maintainers column from seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -136,7 +136,6 @@ if Rails.env.development?
     cookbook_version = cookbook.cookbook_versions.where(
       version: '0.1.0'
     ).first_or_create(
-      maintainer: Faker::Name.name,
       description: Faker::Lorem.sentences(1).first,
       license: 'MIT',
       tarball: File.open('spec/support/cookbook_fixtures/redis-test-v1.tgz'),


### PR DESCRIPTION
it got removed from cbv table, but was left in seeds.
