### PR TITLE
Remove Breadcrumbs

### DIFF
--- a/app/assets/stylesheets/libs/_structure.scss
+++ b/app/assets/stylesheets/libs/_structure.scss
@@ -177,32 +177,6 @@ body {
   }
 }
 
-// Breadcrumbs
-.breadcrumbs {
-  background-color: white;
-  border: 0;
-  padding: 0;
-  position: absolute;
-  top: rem-calc(30);
-  left: rem-calc(70);
-  z-index: 1;
-
-  * {
-    color: $concrete;
-    text-decoration: underline;
-    text-transform: none;
-
-    &:hover {
-      text-decoration: none;
-    }
-
-    &:last-child {
-      text-decoration: none;
-    }
-  }
-}
-
-
 // Select2 Customizations
 .select2-container-multi .select2-choices .select2-search-field input {
   padding: rem-calc(8) !important;

--- a/app/views/cookbook_versions/show.html.erb
+++ b/app/views/cookbook_versions/show.html.erb
@@ -2,7 +2,6 @@
 <%= provide(:description, @cookbook.description) %>
 
 <div class="cookbook_show">
-  <%= render 'cookbooks/breadcrumbs', cookbook: @cookbook %>
   <%= render 'cookbooks/main', cookbook: @cookbook, version: @version, cookbook_versions: @cookbook_versions %>
   <%= render 'cookbooks/sidebar', cookbook: @cookbook, version: @version, supported_platforms: @supported_platforms, owner: @owner, collaborators: @collaborators %>
 </div>

--- a/app/views/cookbooks/_breadcrumbs.html.erb
+++ b/app/views/cookbooks/_breadcrumbs.html.erb
@@ -1,5 +1,0 @@
-<nav class="breadcrumbs show-for-large-up">
-  <%= link_to 'Cookbooks', cookbooks_path %>
-  <%= link_to cookbook.category.name, cookbooks_category_path(cookbook.category) if cookbook.category.present? %>
-  <%= link_to cookbook.name, cookbook %>
-</nav>


### PR DESCRIPTION
:fork_and_knife: Since breadcrumbs aren't displayed on cookbook show they should not be displayed on cookbook version show. Since they are now no longer used anywhere within the application this removes the breadcrumbs partial and styles specific to the cookbook breadcrumbs.
