### PR TITLE
Increase the gravatar border-radius.

### DIFF
--- a/app/assets/stylesheets/libs/_users.scss
+++ b/app/assets/stylesheets/libs/_users.scss
@@ -1,5 +1,5 @@
 .gravatar {
-  @include border-radius(rem-calc(100));
+  @include border-radius(rem-calc(200));
 }
 
 .profile {


### PR DESCRIPTION
:fork_and_knife: 

Ensure that gravatars are always displayed circularly at all screen sizes.

Addresses: https://trello.com/c/D1ohm4dB
