### PR TITLE
Disconnect from the community site on fork, reconnect after

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'sass-rails',   '~> 4.0.1'
 gem 'compass-rails'
 gem 'uglifier',     '~> 2.2'
 
-gem 'chef-legacy', github: 'gofullstack/chef-legacy', ref: 'v1.0.0'
+gem 'chef-legacy', github: 'gofullstack/chef-legacy', ref: 'v1.1.0'
 
 group :doc do
   gem 'yard', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/gofullstack/chef-legacy.git
-  revision: a2f7c3158883b4d1a7b2642da316590e435c6803
-  ref: v1.0.0
+  revision: dbfc20cc525cb017ba45609e45a22519afdf9367
+  ref: v1.1.0
   specs:
     chef-legacy (1.0.0)
       connection_pool

--- a/config/unicorn/development.rb
+++ b/config/unicorn/development.rb
@@ -10,6 +10,9 @@ before_fork do |server, worker|
 
   defined?(ActiveRecord::Base) &&
     ActiveRecord::Base.connection.disconnect!
+
+  defined?(Supermarket::CommunitySite) &&
+    Supermarket::CommunitySite.disconnect!
 end
 
 after_fork do |server, worker|
@@ -23,4 +26,7 @@ after_fork do |server, worker|
 
   defined?(ActiveRecord::Base) &&
     ActiveRecord::Base.establish_connection
+
+  defined?(Supermarket::CommunitySite) &&
+    Supermarket::CommunitySite.connect!
 end

--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -12,6 +12,9 @@ before_fork do |server, worker|
 
   defined?(ActiveRecord::Base) &&
     ActiveRecord::Base.connection.disconnect!
+
+  defined?(Supermarket::CommunitySite) &&
+    Supermarket::CommunitySite.disconnect!
 end
 
 after_fork do |server, worker|
@@ -25,4 +28,7 @@ after_fork do |server, worker|
 
   defined?(ActiveRecord::Base) &&
     ActiveRecord::Base.establish_connection
+
+  defined?(Supermarket::CommunitySite) &&
+    Supermarket::CommunitySite.connect!
 end


### PR DESCRIPTION
:fork_and_knife:

This uses the new methods in chef-legacy to disconnect any open connections to the community site on fork, and to rebuild the connection pool after fork.
