### PR TITLE
Add application/x-targz to the set of valid content types

### DIFF
--- a/app/models/cookbook_version.rb
+++ b/app/models/cookbook_version.rb
@@ -28,7 +28,7 @@ class CookbookVersion < ActiveRecord::Base
                      'application/x-gtar-compressed', 'application/zip',
                      'application/x-bzip', 'application/x-zip-compressed',
                      'application/cap', 'application/x-tar-gz',
-                     'application/postscript']
+                     'application/postscript', 'application/x-targz']
     }
   )
 


### PR DESCRIPTION
:fork_and_knife: 

Supermarket is currently missing one cookbook from the community site, and it appears to be due to Supermarket rejecting `application/x-targz`  as a tarball content type.
