### PR TITLE
Order and paginate profile cookbooks

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,8 @@ class UsersController < ApplicationController
     else
       @cookbooks = @user.owned_cookbooks
     end
+
+    @cookbooks = @cookbooks.order(:name).page(params[:page]).per(20)
   end
 
   #

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,6 +18,7 @@
     <% if @cookbooks.any? %>
       <ul class="cookbook_listing">
         <%= render partial: 'cookbooks/cookbook', collection: @cookbooks %>
+        <%= paginate @cookbooks %>
       </ul>
     <% else %>
       <% if @user == current_user %>


### PR DESCRIPTION
:fork_and_knife: Cookbooks on user profiles should be ordered ascending by name. Also some users do have quite a few cookbooks listing all of them at once causes some performance issues so this also adds pagination limited to 20 per page. Closes #444.
