### PR TITLE
Fix CSS bug with cookbook versions dropdown

### DIFF
--- a/app/assets/stylesheets/libs/_cookbooks.scss
+++ b/app/assets/stylesheets/libs/_cookbooks.scss
@@ -1,8 +1,17 @@
 // Cookbooks
 
-#versions {
+#versions li:hover {
+  background: white;
+}
+
+#versions ul {
   max-height: 200px;
   overflow-y: scroll;
+  margin: 0;
+
+  li:hover {
+    background: #eee;
+  }
 }
 
 // Cookbooks search
@@ -1111,7 +1120,6 @@ pre {
 
 .version_dropdown {
   @include inline-block;
-  margin: rem-calc(-5 10 0);
 }
 
 .previouspage {

--- a/app/views/cookbooks/_main.html.erb
+++ b/app/views/cookbooks/_main.html.erb
@@ -4,14 +4,18 @@
     <small class="version_dropdown">
       <%= link_to version.version, '#', 'data-dropdown' => 'versions', class: 'button radius tiny dropdown secondary', rel: 'cookbook_versions' %>
       <ul id="versions" data-dropdown-content class="f-dropdown">
-        <% cookbook_versions.each do |cookbook_version| %>
-          <li>
-            <%= link_to cookbook_version_path(cookbook, cookbook_version), rel: 'cookbook_version' do %>
-              <%= cookbook_version.version %>
-              <% if cookbook_version == version %><i class="fa fa-check right"></i><% end %>
+        <li>
+          <ul>
+            <% cookbook_versions.each do |cookbook_version| %>
+              <li>
+                <%= link_to cookbook_version_path(cookbook, cookbook_version), rel: 'cookbook_version' do %>
+                  <%= cookbook_version.version %>
+                  <% if cookbook_version == version %><i class="fa fa-check right"></i><% end %>
+                <% end %>
+              </li>
             <% end %>
-          </li>
-        <% end %>
+          </ul>
+        </li>
       </ul>
     </small>
     <small class="versions_count">


### PR DESCRIPTION
:fork_and_knife: Adding overflow-y: scroll to foundations dropdown directly causes some strange CSS bugs and doesn't show the dropdown arrow. Instead this nests another unordered list within the dropdowns first list element and makes the nested unordered list scroll instead of the dropdown list.

 :arrow_down: Looks like this now.

![screen shot 2014-05-27 at 4 41 10 pm](https://cloud.githubusercontent.com/assets/316507/3097512/cb193ab8-e5df-11e3-9d05-81c4c4409632.png)
