### PR TITLE
Add application/postscript to the list of valid tarball content types

### DIFF
--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -27,7 +27,8 @@ class CookbookVersion < ActiveRecord::Base
                      'application/x-compressed', 'application/download',
                      'application/x-gtar-compressed', 'application/zip',
                      'application/x-bzip', 'application/x-zip-compressed',
-                     'application/cap', 'application/x-tar-gz']
+                     'application/cap', 'application/x-tar-gz',
+                     'application/postscript']
     }
   )
 


### PR DESCRIPTION
:fork_and_knife:

This is required in order to migrate a small number of cookbooks from the Opscode Community Site.
