### PR TITLE
Improve Curry UX

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -17,6 +17,7 @@
 *= require tabs
 *= require dashboard
 *= require welcome
+*= require curry
 *= require alerts
 *= require structure
 */

--- a/app/assets/stylesheets/curry.scss
+++ b/app/assets/stylesheets/curry.scss
@@ -1,0 +1,56 @@
+@import "foundation/components/grid";
+@import "common";
+
+.curry {
+  @include grid-row();
+
+  .add {
+    @include grid-column($columns: 4);
+    background: $sidebar_blue;
+    padding: rem-calc(55);
+
+    p {
+      color: $secondary_gray;
+      font-size: rem-calc(14);
+    }
+
+    form {
+      margin-bottom: rem-calc(40);
+    }
+  }
+
+  @media #{$mobile-only} {
+    .add {
+      @include grid-column($columns: 12);
+    }
+  }
+
+  @media #{$small-only} {
+    .add {
+      @include grid-column($columns: 12);
+    }
+  }
+
+  .watched {
+    @include grid-column($columns: 8);
+    background: #fff;
+    padding: rem-calc(55);
+
+    table {
+      text-align: left;
+      width: 100%;
+    }
+  }
+
+  @media #{$mobile-only} {
+    .watched {
+      @include grid-column($columns: 12);
+    }
+  }
+
+  @media #{$small-only} {
+    .watched {
+      @include grid-column($columns: 12);
+    }
+  }
+}

--- a/app/controllers/curry/repositories_controller.rb
+++ b/app/controllers/curry/repositories_controller.rb
@@ -59,7 +59,7 @@ class Curry::RepositoriesController < ApplicationController
   # The permitted strong params for a repository.
   #
   def repository_params
-    params.require(:curry_repository).permit(:owner, :name)
+    params.require(:curry_repository).permit(:full_name)
   end
 
   #

--- a/app/models/curry/repository.rb
+++ b/app/models/curry/repository.rb
@@ -8,6 +8,12 @@ class Curry::Repository < ActiveRecord::Base
   has_many :pull_requests, dependent: :destroy
 
   def full_name
-    [owner, name].join('/')
+    if owner.present? && name.present?
+      [owner, name].join('/')
+    end
+  end
+
+  def full_name=(full_name)
+    self.owner, self.name = full_name.split('/')
   end
 end

--- a/app/views/curry/repositories/index.html.erb
+++ b/app/views/curry/repositories/index.html.erb
@@ -1,43 +1,39 @@
 <%= provide(:title, "Manage Subscribed Repositories") %>
 
-<div class="page">
-  <div class="title">
-    <span class="fa fa-eye"></span>Watched Repositories
+<div class="curry" data-equalizer>
+  <div class="watched" data-equalizer-watch>
+    <h1 class="title">Repositories Watched by Curry</h1>
+    <table>
+      <tr>
+        <th>Repository</th>
+        <th>Actions</th>
+      </tr>
+
+      <% @repositories.each do |repository| %>
+        <tr class="repository">
+          <td>
+            <%= "#{repository.owner}/#{repository.name}" %>
+          </td>
+          <td>
+            <%= link_to "Remove Repository", repository, method: :delete, rel: 'remove_repository' %>
+          </td>
+        </tr>
+      <% end %>
+    </table>
   </div>
 
-  <table class="green">
-    <tr>
-      <th>Repository</th>
-      <th>Actions</th>
-    </tr>
+  <div class="add" data-equalizer-watch>
+    <h1>Add A Repository</h1>
 
-    <% @repositories.each do |repository| %>
-      <tr class="repository">
-        <td>
-          <%= "#{repository.owner}/#{repository.name}" %>
-        </td>
-        <td>
-          <%= link_to "Remove Repository", repository, method: :delete, rel: 'remove_repository' %>
-        </td>
-      </tr>
+    <%= form_for(@repository) do |f| %>
+      <%= f.text_field :full_name, placeholder: 'opscode/supermarket' %>
+      <%= f.submit "Add Repository", class: 'button radius primary expand' %>
     <% end %>
-  </table>
 
-  <%= form_for(@repository) do |f| %>
-    <fieldset>
-      <div>
-        <%= f.label :owner, "GitHub Repository Owner" %>
-        <%= f.text_field :owner %><br/>
-      </div>
+    <h3>About Curry</h3>
+    <p>Curry subscribes to repositories on GitHub in order to determine if any committers in a pull request need to sign a CLA. By adding a repository, Curry will be notified whenever a pull request is opened or updated. Curry will then leave a comment with the list of committers who need to sign a CLA. If all is well, Curry will add a label to the pull request letting you know all committers have signed a CLA.</p>
 
-      <div>
-        <%= f.label :name, "GitHub Repository Name" %>
-        <%= f.text_field :name %><br/>
-      </div>
+    <p>Whenever a new CLA is signed, Curry knows to check and see if that person has any open pull requests on the repositories that Curry subscribes to. If that person is a committer on any open pull requests, Curry will re-evaluate those pull requests and add a label if all is well.</p>
 
-      <div>
-        <%= f.submit "Add Repository", class: 'button primary' %>
-      </div>
-    </fieldset>
-  <% end %>
+  </div>
 </div>

--- a/spec/features/curry/curry_management_spec.rb
+++ b/spec/features/curry/curry_management_spec.rb
@@ -9,8 +9,8 @@ describe 'Curry management', uses_secrets: true do
       manage_repositories
 
       within '.new_curry_repository' do
-        fill_in 'GitHub Repository Owner', with: 'gofullstack'
-        fill_in 'GitHub Repository Name', with: 'paprika'
+        fill_in 'curry_repository_full_name', with: 'gofullstack/paprika'
+
         VCR.use_cassette('curry_add_repo', record: :once) do
           submit_form
         end
@@ -27,8 +27,7 @@ describe 'Curry management', uses_secrets: true do
       manage_repositories
 
       within '.new_curry_repository' do
-        fill_in 'GitHub Repository Owner', with: 'gofullstack'
-        fill_in 'GitHub Repository Name', with: 'paprika'
+        fill_in 'curry_repository_full_name', with: 'gofullstack/paprika'
         submit_form
 
         VCR.use_cassette('curry_add_repo', record: :once) do

--- a/spec/models/curry/repository_spec.rb
+++ b/spec/models/curry/repository_spec.rb
@@ -15,4 +15,11 @@ describe Curry::Repository do
       repository.destroy
     end.to change(Curry::PullRequest, :count).by(-1)
   end
+
+  it 'assigns name and owner based on full_name' do
+    repository = Curry::Repository.new(full_name: 'opscode/supermarket')
+
+    expect(repository.owner).to eql('opscode')
+    expect(repository.name).to eql('supermarket')
+  end
 end


### PR DESCRIPTION
:fork_and_knife: When adding a repo to be watched with Curry you can now specify the repo as a single string which includes the repos owner and name. This also styles up the curry views so they're a bit prettier.

![screen shot 2014-06-19 at 2 18 49 pm](https://cloud.githubusercontent.com/assets/316507/3331574/34900f2a-f7de-11e3-80ca-b0c575f40e16.png)
