### PR TITLE
add dependencies and supported platforms to the cookbook versions API

### DIFF
--- a/app/views/api/v1/cookbook_versions/show.json.jbuilder
+++ b/app/views/api/v1/cookbook_versions/show.json.jbuilder
@@ -4,3 +4,13 @@ json.version @cookbook_version.version
 json.average_rating nil
 json.cookbook api_v1_cookbook_url(@cookbook)
 json.file cookbook_version_download_url(@cookbook_version.cookbook, @cookbook_version)
+json.set! :dependencies do
+  @cookbook_version.cookbook_dependencies.each do |dependency|
+    json.set! dependency.name, dependency.version_constraint
+  end
+end
+json.set! :platforms do
+  @cookbook_version.supported_platforms.each do |platform|
+    json.set! platform.name, platform.version_constraint
+  end
+end

--- a/spec/api/cookbook_version_spec.rb
+++ b/spec/api/cookbook_version_spec.rb
@@ -30,7 +30,7 @@ describe 'GET /api/v1/cookbooks/:cookbook/versions/:version' do
       it 'returns a version of the cookbook' do
         get '/api/v1/cookbooks/redis-test/versions/latest'
 
-        expect(signature(json_body)).to eql(cookbook_version_signature)
+        expect(signature(json_body)).to include(cookbook_version_signature)
       end
     end
 
@@ -53,7 +53,7 @@ describe 'GET /api/v1/cookbooks/:cookbook/versions/:version' do
       it 'returns a version of the cookbook' do
         get json_body['versions'].find { |v| v =~ /0_1_0/ }
 
-        expect(signature(json_body)).to eql(cookbook_version_signature)
+        expect(signature(json_body)).to include(cookbook_version_signature)
       end
     end
 

--- a/spec/factories/supported_platform.rb
+++ b/spec/factories/supported_platform.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :supported_platform do
+    association :cookbook_version
+
+    name 'ubuntu'
+    version_constraint '>= 12.04'
+  end
+end

--- a/spec/views/api/v1/cookbook_versions/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbook_versions/show.json.jbuilder_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe 'api/v1/cookbook_versions/show' do
   let(:cookbook) { create(:cookbook, name: 'redis') }
+  let(:apt) { create(:cookbook, name: 'apt') }
   let(:tarball) do
     File.open('spec/support/cookbook_fixtures/redis-test-v1.tgz')
   end
@@ -17,41 +18,44 @@ describe 'api/v1/cookbook_versions/show' do
   end
 
   before do
-    assign(:cookbook, cookbook)
+    create(:cookbook_dependency, cookbook_version: cookbook_version, cookbook: apt, name: 'apt', version_constraint: '>= 1.0.0')
+    create(:supported_platform, cookbook_version: cookbook_version, name: 'ubuntu', version_constraint: '= 12.04')
 
+    assign(:cookbook, cookbook)
     assign(:cookbook_version, cookbook_version)
+    render
+  end
+
+  it "displays the cookbook version's dependencies" do
+    dependencies = json_body['dependencies']
+    expect(dependencies['apt']).to eql('>= 1.0.0')
+  end
+
+  it "displays the cookbook version's supported platforms" do
+    platforms = json_body['platforms']
+    expect(platforms['ubuntu']).to eql('= 12.04')
   end
 
   it "displays the cookbook version's license" do
-    render
-
     cookbook_version_license = json_body['license']
     expect(cookbook_version_license).to eql('MIT')
   end
 
   it "displays the cookbook version's license" do
-    render
-
     cookbook_version_version = json_body['version']
     expect(cookbook_version_version).to eql('1.2.0')
   end
 
   it "displays the cookbook version's cookbook url" do
-    render
-
     cookbook_url = json_body['cookbook']
     expect(cookbook_url).to eql('http://test.host/api/v1/cookbooks/redis')
   end
 
   it "displays the cookbook version's tarball file size" do
-    render
-
     expect(json_body['tarball_file_size']).to eql(1791)
   end
 
   it "displays the cookbook version's file url" do
-    render
-
     file_url = URI(json_body['file'])
 
     expect(file_url.relative?).to eql(false)


### PR DESCRIPTION
:fork_and_knife: 

For this Trello card: https://trello.com/c/kZFdp1BG/94-expose-cookbook-version-dependencies-and-supported-platforms-via-the-cookbook-version-api
