### PR TITLE
Update order of user nav to be user links first.

### DIFF
--- a/app/views/application/_appheader.html.erb
+++ b/app/views/application/_appheader.html.erb
@@ -12,13 +12,14 @@
       <%= gravatar_for current_user, size: 80 %>
       <%= current_user.username %> <i class="fa fa-caret-down"></i>
       <ul class="userdropdown">
+        <li><%= link_to 'View Profile', current_user, class: 'fa fa-user', rel: 'view_profile' %></li>
+        <li><%= link_to 'Manage Profile', edit_profile_path, class: 'fa fa-cog', rel: 'manage_profile' %></li>
+
         <% unless current_user.signed_icla? %>
           <li><%= link_to 'Sign ICLA', new_icla_signature_path, class: 'fa fa-file-text', rel: 'sign_icla' %></li>
         <% end %>
 
         <li><%= link_to 'Sign CCLA', new_ccla_signature_path, class: 'fa fa-file-text', rel: 'sign_ccla' %></li>
-        <li><%= link_to 'View Profile', current_user, class: 'fa fa-user', rel: 'view_profile' %></li>
-        <li><%= link_to 'Manage Profile', edit_profile_path, class: 'fa fa-cog', rel: 'manage_profile' %></li>
 
         <% if current_user && current_user.is?(:admin) %>
           <li>


### PR DESCRIPTION
:fork_and_knife: 

The links to view and manage the signed in user's profile seem a little more
important than those for signing a CLA. This is my proposal to move them above
the CLA links in the user nav.

How it looks now:

![screen shot 2014-06-09 at 7 48 26 am](https://cloud.githubusercontent.com/assets/928367/3216192/041bf206-efcc-11e3-8046-db87cab38327.png)
