### PR TITLE
Render follow/unfollow button via AJAX.

### DIFF
--- a/app/assets/javascripts/cookbookShow.js
+++ b/app/assets/javascripts/cookbookShow.js
@@ -6,7 +6,15 @@ $(function() {
     $(".cookbook-urls").fadeToggle();
   });
 
-  $('a[data-remote]').on('ajax:success', function(e, data, status, xhr) {
+  $('a[rel~="remove-cookbook-collaborator"]').on('ajax:success', function(e, data, status, xhr) {
     $(this).parents('.gravatar-container').remove();
+  });
+
+  $('a[rel~="follow"], a[rel~="unfollow"]').on('click', function() {
+    $(this).addClass('disabled');
+  });
+
+  $('body').delegate('a[rel~="follow"], a[rel~="unfollow"]', 'ajax:success', function(e, data, status, xhr) {
+    $(this).parent().load(window.location.href + ' a[data-cookbook="' + $(this).data('cookbook') + '"]');
   });
 });

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -123,7 +123,7 @@ class CookbooksController < ApplicationController
   def follow
     @cookbook.cookbook_followers.create(user: current_user)
 
-    redirect_to :back
+    head 200
   end
 
   #
@@ -133,10 +133,10 @@ class CookbooksController < ApplicationController
   #
   def unfollow
     cookbook_follower = @cookbook.cookbook_followers.
-      where(user: current_user).first
-    cookbook_follower.try(:destroy)
+      where(user: current_user).first!
+    cookbook_follower.destroy
 
-    redirect_to @cookbook
+    head 200
   end
 
   private

--- a/app/helpers/cookbooks_helper.rb
+++ b/app/helpers/cookbooks_helper.rb
@@ -114,7 +114,7 @@ module CookbooksHelper
         class: 'button radius tiny follow',
         id: 'unfollow_cookbook',
         'data-cookbook' => cookbook.name,
-        'data-disable-with' => 'Unfollowing'
+        remote: true
       ) do
         if block
           block.call(true)
@@ -130,7 +130,7 @@ module CookbooksHelper
         class: 'button radius tiny follow',
         id: 'follow_cookbook',
         'data-cookbook' => cookbook.name,
-        'data-disable-with' => 'Following'
+        remote: true
       ) do
         if block
           block.call(false)

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -269,7 +269,6 @@ describe CookbooksController do
 
   describe 'PUT #follow' do
     let(:cookbook) { create(:cookbook) }
-    before { request.env['HTTP_REFERER'] = cookbook_url(cookbook) }
 
     context 'a user is signed in' do
       before { sign_in create(:user) }
@@ -280,10 +279,10 @@ describe CookbooksController do
         end.to change(cookbook.cookbook_followers, :count).by(1)
       end
 
-      it 'redirects back' do
+      it 'returns a 200' do
         put :follow, id: cookbook
 
-        expect(response).to redirect_to(:back)
+        expect(response.status.to_i).to eql(200)
       end
     end
 
@@ -308,7 +307,6 @@ describe CookbooksController do
 
   describe 'DELETE #unfollow' do
     let(:cookbook) { create(:cookbook) }
-    before { request.env['HTTP_REFERER'] = cookbook_url(cookbook) }
 
     context 'the signed in user follows the specified cookbook' do
       before do
@@ -323,10 +321,10 @@ describe CookbooksController do
         end.to change(cookbook.cookbook_followers, :count).by(-1)
       end
 
-      it 'redirects back' do
+      it 'redirects 200' do
         delete :follow, id: cookbook
 
-        expect(response).to redirect_to(:back)
+        expect(response.status.to_i).to eql(200)
       end
     end
 
@@ -339,10 +337,10 @@ describe CookbooksController do
         end.to_not change(cookbook.cookbook_followers, :count)
       end
 
-      it 'redirects back' do
-        delete :follow, id: cookbook
+      it 'returns a 404' do
+        delete :unfollow, id: cookbook
 
-        expect(response).to redirect_to(:back)
+        expect(response.status.to_i).to eql(404)
       end
     end
   end

--- a/spec/features/cookbook_following_spec.rb
+++ b/spec/features/cookbook_following_spec.rb
@@ -14,7 +14,7 @@ describe 'cookbook following' do
     end
   end
 
-  it 'allows a user to follow a cookbook' do
+  it 'allows a user to follow a cookbook', use_poltergeist: true do
     within '.cookbook_show_content' do
       follow_relation 'follow'
     end
@@ -22,7 +22,7 @@ describe 'cookbook following' do
     expect(page).to have_xpath("//a[starts-with(@rel, 'unfollow')]")
   end
 
-  it 'allows a user to unfollow a cookbook' do
+  it 'allows a user to unfollow a cookbook', use_poltergeist: true do
     within '.cookbook_show_content' do
       follow_relation 'follow'
     end


### PR DESCRIPTION
:fork_and_knife: Currently the follow, unfollow actions redirect back. This causes a bug in Chrome where items in the history stack are duplicated causing the user to have to click back twice. This changes the follow, unfollow button to be a remote link with a ajax:success event bound to it that loads the current view and loads the follow, unfollow button from that into the dom without a page reload. This doesn't really save on page load as it's still rendering the entire view but it does fix the bug and provide a better user experience.
