### PR TITLE
Remove CLA signature links from user nav.

### DIFF
--- a/app/views/application/_appheader.html.erb
+++ b/app/views/application/_appheader.html.erb
@@ -15,12 +15,6 @@
         <li><%= link_to 'View Profile', current_user, class: 'fa fa-user', rel: 'view_profile' %></li>
         <li><%= link_to 'Manage Profile', edit_profile_path, class: 'fa fa-cog', rel: 'manage_profile' %></li>
 
-        <% unless current_user.signed_icla? %>
-          <li><%= link_to 'Sign ICLA', new_icla_signature_path, class: 'fa fa-file-text', rel: 'sign_icla' %></li>
-        <% end %>
-
-        <li><%= link_to 'Sign CCLA', new_ccla_signature_path, class: 'fa fa-file-text', rel: 'sign_ccla' %></li>
-
         <% if current_user && current_user.is?(:admin) %>
           <li>
             <%= link_to "Watched Repositories", curry_repositories_url, :class => 'fa fa-github', rel: 'manage_repositories' %>


### PR DESCRIPTION
:fork_and_knife: This a proposal for the user nav:

To keep the user nav as simple possible, there should only be absolutely
necessary links in the nav. I believe that the ICLA and CCLA nav items are not
appropriate to be present. For example, a user could use Supermarket without
ever needing to sign a CLA.

The flow for signing a CLA, imo should be: go to Contribute where you can view
other contributors, info about contributing and elect to become a contributor as
an individual or on behalf of a company. If a person opens a PR on a Chef repo,
Curry will let them know that they need to sign the CLA. These seem like the two
most common and useful ways for people to discover CLA signing without it being
all up in their user nav.
