### PR TITLE
Improve cookbook search

### DIFF
--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -21,10 +21,13 @@ class CookbooksController < ApplicationController
   #
   def index
     @cookbooks = Cookbook.includes(:cookbook_versions)
-    @cookbooks = @cookbooks.ordered_by(params[:order])
 
     if params[:q]
       @cookbooks = @cookbooks.search(params[:q])
+    end
+
+    if params[:order]
+      @cookbooks = @cookbooks.ordered_by(params[:order])
     end
 
     @number_of_cookbooks = @cookbooks.count(:all)

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -23,7 +23,7 @@ class Cookbook < ActiveRecord::Base
   scope :recently_updated, -> { where('updated_at > ?', Time.now - 2.weeks) }
 
   scope :ordered_by, lambda { |ordering|
-    order({
+    reorder({
       'recently_updated' => 'updated_at DESC',
       'recently_added' => 'id DESC',
       'most_downloaded' => '(web_download_count + api_download_count) DESC',
@@ -43,12 +43,12 @@ class Cookbook < ActiveRecord::Base
       name: 'A'
     },
     associated_against: {
-      category: :name,
-      cookbook_versions: :description,
-      chef_account: :username
+      cookbook_versions: { description: 'C' },
+      chef_account: { username: 'B' }
     },
     using: {
-      tsearch: { prefix: true, dictionary: 'english' }
+      tsearch: { dictionary: 'english' },
+      trigram: { threshold: 0.05 }
     }
   )
 

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -221,13 +221,13 @@ describe Cookbook do
         :cookbook,
         name: 'redis',
         category: create(:category, name: 'datastore'),
+        owner: create(:user, chef_account: create(:account, provider: 'chef_oauth2', username: 'johndoe')),
         cookbook_versions: [
           create(
             :cookbook_version,
             description: 'Redis: a fast, flexible datastore offering an extremely useful set of data structure primitives'
           )
-        ],
-        cookbook_versions_count: 0
+        ]
       )
     end
 
@@ -236,10 +236,11 @@ describe Cookbook do
         :cookbook,
         name: 'redisio',
         category: create(:category, name: 'datastore'),
+        owner: create(:user, chef_account: create(:account, provider: 'chef_oauth2', username: 'fanny')),
         cookbook_versions: [
           create(
             :cookbook_version,
-            description: 'Installs/Configures redis'
+            description: 'Installs/Configures redis. Created by the formidable johndoe, johndoe is pretty awesome.'
           )
         ],
         cookbook_versions_count: 0
@@ -251,19 +252,24 @@ describe Cookbook do
       expect(Cookbook.search('redis')).to include(redisio)
     end
 
+    it 'returns cookbooks with a similar description' do
+      expect(Cookbook.search('fast')).to include(redis)
+      expect(Cookbook.search('fast')).to_not include(redisio)
+    end
+
     it 'returns cookbooks with a similar maintainer' do
       expect(Cookbook.search('johndoe')).to include(redisio)
       expect(Cookbook.search('janesmith')).to_not include(redisio)
     end
 
-    it 'returns cookbooks with a similar category' do
-      expect(Cookbook.search('datastore')).to include(redisio)
-      expect(Cookbook.search('datastore')).to include(redis)
+    it 'weights cookbook name over cookbook description' do
+      expect(Cookbook.search('redis')[0]).to eql(redis)
+      expect(Cookbook.search('redis')[1]).to eql(redisio)
     end
 
-    it 'returns cookbooks with a similar description' do
-      expect(Cookbook.search('fast')).to include(redis)
-      expect(Cookbook.search('fast')).to_not include(redisio)
+    it 'weights cookbook maintainer over cookbook description' do
+      expect(Cookbook.search('johndoe')[0]).to eql(redis)
+      expect(Cookbook.search('johndoe')[1]).to eql(redisio)
     end
   end
 


### PR DESCRIPTION
:fork_and_knife: To provide better search results based on name this weights cookbook name over cookbook description. Since there are also a lot of cookbooks with similar names (redis, redisio, redis-test etc.) this also takes into account follower count to surface the more common cookbooks to the top of results. Presumably we'll need to continue to tweak search as we discover use cases from the user base but this is a step in the right direction.
