### PR TITLE
Allow mailer URLs to have protocol specified

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ CLA_SIGNATURE_NOTIFICATION_EMAIL: some-email@example.com
 FROM_EMAIL: donotreply@example.com
 HOST: localhost
 PORT: 3000
+PROTOCOL: http
 SMTP_ADDRESS: localhost
 SMTP_PORT: 25
 SMTP_USER_NAME: some-username@example.com

--- a/config/application.rb
+++ b/config/application.rb
@@ -82,7 +82,8 @@ module Supermarket
     # Set default URL for ActionMailer
     config.action_mailer.default_url_options = {
       host: Supermarket::Config.host,
-      port: Supermarket::Config.port
+      port: Supermarket::Config.port,
+      protocol: ENV['PROTOCOL']
     }
 
     config.action_mailer.asset_host = Supermarket::Config.port ? "#{Supermarket::Config.host}:#{Supermarket::Config.port}" : Supermarket::Config.host


### PR DESCRIPTION
:fork_and_knife: You cannot rely on email clients handling URLs without a protocol specified correctly. So this allows a protocol to be specified (generally either http or https) so a full absolute URL can be generated. This issue originally reared its head by not routing to images correctly in most email clients.
