### PR TITLE
Adjust the bottom margin for tab dds.

### DIFF
--- a/app/assets/stylesheets/tabs.scss
+++ b/app/assets/stylesheets/tabs.scss
@@ -9,8 +9,9 @@
   &.profiletabs { padding-top: rem-calc(2); }
 
   dd {
-
     &:last-child { border-right: none; }
+
+    margin-bottom: -1px !important;
 
     a {
       background-color: transparent;


### PR DESCRIPTION
:fork_and_knife: 

This fixes the style issue where a border-bottom was still displayed on active
tabs.

It was:

![screen shot 2014-06-03 at 11 51 06 am](https://cloud.githubusercontent.com/assets/928367/3162634/3cab44c6-eb37-11e3-9a82-04a2a775ff39.png)

It is now:

![screen shot 2014-06-03 at 11 52 27 am](https://cloud.githubusercontent.com/assets/928367/3162643/48a81664-eb37-11e3-80f0-69c40657562b.png)

Overriding an `!important` style with `!important` feels hacky but it gets the job done.
