### PR TITLE
Update chef-legacy to 1.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'sass-rails',   '~> 4.0.1'
 gem 'compass-rails'
 gem 'uglifier',     '~> 2.2'
 
-gem 'chef-legacy', github: 'gofullstack/chef-legacy', ref: 'v1.3.0'
+gem 'chef-legacy', github: 'gofullstack/chef-legacy', ref: 'v1.4.0'
 
 group :doc do
   gem 'yard', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git://github.com/gofullstack/chef-legacy.git
-  revision: 3a27451f99f06b93b178b10e660e0b65f4dbfa99
-  ref: v1.3.0
+  revision: f875db26ec37bf0ec9278603e7145bb8da8e2332
+  ref: v1.4.0
   specs:
     chef-legacy (1.0.0)
       connection_pool


### PR DESCRIPTION
:fork_and_knife: 

1.4 includes the data revision task which will re-process each cookbook artifact to make sure we've imported its description, README, and dependencies correctly.
