### PR TITLE
Bump chef-legacy to 1.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'sass-rails',   '~> 4.0.1'
 gem 'compass-rails'
 gem 'uglifier',     '~> 2.2'
 
-gem 'chef-legacy', github: 'gofullstack/chef-legacy', ref: 'v1.1.0'
+gem 'chef-legacy', github: 'gofullstack/chef-legacy', ref: 'v1.1.1'
 
 group :doc do
   gem 'yard', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/gofullstack/chef-legacy.git
-  revision: dbfc20cc525cb017ba45609e45a22519afdf9367
-  ref: v1.1.0
+  revision: 322de4b7071ffc488b3b7abb84306134a213c4de
+  ref: v1.1.1
   specs:
     chef-legacy (1.0.0)
       connection_pool


### PR DESCRIPTION
:fork_and_knife: 

This bundles a release of chef-legacy which has a bugfix and better reporting when a CookbookVersion cannot be imported due to its `tarball_content_type`.
