### PR TITLE
Improve search results responsiveness

### DIFF
--- a/app/assets/stylesheets/cookbooks/cookbook.scss
+++ b/app/assets/stylesheets/cookbooks/cookbook.scss
@@ -307,7 +307,13 @@
     .fa {
       @include inline-block;
       font-size: rem-calc(16);
-      margin: rem-calc(-2 8 0 16);
+      margin: rem-calc(-2 8 0 10);
+    }
+
+    @media #{$mobile-only} {
+      .fa {
+        margin: rem-calc(-2 4 0 0);
+      }
     }
 
     h5 {
@@ -319,6 +325,18 @@
       text-transform: none;
       display: inline;
       margin: 0;
+    }
+  }
+
+  @media #{$mobile-only} {
+    li {
+      margin: rem-calc(0 10 0 0);
+    }
+  }
+
+  @media #{$mobile-only} {
+    .follow {
+      padding: rem-calc(8);
     }
   }
 }

--- a/app/assets/stylesheets/cookbooks/search.scss
+++ b/app/assets/stylesheets/cookbooks/search.scss
@@ -195,4 +195,18 @@ input[type="search"].cookbook_search_textfield {
       }
     }
   }
+
+  @media #{$mobile-only} {
+    a.button {
+      @include inline-block;
+      width: 100%;
+      margin-bottom: rem-calc(5);
+    }
+  }
+}
+
+@media #{$mobile-only} {
+  .order_cookbooks_by {
+    padding: 0;
+  }
 }


### PR DESCRIPTION
:fork_and_knife: Follow button no longer wraps on mobile displays. Make sort buttons 100% width on smaller displays.

![screen shot 2014-06-18 at 11 45 23 am](https://cloud.githubusercontent.com/assets/316507/3316148/c9361a6e-f6ff-11e3-9a18-9fb252d1d9e6.png)
