### PR TITLE
Relax query bounds when scheduling token refreshes

### DIFF
--- a/app/workers/oauth_token_refresh_schedule_worker.rb
+++ b/app/workers/oauth_token_refresh_schedule_worker.rb
@@ -9,7 +9,10 @@ class OauthTokenRefreshScheduleWorker
   end
 
   #
-  # Queue jobs for OauthTokenRefreshWorker
+  # Queue jobs for OauthTokenRefreshWorker.
+  #
+  # Accounts whose OAuth tokens will expire in the next 25 minutes will have
+  # their tokens refreshed.
   #
   # @param last_occurrence [Float] the time at which the previously-scheduled
   #   OauthTokenRefreshScheduleWorker ran.
@@ -22,7 +25,7 @@ class OauthTokenRefreshScheduleWorker
   #   otherwise unused.
   #
   def perform(last_occurrence, current_occurrence)
-    lower_bound = Time.at(current_occurrence.floor - 1) + 20.minutes
+    lower_bound = Time.at(current_occurrence.floor)
     upper_bound = Time.at(current_occurrence.ceil + 1) + 25.minutes
 
     Account.

--- a/spec/workers/oauth_token_refresh_schedule_worker_spec.rb
+++ b/spec/workers/oauth_token_refresh_schedule_worker_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe OauthTokenRefreshScheduleWorker do
   context 'on the first run' do
-    it 'refreshes only tokens which expire 20-25 minutes from now' do
+    it 'refreshes only tokens which expire within 25 minutes from now' do
       last_run = -1 # Sidetiq uses -1 to denote the first run
       now = Time.now
 
-      [19.9, 20, 22, 25, 26.1].each do |expiry|
+      [-0.1, 0, 12.5, 25, 26.1].each do |expiry|
         create(:user).tap do |user|
           user.chef_account.update_attributes!(
             oauth_expires: now + expiry.minutes
@@ -23,11 +23,11 @@ describe OauthTokenRefreshScheduleWorker do
   end
 
   context 'on subsequent runs' do
-    it 'refreshes only tokens which expire 20-25 minutes from now' do
+    it 'refreshes only tokens which expire within 25 minutes from now' do
       last_run = 5.minutes.ago
       now = Time.now
 
-      [19.9, 20, 22, 25, 26.1].each do |expiry|
+      [-0.1, 0, 12.5, 25, 26.1].each do |expiry|
         create(:user).tap do |user|
           user.chef_account.update_attributes!(
             oauth_expires: now + expiry.minutes


### PR DESCRIPTION
:fork_and_knife: 

The current query bounds may exclude accounts whose token expiration timestamps fall in the first 15 seconds of a mod-5-minute (e.g. 12:05:10) due to Sidekiq's dequeuing strategy. We may as well simplify the construction of these bounds and eliminate this bug.
