### PR TITLE
Propagate 500s when refreshing an OAuth token

### DIFF
--- a/app/workers/oauth_token_refresh_worker.rb
+++ b/app/workers/oauth_token_refresh_worker.rb
@@ -29,7 +29,13 @@ class OauthTokenRefreshWorker
       oauth_expires: Time.at(refreshed_token.expires_at),
       oauth_refresh_token: refreshed_token.refresh_token
     )
-  rescue ActiveRecord::RecordNotFound, OAuth2::Error => e
+  rescue ActiveRecord::RecordNotFound => e
     logger.error(e.message) unless Rails.env.test?
+  rescue OAuth2::Error => e
+    if e.response.status.to_i >= 500
+      raise e
+    else
+      logger.error(e.message) unless Rails.env.test?
+    end
   end
 end


### PR DESCRIPTION
:fork_and_knife: 

Even after #374 an OAuth token failed to refresh. Looking at the Sidekiq logs, the response to the refresh request in question was a generic 500 from the OAuth provider. In this case, we want the worker to crash and re-queue itself.
