### PR TITLE
Remove html from plain text collaborator email.

### DIFF
--- a/app/views/collaborator_mailer/added_email.text.erb
+++ b/app/views/collaborator_mailer/added_email.text.erb
@@ -1,4 +1,4 @@
 Chef Supermarket - Collaborator Notification
 _________________________________________________________
 
-You've been added as a collaborator to the <%= @cookbook.name %> cookbook.  Find out more details here: <%= link_to cookbook_url(@cookbook), cookbook_url(@cookbook) %>
+You've been added as a collaborator to the <%= @cookbook.name %> cookbook.  Find out more details here: <%= cookbook_url(@cookbook) %>


### PR DESCRIPTION
Maybe it is because I am some kind of plain text email viewing mutant, but I noticed that there was some HTML trying to sneak its way into my plain text email. This fixes it. :ok_hand: :fork_and_knife: 
