### PR TITLE
Store supported platform legacy IDs on the platform join table

### DIFF
--- a/db/migrate/20140609130418_track_supported_platform_legacy_id_on_join.rb
+++ b/db/migrate/20140609130418_track_supported_platform_legacy_id_on_join.rb
@@ -1,0 +1,8 @@
+class TrackSupportedPlatformLegacyIdOnJoin < ActiveRecord::Migration
+  def change
+    remove_index :supported_platforms, column: :legacy_id, unique: true
+    remove_column :supported_platforms, :legacy_id, :integer
+    add_column :cookbook_version_platforms, :legacy_id, :integer
+    add_index :cookbook_version_platforms, :legacy_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140604195117) do
+ActiveRecord::Schema.define(version: 20140609130418) do
 
   create_table "accounts", force: true do |t|
     t.integer  "user_id"
@@ -123,9 +123,11 @@ ActiveRecord::Schema.define(version: 20140604195117) do
     t.integer  "supported_platform_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "legacy_id"
   end
 
   add_index "cookbook_version_platforms", ["cookbook_version_id", "supported_platform_id"], name: "index_cvp_on_cvi_and_spi", unique: true, using: :btree
+  add_index "cookbook_version_platforms", ["legacy_id"], name: "index_cookbook_version_platforms_on_legacy_id", unique: true, using: :btree
 
   create_table "cookbook_versions", force: true do |t|
     t.integer  "cookbook_id"
@@ -260,10 +262,8 @@ ActiveRecord::Schema.define(version: 20140604195117) do
     t.string   "version_constraint", default: ">= 0.0.0", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "legacy_id"
   end
 
-  add_index "supported_platforms", ["legacy_id"], name: "index_supported_platforms_on_legacy_id", unique: true, using: :btree
   add_index "supported_platforms", ["name", "version_constraint"], name: "index_supported_platforms_on_name_and_version_constraint", unique: true, using: :btree
 
   create_table "users", force: true do |t|


### PR DESCRIPTION
:fork_and_knife: 

This supports a forthcoming change to the chef-legacy project to import `SupportedPlatform` records in their newly-normalized form.
