### PR TITLE
Override Foundation alert border colors.

### DIFF
--- a/app/assets/stylesheets/alerts.scss
+++ b/app/assets/stylesheets/alerts.scss
@@ -5,3 +5,23 @@
   top: 0;
   margin-bottom: 0;
 }
+
+.alert-box.success {
+  border-color: #43AC6A;
+}
+
+.alert-box.alert {
+  border-color: #F04124;
+}
+
+.alert-box.warning {
+  border-color: #F08A24;
+}
+
+.alert-box.secondary {
+  border-color: #E7E7E7;
+}
+
+.alert-box.info {
+  border-color: #A0D3E8;
+}


### PR DESCRIPTION
:fork_and_knife: 

This overrides the Foundation alert border colors to be the same as the alert
background colors. This creates a more consistent UI within Supermarket.

These colors are set within Foundation - no sure if I can access them via variables
so I just hard-coded them.
