### PR TITLE
Supported platform cleanup

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -178,10 +178,7 @@ class Cookbook < ActiveRecord::Base
       save!
 
       metadata.platforms.each do |name, version_constraint|
-        cookbook_version.supported_platforms.create!(
-          name: name,
-          version_constraint: version_constraint
-        )
+        cookbook_version.add_supported_platform(name, version_constraint)
       end
 
       metadata.dependencies.each do |name, version_constraint|

--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -1,7 +1,8 @@
 class CookbookVersion < ActiveRecord::Base
   # Associations
   # --------------------
-  has_many :supported_platforms, dependent: :destroy
+  has_many :cookbook_version_platforms
+  has_many :supported_platforms, through: :cookbook_version_platforms
   has_many :cookbook_dependencies, dependent: :destroy
   belongs_to :cookbook
 
@@ -55,6 +56,16 @@ class CookbookVersion < ActiveRecord::Base
   #
   def download_count
     web_download_count + api_download_count
+  end
+
+  # Create a link between a SupportedPlatform and a CookbookVersion
+  #
+  # @param name [String] platform name
+  # @param version [String] platform version
+  #
+  def add_supported_platform(name, version)
+    platform = SupportedPlatform.for_name_and_version(name, version)
+    CookbookVersionPlatform.create! supported_platform: platform, cookbook_version: self
   end
 
   private

--- a/app/models/cookbook_version_platform.rb
+++ b/app/models/cookbook_version_platform.rb
@@ -1,0 +1,11 @@
+class CookbookVersionPlatform < ActiveRecord::Base
+  # Associations
+  # --------------------
+  belongs_to :cookbook_version
+  belongs_to :supported_platform
+
+  # Validations
+  # --------------------
+  validates :cookbook_version, presence: true
+  validates :supported_platform, presence: true
+end

--- a/app/models/supported_platform.rb
+++ b/app/models/supported_platform.rb
@@ -3,11 +3,28 @@ require 'active_model/validations/chef_version_constraint_validator'
 class SupportedPlatform < ActiveRecord::Base
   # Associations
   # --------------------
-  belongs_to :cookbook_version
+  has_many :cookbook_version_platforms
+  has_many :cookbook_versions, through: :cookbook_version_platforms
 
   # Validations
   # --------------------
   validates :name, presence: true
-  validates :cookbook_version, presence: true
   validates :version_constraint, chef_version_constraint: true
+
+  #
+  # Creates or returns a SupportedPlatform, as necessary, given the name and
+  # version information.
+  #
+  # @param name [String] the platform name
+  # @param version [String] the version constraint
+  #
+  def self.for_name_and_version(name, version)
+    platform = where(name: name, version_constraint: version).first
+
+    if platform
+      platform
+    else
+      create! name: name, version_constraint: version
+    end
+  end
 end

--- a/db/migrate/20140603165708_create_cookbook_version_platforms.rb
+++ b/db/migrate/20140603165708_create_cookbook_version_platforms.rb
@@ -1,0 +1,11 @@
+class CreateCookbookVersionPlatforms < ActiveRecord::Migration
+  def change
+    create_table :cookbook_version_platforms do |t|
+      t.references :cookbook_version
+      t.references :supported_platform
+      t.timestamps
+    end
+
+    add_index :cookbook_version_platforms, [:cookbook_version_id, :supported_platform_id], unique: true, name: 'index_cvp_on_cvi_and_spi'
+  end
+end

--- a/db/migrate/20140603201106_make_cookbook_version_optional.rb
+++ b/db/migrate/20140603201106_make_cookbook_version_optional.rb
@@ -1,0 +1,9 @@
+class MakeCookbookVersionOptional < ActiveRecord::Migration
+  def up
+    change_column :supported_platforms, :cookbook_version_id, :integer, null: true
+  end
+
+  def down
+    change_column :supported_platforms, :cookbook_version_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -118,6 +118,15 @@ ActiveRecord::Schema.define(version: 20140603202553) do
   add_index "cookbook_followers", ["cookbook_id", "user_id"], name: "index_cookbook_followers_on_cookbook_id_and_user_id", unique: true, using: :btree
   add_index "cookbook_followers", ["legacy_id"], name: "index_cookbook_followers_on_legacy_id", unique: true, using: :btree
 
+  create_table "cookbook_version_platforms", force: true do |t|
+    t.integer  "cookbook_version_id"
+    t.integer  "supported_platform_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "cookbook_version_platforms", ["cookbook_version_id", "supported_platform_id"], name: "index_cvp_on_cvi_and_spi", unique: true, using: :btree
+
   create_table "cookbook_versions", force: true do |t|
     t.integer  "cookbook_id"
     t.string   "license"
@@ -249,7 +258,7 @@ ActiveRecord::Schema.define(version: 20140603202553) do
   create_table "supported_platforms", force: true do |t|
     t.string   "name",                                     null: false
     t.string   "version_constraint",  default: ">= 0.0.0", null: false
-    t.integer  "cookbook_version_id",                      null: false
+    t.integer  "cookbook_version_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "legacy_id"

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,15 @@
+namespace :cleanup do
+  task :supported_platforms => :environment do
+    platforms = SupportedPlatform.all.reduce([]) do |result, platform|
+      result << {name: platform.name, version: platform.version_constraint, cookbook_version_id: platform.cookbook_version_id}
+    end
+
+    SupportedPlatform.delete_all
+
+    platforms.each do |platform|
+      cookbook_version = CookbookVersion.find(platform[:cookbook_version_id])
+      supported_platform = SupportedPlatform.for_name_and_version(platform[:name], platform[:version])
+      CookbookVersionPlatform.create! supported_platform: supported_platform, cookbook_version: cookbook_version
+    end
+  end
+end

--- a/spec/factories/cookbook_version_platform.rb
+++ b/spec/factories/cookbook_version_platform.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :cookbook_version_platform do
+    association :cookbook_version
+    association :supported_platform
+  end
+end

--- a/spec/factories/supported_platform.rb
+++ b/spec/factories/supported_platform.rb
@@ -1,7 +1,5 @@
 FactoryGirl.define do
   factory :supported_platform do
-    association :cookbook_version
-
     name 'ubuntu'
     version_constraint '>= 12.04'
   end

--- a/spec/lib/tasks/cleanup_rake_spec.rb
+++ b/spec/lib/tasks/cleanup_rake_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'cleanup:supported_platforms' do
+  include_context 'rake'
+
+  let(:platforms) { %w(ubuntu centos rhel) }
+  let(:versions) { ['>= 5.0', '>= 6.0', '= 7.5'] }
+  let(:cookbook) { create(:cookbook) }
+
+  def fetch_randomly(sym)
+    ary = method(sym).call
+    ary[rand(ary.size)]
+  end
+
+  it 'should cleanup supported platforms' do
+    max_records = 100
+
+    1.upto(max_records) do |i|
+      cv = create(:cookbook_version, cookbook: cookbook)
+      create(:supported_platform, name: fetch_randomly(:platforms), version_constraint: fetch_randomly(:versions), cookbook_version_id: cv.id)
+    end
+
+    expect(SupportedPlatform.count).to eql(max_records)
+    distinct_platforms = SupportedPlatform.pluck(:name).uniq.size
+    distinct_versions = SupportedPlatform.pluck(:version_constraint).uniq.size
+
+    subject.invoke
+
+    expect(SupportedPlatform.count).to eql(distinct_platforms * distinct_versions)
+    expect(CookbookVersionPlatform.count).to eql(max_records)
+  end
+end

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -179,7 +179,6 @@ describe Cookbook do
     let(:cookbook) { create(:cookbook) }
     let(:tarball) { File.open('spec/support/cookbook_fixtures/redis-test-v1.tgz') }
     let(:readme) { CookbookUpload::Readme.new(contents: '', extension: '') }
-
     let(:metadata) do
       CookbookUpload::Metadata.new(
         license: 'MIT',

--- a/spec/models/cookbook_version_platform_spec.rb
+++ b/spec/models/cookbook_version_platform_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe CookbookVersionPlatform do
+  it { should validate_presence_of(:cookbook_version) }
+  it { should validate_presence_of(:supported_platform) }
+end

--- a/spec/models/supported_platform_spec.rb
+++ b/spec/models/supported_platform_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe SupportedPlatform do
   context 'validations' do
+    it { should validate_presence_of(:name) }
+
     it 'allows ">= 0.0.0" as a version constraint' do
       platform = SupportedPlatform.new(version_constraint: '>= 0.0.0')
 
@@ -26,6 +28,27 @@ describe SupportedPlatform do
 
       expect(platform.errors[:version_constraint]).
         to include('is not a valid Chef version constraint')
+    end
+  end
+
+  context '#for_name_and_version' do
+    let(:name) { 'ubuntu' }
+    let(:version) { '= 12.04' }
+
+    it 'should return a record when one exists' do
+      create(:supported_platform, name: name, version_constraint: version)
+      result = SupportedPlatform.for_name_and_version(name, version)
+      expect(result.name).to eql('ubuntu')
+      expect(result.version_constraint).to eql('= 12.04')
+    end
+
+    it 'should return a record when one does not exist' do
+      first = SupportedPlatform.where(name: name, version_constraint: version).first
+      expect(first).to be_nil
+      second = SupportedPlatform.for_name_and_version(name, version)
+      expect(second.persisted?).to be_true
+      expect(second.name).to eql('ubuntu')
+      expect(second.version_constraint).to eql('= 12.04')
     end
   end
 end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,19 @@
+require 'rake'
+
+shared_context 'rake' do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  subject         { rake[task_name] }
+
+  def loaded_files_excluding_current_rake_file
+    $LOADED_FEATURES.reject { |file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/views/api/v1/cookbook_versions/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbook_versions/show.json.jbuilder_spec.rb
@@ -19,7 +19,8 @@ describe 'api/v1/cookbook_versions/show' do
 
   before do
     create(:cookbook_dependency, cookbook_version: cookbook_version, cookbook: apt, name: 'apt', version_constraint: '>= 1.0.0')
-    create(:supported_platform, cookbook_version: cookbook_version, name: 'ubuntu', version_constraint: '= 12.04')
+    platform = create(:supported_platform, name: 'ubuntu', version_constraint: '= 12.04')
+    create(:cookbook_version_platform, cookbook_version: cookbook_version, supported_platform: platform)
 
     assign(:cookbook, cookbook)
     assign(:cookbook_version, cookbook_version)


### PR DESCRIPTION
:fork_and_knife: 

This introduces a new join model to connect `SupportedPlatform` and `CookbookVersion` and defines a rake task to go through and eliminate all the existing duplicates.

In a forthcoming PR, I'll be adding a unique constraint to the db and AR model to ensure `SupportedPlatform` is unique based on name and version, and removing the `cookbook_version_id` column from `SupportedPlatform`.
