### PR TITLE
Load either .env or .env.production on boot

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,10 +2,10 @@ require File.expand_path('../boot', __FILE__)
 
 require 'dotenv'
 
-begin
-  Dotenv.load!('.env')
-rescue Errno::ENOENT
-  fail 'Cannot run Supermarket without a .env file. To get started, `cp .env.example .env`'
+Dotenv.load('.env', '.env.production').tap do |env|
+  if env.empty?
+    fail 'Cannot run Supermarket without a .env file. To get started, `cp .env.example .env`'
+  end
 end
 
 require 'rails'


### PR DESCRIPTION
:fork_and_knife:

This will allow us to change the Supermarket cookbook to symlink its .env template to .env.production. Once that's in place, we should be clear to make dotenv the sole mechanism of configuration (i.e. #399).
