### PR TITLE
Allow cookbook sorting through the API

### DIFF
--- a/app/controllers/api/v1/cookbooks_controller.rb
+++ b/app/controllers/api/v1/cookbooks_controller.rb
@@ -9,14 +9,17 @@ class Api::V1::CookbooksController < Api::V1Controller
   # returned is 100.
   #
   # Pass in the start and items params to specify the index at which to start
-  # and how many to return.
+  # and how many to return. You can also pass in an order param to specify how
+  # you'd like the the collection ordered. Possible values are
+  # recently_updated, recently_added, most_downloaded, most_followed
   #
   # @example
   #   GET /api/v1/cookbooks?start=5&items=15
+  #   GET /api/v1/cookbooks?order=recently_updated
   #
   def index
     @total = Cookbook.count
-    @cookbooks = Cookbook.order('name ASC').limit(@items).offset(@start)
+    @cookbooks = Cookbook.ordered_by(@order).limit(@items).offset(@start)
   end
 
   #
@@ -66,5 +69,6 @@ class Api::V1::CookbooksController < Api::V1Controller
   def init_params
     @start = params.fetch(:start, 0).to_i
     @items = [params.fetch(:items, 10).to_i, 100].min
+    @order = params.fetch(:order, 'name ASC').to_s
   end
 end

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -25,7 +25,7 @@ class Cookbook < ActiveRecord::Base
   scope :ordered_by, lambda { |ordering|
     order({
       'recently_updated' => 'updated_at DESC',
-      'recently_added' => 'created_at DESC',
+      'recently_added' => 'id DESC',
       'most_downloaded' => '(web_download_count + api_download_count) DESC',
       'most_followed' => 'cookbook_followers_count DESC'
     }.fetch(ordering, 'name ASC'))

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -21,8 +21,6 @@ describe CookbooksController do
         create(
           :cookbook,
           name: 'mysql',
-          updated_at: 1.year.ago,
-          created_at: 1.year.ago,
           web_download_count: 1,
           api_download_count: 100,
           cookbook_followers_count: 100
@@ -33,8 +31,6 @@ describe CookbooksController do
         create(
           :cookbook,
           name: 'mysql-admin-tools',
-          updated_at: 1.day.ago,
-          created_at: 2.years.ago,
           web_download_count: 1,
           api_download_count: 50,
           cookbook_followers_count: 50
@@ -42,13 +38,14 @@ describe CookbooksController do
       end
 
       it 'orders @cookbooks by updated at' do
+        cookbook_2.touch
         get :index, order: 'recently_updated'
         expect(assigns[:cookbooks].first).to eql(cookbook_2)
       end
 
-      it 'orders @cookbooks by created at' do
+      it 'orders @cookbooks with the most recently created first' do
         get :index, order: 'recently_added'
-        expect(assigns[:cookbooks].first).to eql(cookbook_1)
+        expect(assigns[:cookbooks].first).to eql(cookbook_2)
       end
 
       it 'orders @cookbooks by their download count' do


### PR DESCRIPTION
:fork_and_knife: 

https://trello.com/c/3vXSlw3T/179-support-optional-order-parameter-at-api-v1-cookbooks
