### PR TITLE
Enable markdown table rendering, improve docs

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,19 +1,28 @@
 module MarkdownHelper
+  #
   # Make auto-links target=_blank
+  #
   class TargetBlankRenderer < Redcarpet::Render::HTML
     def initialize(extensions = {})
       super extensions.merge(link_attributes: { target: '_blank' })
     end
   end
 
-  # Render markdown
+  #
+  # Renders markdown as escaped HTML.
+  #
+  # @param text [String] markdown to be rendered
+  #
+  # @return [String] escaped HTML.
+  #
   def render_markdown(text)
     Redcarpet::Markdown.new(
       TargetBlankRenderer,
       autolink: true,
-      fenced_code_blocks: true
+      fenced_code_blocks: true,
+      tables: true
     ).render(
-      text.to_s
+      text
     ).html_safe
   end
 end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -21,4 +21,15 @@ $ bundle exec rake spec:all
         to match(Regexp.quote('<a href="http://getchef.com" target="_blank">http://getchef.com</a>'))
     end
   end
+
+  it 'renders tables' do
+    table = <<-EOH
+| name | version |
+| ---- | ------- |
+| apt  | 0.25    |
+| yum  | 0.75    |
+    EOH
+
+    expect(helper.render_markdown(table)).to match(/<table>/)
+  end
 end


### PR DESCRIPTION
:fork_and_knife: Enable Redcarpet markdown table rendering in the MarkdownHelper. Also improve the docs for MarkdownHelper and don't do unnecessary type coercion as render_markdown method should only accept a String.
