### PR TITLE
Remove categories from cookbooks index

### DIFF
--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -4,14 +4,12 @@ class CookbooksController < ApplicationController
   before_filter :store_location_then_authenticate_user!, only: [:follow, :unfollow]
 
   #
-  # GET /cookbooks(/categories/:category)
+  # GET /cookbooks
   #
   # Return all cookbooks. Cookbooks are sorted alphabetically by name.
   # Optionally a category can be specified to return only cookbooks for a
   # given category. Cookbooks can also be returned as an atom feed if the atom
   # format is specified.
-  #
-  # Pass in a query param to search for specific cookbooks
   #
   # @example
   #   GET /cookbooks?q=redis
@@ -22,15 +20,7 @@ class CookbooksController < ApplicationController
   #   GET /cookbooks?order=recently_updated
   #
   def index
-    if params[:category]
-      @cookbooks = Cookbook.
-        includes(:cookbook_versions).
-        joins(:category).
-        where('categories.slug = ?', params[:category])
-    else
-      @cookbooks = Cookbook.includes(:cookbook_versions)
-    end
-
+    @cookbooks = Cookbook.includes(:cookbook_versions)
     @cookbooks = @cookbooks.ordered_by(params[:order])
 
     if params[:q]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,6 @@ Supermarket::Application.routes.draw do
   end
 
   get 'cookbooks/directory' => 'cookbooks#directory'
-  get 'cookbooks(/categories/:category)' => 'cookbooks#index', as: :cookbooks_category
-  get 'cookbooks/categories', to: redirect('/cookbooks')
 
   resources :cookbooks, only: [:index, :show, :update] do
     resources :collaborators, only: [:index, :new, :create, :destroy] do

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -14,11 +14,6 @@ describe CookbooksController do
 
         expect(assigns[:cookbooks].count).to eql(20)
       end
-
-      it 'assigns @categories' do
-        get :index
-        expect(assigns[:categories]).to_not be_nil
-      end
     end
 
     context 'there is an order parameter' do
@@ -69,18 +64,6 @@ describe CookbooksController do
       it 'correctly orders @cookbooks when also searching' do
         get :index, order: 'most_followed', q: 'mysql'
         expect(assigns[:cookbooks].first).to eql(cookbook_1)
-      end
-    end
-
-    context 'there is a category parameter' do
-      let!(:databases_cookbook) { create(:cookbook, category: create(:category, name: 'Databases')) }
-      let!(:other_cookbook) { create(:cookbook, category: create(:category, name: 'Other')) }
-
-      it 'only returns @cookbooks with the specified category' do
-        get :index, category: 'other'
-
-        expect(assigns[:cookbooks]).to include(other_cookbook)
-        expect(assigns[:cookbooks]).to_not include(databases_cookbook)
       end
     end
 


### PR DESCRIPTION
:fork_and_knife: Since we're no longer exposing cookbook categories in the cookbooks index UI there is no need to allow the cookbooks index to allow only certain categories to be returned.
