### PR TITLE
User show current_user logic fix

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -67,7 +67,7 @@
         <%= render partial: 'cookbooks/cookbook', collection: @cookbooks %>
       </ul>
     <% else %>
-      <% if current_user %>
+      <% if @user == current_user %>
         <h3><%= t("profile.current_user_no_cookbooks.#{params[:tab] || 'owns'}") %></h3>
       <% else %>
         <h3><%= t("profile.no_cookbooks.#{params[:tab] || 'owns'}", username: @user.username) %></h3>


### PR DESCRIPTION
:fork_and_knife: 

This wraps up the remaining two QA items on: https://trello.com/c/tRtYe2r9

It adjusts the logic for when the Manage Profile button is displayed and what logic to display when there are no cookbooks for the different user profile tabs.
