### PR TITLE
Allow emails to be responsive

### DIFF
--- a/app/assets/stylesheets/mailers.css.scss
+++ b/app/assets/stylesheets/mailers.css.scss
@@ -59,7 +59,11 @@ a { color: #404248; }
 /* Chef Styles */
 #wrapper { background-color: #eeeeee; }
 
-.content { margin-bottom: 30px; }
+.content {
+  margin-bottom: 30px;
+  width: 80%;
+  max-width: 720px;
+}
 
 .header {
   height: 120px;
@@ -112,6 +116,11 @@ a { color: #404248; }
 .icon {
   display: inline-block;
   margin: 4px 8px -2px 0;
+  background: #ECEDEF;
+  padding: 2px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  -webkit-border-radius:4px;
 }
 
 .panel {
@@ -162,11 +171,12 @@ a { color: #404248; }
 .button:hover, .button-small:hover { opacity: .8; }
 .button:hover, .button-small:hover{ opacity:.8; }
 .lightbutton { background-color: #a0a9ba; }
-.signedcla { background-color: #f79005; float: right; margin: -35px 0 0 0; }
+.signedcla { background-color: #f79005; }
 
 .accept {
   background-color: #43AC6A;
   padding: 0 50px;
+  margin-bottom: 10px;
 }
 
 .decline {

--- a/app/views/cla_signature_mailer/ccla_signature_notification_email.html.erb
+++ b/app/views/cla_signature_mailer/ccla_signature_notification_email.html.erb
@@ -1,5 +1,5 @@
 <h1>A new CCLA has been signed.</h1>
-<%= link_to "View Signed CCLA", ccla_signature_url(@ccla_signature), class: "button signedcla" %>
 <p><%= @ccla_signature.name %> signed a CCLA on behalf of <%= @ccla_signature.company %>.</p>
+<%= link_to "View Signed CCLA", ccla_signature_url(@ccla_signature), class: "button signedcla" %>
 
 <%= render 'ccla_signature', signature: @ccla_signature %>

--- a/app/views/cla_signature_mailer/icla_signature_notification_email.html.erb
+++ b/app/views/cla_signature_mailer/icla_signature_notification_email.html.erb
@@ -1,5 +1,5 @@
 <h1>A new ICLA has been signed.</h1>
-<%= link_to "View Signed ICLA", icla_signature_url(@icla_signature), class: "button signedcla" %>
 <p><%= @icla_signature.name %> signed an ICLA.</p>
+<%= link_to "View Signed ICLA", icla_signature_url(@icla_signature), class: "button signedcla" %>
 
 <%= render 'icla_signature', signature: @icla_signature %>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -11,7 +11,7 @@
   <table cellpadding="0" cellspacing="0" border="0" width="100%" id="wrapper">
     <tr>
       <td align="center">
-        <table class="content" cellpadding="0" cellspacing="0" border="0" width="720">
+        <table class="content" cellpadding="0" cellspacing="0" border="0">
           <tr>
             <td class="header" align="center">
               <%= image_tag "logo_email.jpg", alt: "Chef Supermarket", title: "Chef Supermarket", width: 251, height: 63, class: "image_fix" %>


### PR DESCRIPTION
:fork_and_knife: This removes the set width on the content container for mailers and sets a percentage based with and a max width and makes a few adjustments so everything looks ok at smaller sizes.

![screen shot 2014-06-24 at 11 33 44 am](https://cloud.githubusercontent.com/assets/316507/3373576/f6ab2d04-fbb4-11e3-96b3-aba666a168b6.png)
