### PR TITLE
Display cookbook version as cookbook updated at

### DIFF
--- a/app/views/cookbooks/_cookbook.html.erb
+++ b/app/views/cookbooks/_cookbook.html.erb
@@ -7,7 +7,7 @@
         <small><%= cookbook.latest_cookbook_version.version %></small>
       </h2>
       <span class="cookbook_dates">
-        <i class="fa fa-clock-o"></i> Updated <%= cookbook.updated_at.to_s(:longish) %><br />
+        <i class="fa fa-clock-o"></i> Updated <%= cookbook.latest_cookbook_version.created_at.to_s(:longish) %><br />
       </span>
       <div class="cookbook_owner">
         <%= link_to cookbook.owner do %>


### PR DESCRIPTION
:fork_and_knife: Since publish version doesn't update a cookbook anymore we should display the created at date for the latest version to represent when a cookbook was updated.
