### PR TITLE
Make purpose of CCLA more clear

### DIFF
--- a/app/views/ccla_signatures/new.html.erb
+++ b/app/views/ccla_signatures/new.html.erb
@@ -5,7 +5,7 @@
     <h1>Corporate Contributor License Agreement <small>(CCLA)</small></h1>
 
     <p>
-      You have been asked to sign an CCLA as part of the <%= link_to 'Community Contribution process', 'http://docs.opscode.com/community_contributions.html', target: :blank %>. Please read the document below and complete the form to file your CCLA you may also view a printable copy <%= link_to 'here', agreement_ccla_signatures_path, target: 'blank' %>.
+      The Corporate CLA allows a company to complete a single Contributor License Agreement and include multiple employees on it. This should be completed by a representative of the company who is authorized to sign agreements related to copyright and patents only. You can view a printable copy of the CCLA <%= link_to 'here', agreement_ccla_signatures_path, target: 'blank' %>.
     </p>
 
     <div class="signature">


### PR DESCRIPTION
:fork_and_knife: It should be clear that the CCLA is to be signed by a single person at an organization, someone with legal authority to do so. For more context surrounding this change see #447.
