### PR TITLE
Include protocol in asset host

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -86,7 +86,7 @@ module Supermarket
       protocol: ENV['PROTOCOL']
     }
 
-    config.action_mailer.asset_host = Supermarket::Config.port ? "#{Supermarket::Config.host}:#{Supermarket::Config.port}" : Supermarket::Config.host
+    config.action_mailer.asset_host = ENV['PORT'].present? ? "#{ENV['PROTOCOL']}://#{ENV['HOST']}:#{ENV['PORT']}" : "#{ENV['PROTOCOL']}://#{ENV['HOST']}"
 
     # Set default from email for ActionMailer
     ActionMailer::Base.default from: Supermarket::Config.from_email


### PR DESCRIPTION
:fork_and_knife: To prevent image tags from breaking in mailers a protocol needs to be defined for the asset host.
