### PR TITLE
Remove rake spec:javascipts from Travis CI config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ before_script:
 bundler_args: --without development
 script:
   - bundle exec rake spec
-  - bundle exec rake spec:javascripts
   - bundle exec rake spec:rubocop
 services:
   - redis-server


### PR DESCRIPTION
At this point in time, Travis CI takes about 15 minutes to run the entire test
suite. Travis CI is running the JavaScript specs, which requires installing a
bunch of NPM packages. The thing is we only have one JavaScript spec for the
alert message to disappear. Removing the rake spec:javascripts script from
Travis CI runs should improve the time it takes to complete. While this is not
ideal once/if more JS is added to the app, I think for now it is a little win
that helps.

At its best when passing:

![screen shot 2014-06-04 at 9 44 04 am](https://cloud.githubusercontent.com/assets/928367/3174170/0217b82c-ebef-11e3-814b-2fba7429576b.png)

At its worst when failing:

![screen shot 2014-06-04 at 9 48 05 am](https://cloud.githubusercontent.com/assets/928367/3174173/0e9bea5a-ebef-11e3-9839-b6f8b7450003.png)
