### PR TITLE
Use same protocol for S3 URLs as the application

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -9,7 +9,8 @@ end
       s3_credentials: Supermarket::Config.s3,
       url: ':s3_path_url',
       path: path,
-      bucket: Supermarket::Config.s3['bucket']
+      bucket: Supermarket::Config.s3['bucket'],
+      s3_protocol: ENV['PROTOCOL']
     )
   else
     ::Paperclip::Attachment.default_options.update(


### PR DESCRIPTION
:fork_and_knife: Berkshelf is not happy if the protocol for the application is not the same as the S3 URLs so this configures Paperclip to use the same protocol.
