### PR TITLE
Allow admins to make other users admins

### DIFF
--- a/app/assets/stylesheets/users/show.scss
+++ b/app/assets/stylesheets/users/show.scss
@@ -97,6 +97,10 @@
     margin-bottom: rem-calc(20);
   }
 
+  .button {
+    margin-bottom: rem-calc(20);
+  }
+
   .user_stats {
     @include block-grid(3, $spacing: 0);
     border: rem-calc(1) solid lighten($secondary_gray, 30%);

--- a/app/authorizers/user_authorizer.rb
+++ b/app/authorizers/user_authorizer.rb
@@ -1,0 +1,10 @@
+require 'authorizer/base'
+
+class UserAuthorizer < Authorizer::Base
+  #
+  # Admins can make other non admin users admins.
+  #
+  def make_admin?
+    user.is?(:admin) && !record.is?(:admin)
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_filter :assign_user
+
   #
   # GET /users/:id
   #
@@ -8,8 +10,6 @@ class UsersController < ApplicationController
   # the user owns.
   #
   def show
-    @user = Account.for('chef_oauth2').with_username(params[:id]).first!.user
-
     case params[:tab]
     when 'collaborates'
       @cookbooks = @user.collaborated_cookbooks
@@ -18,5 +18,23 @@ class UsersController < ApplicationController
     else
       @cookbooks = @user.owned_cookbooks
     end
+  end
+
+  #
+  # PUT /users/:id/make_admin
+  #
+  # Assigns the admin role to a given user then redirects back to
+  # the users profile.
+  #
+  def make_admin
+    authorize! @user
+    @user.update_attributes(roles: 'admin')
+    redirect_to @user, notice: t('user.made_admin', name: @user.username)
+  end
+
+  private
+
+  def assign_user
+    @user = Account.for('chef_oauth2').with_username(params[:id]).first!.user
   end
 end

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -44,6 +44,12 @@
     <li><h3><%= pluralized_stats(@user.followed_cookbooks.count, 'Follow') %></h3></li>
   </ul>
 
+  <% if policy(@user).make_admin? %>
+    <%= link_to 'Make Admin', make_admin_user_path(@user), method: 'put', class: 'button medium expand radius', rel: 'make_admin' %>
+  <% elsif current_user.try(:is?, :admin) %>
+    <button class="button medium expand radius secondary disabled">Admin</button>
+  <% end %>
+
   <% if @user == current_user %>
     <% if params[:controller] == "profile" %>
       <%= link_to 'View Profile', @user, class: 'button medium expand radius', rel: 'view_profile' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
     signed_in:  "Welcome back %{name}!"
     signed_out: "Goodbye"
     must_be_signed_in: "You must be signed in to do that."
+    made_admin: "%{name} is now an admin."
   profile:
     no_cookbooks:
       owns: "%{username} doesn't own any cookbooks."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,10 @@ Supermarket::Application.routes.draw do
   end
 
   resources :users, only: [:show] do
+    member do
+      put :make_admin
+    end
+
     resources :accounts, only: [:destroy]
   end
 

--- a/spec/authorizers/user_authorizer_spec.rb
+++ b/spec/authorizers/user_authorizer_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe UserAuthorizer do
+  let(:record) { build(:user) }
+
+  context 'as an admin user' do
+    let(:user) { build(:user, roles: 'admin') }
+    subject { described_class.new(user, record) }
+
+    it { should permit_authorization(:make_admin) }
+  end
+
+  context 'as an admin user acting on another admin user' do
+    let(:user) { build(:user, roles: 'admin') }
+    let(:record) { build(:user, roles: 'admin') }
+    subject { described_class.new(user, record) }
+
+    it { should_not permit_authorization(:make_admin) }
+  end
+
+  context 'as a non admin user' do
+    let(:user) { build(:user) }
+    subject { described_class.new(user, record) }
+
+    it { should_not permit_authorization(:make_admin) }
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -24,4 +24,32 @@ describe UsersController do
       expect(assigns[:cookbooks]).to include(followed_cookbook)
     end
   end
+
+  describe 'PUT #make_admin' do
+    let(:user) { create(:user) }
+
+    context 'the current user is an admin' do
+      before { sign_in(create(:user, roles: 'admin')) }
+
+      it 'adds the admin role to a user' do
+        put :make_admin, id: user
+        user.reload
+        expect(user.roles).to include('admin')
+      end
+
+      it 'redirects back to a user' do
+        put :make_admin, id: user
+        expect(response).to redirect_to(assigns[:user])
+      end
+    end
+
+    context 'the current user is not an admin' do
+      before { sign_in(create(:user)) }
+
+      it 'renders 404' do
+        put :make_admin, id: user
+        expect(response.status.to_i).to eql(404)
+      end
+    end
+  end
 end

--- a/spec/features/admin_grants_admin_role_spec.rb
+++ b/spec/features/admin_grants_admin_role_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_feature_helper'
+
+feature 'admin grants another user admin role' do
+  let(:user) { create(:user) }
+  let(:admin) { create(:admin) }
+
+  before do
+    sign_in(admin)
+    visit user_path(user)
+    follow_relation 'make_admin'
+  end
+
+  it 'displays a success message' do
+    expect_to_see_success_message
+  end
+
+  it 'indicates that the user is now an admin' do
+    expect(page).to have_content('Admin')
+  end
+end


### PR DESCRIPTION
:fork_and_knife: Admin users can now navigate to a users profile (via the URL) and make another user an admin. Once the user is an admin they are indicated as such with (Admin) next to their username on their profile.
