### PR TITLE
Make cookbook following JS more explicit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require foundation.min
 //= require checkbox
 //= require cookbookShow
+//= require cookbookFollowing
 //= require betaBanner
 //= require expandContributors
 //= require flash

--- a/app/assets/javascripts/cookbookFollowing.js
+++ b/app/assets/javascripts/cookbookFollowing.js
@@ -1,0 +1,32 @@
+$(function() {
+  /*
+   * Adds a disabled class when the user clicks a follow or unfollow button
+   * so they know a request is in progress and they don't click follow or unfollow
+   * twice.
+   */
+  $('a[rel~="follow"], a[rel~="unfollow"]').on('click', function() {
+    $(this).addClass('disabled');
+  });
+
+  /*
+   * Binds an ajax:success event to the cookbook partial follow button and replaces
+   * the partial in question with server side rendered HTML.
+   */
+  $('body').delegate('.cookbook_partial .follow', 'ajax:success', function(e, data, status, xhr) {
+    var cookbookId = '#' + $(this).data('cookbook');
+
+    $.get(window.location.href, function(response) {
+      $(cookbookId).replaceWith($(response).find(cookbookId));
+    }, 'html');
+  });
+
+  /*
+   * Binds an ajax:success event to the cookbook show follow button and replaces
+   * the followbutton which includes the follow count with server side rendred HTML.
+   */
+  $('body').delegate('.cookbook_show .follow', 'ajax:success', function(e, data, status, xhr) {
+    $.get(window.location.href, function(response) {
+      $('.followbutton').replaceWith($(response).find('.followbutton'));
+    }, 'html');
+  });
+});

--- a/app/assets/javascripts/cookbookShow.js
+++ b/app/assets/javascripts/cookbookShow.js
@@ -9,12 +9,4 @@ $(function() {
   $('a[rel~="remove-cookbook-collaborator"]').on('ajax:success', function(e, data, status, xhr) {
     $(this).parents('.gravatar-container').remove();
   });
-
-  $('a[rel~="follow"], a[rel~="unfollow"]').on('click', function() {
-    $(this).addClass('disabled');
-  });
-
-  $('body').delegate('a[rel~="follow"], a[rel~="unfollow"]', 'ajax:success', function(e, data, status, xhr) {
-    $(this).parent().load(window.location.href + ' a[data-cookbook="' + $(this).data('cookbook') + '"]');
-  });
 });

--- a/app/views/cookbooks/_cookbook.html.erb
+++ b/app/views/cookbooks/_cookbook.html.erb
@@ -1,4 +1,4 @@
-<li>
+<li id="<%= cookbook.name %>" class="cookbook_partial">
   <div class="cookbook_header">
     <div class="cookbook_partial_content_header">
       <h2 class="cookbook_title">

--- a/spec/features/cookbook_following_spec.rb
+++ b/spec/features/cookbook_following_spec.rb
@@ -3,34 +3,48 @@ require 'spec_feature_helper'
 describe 'cookbook following' do
   before do
     sign_in(create(:user))
-    owner = create(:user)
-    cookbook = create(:cookbook, owner: owner)
+    cookbook = create_list(:cookbook, 2)
+  end
 
-    visit '/'
-    follow_relation 'cookbooks'
+  context 'from the cookbook partial' do
+    before do
+      visit '/cookbooks'
+      follow_first_relation 'follow'
+    end
 
-    within '.recently-updated' do
-      follow_relation 'cookbook'
+    it 'allows a user to follow a cookbook', use_poltergeist: true do
+      expect(page).to have_xpath("//a[starts-with(@rel, 'unfollow')]")
     end
   end
 
-  it 'allows a user to follow a cookbook', use_poltergeist: true do
-    within '.cookbook_show_content' do
-      follow_relation 'follow'
+  context 'from the cookbook show view' do
+    before do
+      visit '/'
+      follow_relation 'cookbooks'
+
+      within '.recently-updated' do
+        follow_first_relation 'cookbook'
+      end
     end
 
-    expect(page).to have_xpath("//a[starts-with(@rel, 'unfollow')]")
-  end
+    it 'allows a user to follow a cookbook', use_poltergeist: true do
+      within '.cookbook_show_content' do
+        follow_relation 'follow'
+      end
 
-  it 'allows a user to unfollow a cookbook', use_poltergeist: true do
-    within '.cookbook_show_content' do
-      follow_relation 'follow'
+      expect(page).to have_xpath("//a[starts-with(@rel, 'unfollow')]")
     end
 
-    within '.cookbook_show_content' do
-      follow_relation 'unfollow'
-    end
+    it 'allows a user to unfollow a cookbook', use_poltergeist: true  do
+      within '.cookbook_show_content' do
+        follow_relation 'follow'
+      end
 
-    expect(page).to have_xpath("//a[starts-with(@rel, 'follow')]")
+      within '.cookbook_show_content' do
+        follow_relation 'unfollow'
+      end
+
+      expect(page).to have_xpath("//a[starts-with(@rel, 'follow')]")
+    end
   end
 end


### PR DESCRIPTION
:fork_and_knife: Since the markup for the follow buttons is a bit different between the cookbook show and the cookbook partial this separates the JS functionality for updating the dom elements that should be updated after a successful follow/unfollow. This also adds an additional feature spec to test the follow button in the cookbook partial context.
