### PR TITLE
Only use Poltergeist to drive features when needed

### DIFF
--- a/spec/features/cookbook_collaboration_spec.rb
+++ b/spec/features/cookbook_collaboration_spec.rb
@@ -18,7 +18,7 @@ describe 'cookbook collaboration' do
     end
   end
 
-  it 'allows the owner to remove a collaborator' do
+  it 'allows the owner to remove a collaborator', use_poltergeist: true do
     sign_in(sally)
     navigate_to_cookbook
 
@@ -26,7 +26,7 @@ describe 'cookbook collaboration' do
     expect(page).to have_no_css('div.gravatar-container')
   end
 
-  it 'allows a collaborator to remove herself' do
+  it 'allows a collaborator to remove herself', use_poltergeist: true do
     sign_in(suzie)
     navigate_to_cookbook
 

--- a/spec/features/cookbook_directory_spec.rb
+++ b/spec/features/cookbook_directory_spec.rb
@@ -5,7 +5,10 @@ describe 'cookbook directory' do
     create_list(:cookbook, 5)
 
     visit '/'
-    click_link 'Cookbooks'
+
+    within '.appnav' do
+      click_link 'Cookbooks'
+    end
   end
 
   it 'lists the three most recently updated cookbooks' do

--- a/spec/features/cookbook_feed_spec.rb
+++ b/spec/features/cookbook_feed_spec.rb
@@ -5,7 +5,10 @@ describe 'cookbook feed' do
     create(:cookbook, name: 'AmazingCookbook')
 
     visit '/'
-    click_link 'Cookbooks'
+
+    within '.appnav' do
+      click_link 'Cookbooks'
+    end
 
     within '.cookbook_search' do
       fill_in 'q', with: 'Amazing'

--- a/spec/features/cookbook_following_spec.rb
+++ b/spec/features/cookbook_following_spec.rb
@@ -15,14 +15,21 @@ describe 'cookbook following' do
   end
 
   it 'allows a user to follow a cookbook' do
-    follow_relation 'follow'
+    within '.cookbook_show_content' do
+      follow_relation 'follow'
+    end
 
     expect(page).to have_xpath("//a[starts-with(@rel, 'unfollow')]")
   end
 
   it 'allows a user to unfollow a cookbook' do
-    follow_relation 'follow'
-    follow_relation 'unfollow'
+    within '.cookbook_show_content' do
+      follow_relation 'follow'
+    end
+
+    within '.cookbook_show_content' do
+      follow_relation 'unfollow'
+    end
 
     expect(page).to have_xpath("//a[starts-with(@rel, 'follow')]")
   end

--- a/spec/features/remove_members_from_ccla_spec.rb
+++ b/spec/features/remove_members_from_ccla_spec.rb
@@ -14,7 +14,7 @@ describe 'Removing members from a CCLA' do
     expect_to_see_success_message
   end
 
-  example 'admins can remove other, non-admin members' do
+  example 'admins can remove other, non-admin members', use_poltergeist: true do
     sign_ccla_and_invite_contributor_to('Acme')
     sign_out
     sign_in(create(:user))

--- a/spec/spec_feature_helper.rb
+++ b/spec/spec_feature_helper.rb
@@ -19,7 +19,7 @@ Capybara.javascript_driver = :quiet_ghost
 # Use JS driver for all features
 RSpec.configure do |config|
   config.before(:each) do
-    if example.metadata[:type] == :feature
+    if example.metadata[:type] == :feature && example.metadata[:use_poltergeist] == true
       Capybara.current_driver = :quiet_ghost
     else
       Capybara.use_default_driver # presumed to be :rack_test

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -8,7 +8,10 @@ module FeatureHelpers
     OmniAuthControl.stub_github!(user)
 
     visit '/'
-    follow_relation 'sign_in'
+
+    within '.appnav' do
+      follow_relation 'sign_in'
+    end
   end
 
   def sign_out
@@ -105,7 +108,9 @@ module FeatureHelpers
       follow_relation 'view_profile'
     end
 
-    follow_relation 'manage_profile'
+    within '.profile_sidebar' do
+      follow_relation 'manage_profile'
+    end
   end
 
   def manage_agreements
@@ -203,12 +208,22 @@ module FeatureHelpers
     all("[rel*=#{rel}]")
   end
 
+  def follow_first_relation(rel)
+    all("[rel*=#{rel}]").first.click
+  end
+
   def submit_form
     find('[type=submit]').click
   end
 
   def in_user_menu
-    find('.usermenu').hover
-    yield
+    begin
+      find('.usermenu').hover
+      yield
+    rescue NotImplementedError
+      within('.usermenu') do
+        yield
+      end
+    end
   end
 end


### PR DESCRIPTION
:fork_and_knife: 

When writing feature specs, the Rack::Test driver is used by default. If the
Poltergeist driver is required to be used, add the +use_poltergeist: true+
metadata to the spec.

This should improve the performance when running feature specs. It should
decrease the opportunities of Capybara timing out when Travis CI runs specs.

Note: because of this switch, it is required to be more specific about elements
that occur multiple times on a page. For example, this may require using within
blocks.
