### PR TITLE
Update chef-legacy to 1.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'sass-rails',   '~> 4.0.1'
 gem 'compass-rails'
 gem 'uglifier',     '~> 2.2'
 
-gem 'chef-legacy', github: 'gofullstack/chef-legacy', ref: 'v1.2.0'
+gem 'chef-legacy', github: 'gofullstack/chef-legacy', ref: 'v1.3.0'
 
 group :doc do
   gem 'yard', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/gofullstack/chef-legacy.git
-  revision: 5aedd00acc4ed1615c145d4aa411edf14de3db6a
-  ref: v1.2.0
+  revision: 3a27451f99f06b93b178b10e660e0b65f4dbfa99
+  ref: v1.3.0
   specs:
     chef-legacy (1.0.0)
       connection_pool


### PR DESCRIPTION
:fork_and_knife:

After updating, the ongoing data migration will not process tarballs which appear to be invalid, and will report the errors it finds to Sentry.
