### PR TITLE
Remove download count from all applicable views.

### DIFF
--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -56,7 +56,6 @@ class CookbooksController < ApplicationController
       limit(5)
 
     @cookbook_count = Cookbook.count
-    @download_count = Cookbook.total_download_count
     @user_count = User.count
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,7 +12,6 @@ class PagesController < ApplicationController
 
     @recently_updated_count = Cookbook.recently_updated.count
     @cookbook_count = Cookbook.count
-    @download_count = Cookbook.total_download_count
     @user_count = User.count
   end
 

--- a/app/views/cookbooks/directory.html.erb
+++ b/app/views/cookbooks/directory.html.erb
@@ -4,7 +4,6 @@
 <div class="page nobg">
   <section class="cookbooks_stats">
     <span class="stat"><span class="number"><%= number_with_delimiter @cookbook_count, delimiter: ',' %></span> Cookbooks</span>
-    <span class="stat"><span class="number"><%= number_with_delimiter @download_count, delimiter: ',' %></span> Downloads</span>
     <span class="stat"><span class="number"><%= number_with_delimiter @user_count, delimiter: ',' %></span> Chefs</span>
   </section>
 

--- a/app/views/pages/welcome.html.erb
+++ b/app/views/pages/welcome.html.erb
@@ -62,6 +62,5 @@
 <section class="cookbooks_stats">
   <h2>Community Stats</h3>
   <span class="stat"><span class="number"><%= number_with_delimiter @cookbook_count, delimiter: ',' %></span> Cookbooks</span>
-  <span class="stat"><span class="number"><%= number_with_delimiter @download_count, delimiter: ',' %></span> Downloads</span>
   <span class="stat"><span class="number"><%= number_with_delimiter @user_count, delimiter: ',' %></span> Chefs</span>
 </section>

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -154,10 +154,6 @@ describe CookbooksController do
       expect(assigns[:cookbook_count]).to_not be_nil
     end
 
-    it 'sends download count to the view' do
-      expect(assigns[:download_count]).to_not be_nil
-    end
-
     it 'sends user count to the view' do
       expect(assigns[:user_count]).to_not be_nil
     end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -23,12 +23,6 @@ describe PagesController do
         expect(assigns[:cookbook_count]).to_not be_nil
       end
 
-      it 'sends download count to the view' do
-        get :welcome
-
-        expect(assigns[:download_count]).to_not be_nil
-      end
-
       it 'sends user count to the view' do
         get :welcome
 


### PR DESCRIPTION
:fork_and_knife: 

The Downloads stat for cookbooks is underreported and does not represent the
actual number of downloads of cookbooks over all time. Better to remove it than
have something inaccurate. This commit removes it from the Cookbooks Directory
and the Welcome page.

Trello card for this: https://trello.com/c/16EAkdj7
