### PR TITLE
Update policy for CCLA contributors tab nav.

### DIFF
--- a/app/views/ccla_signatures/contributors.html.erb
+++ b/app/views/ccla_signatures/contributors.html.erb
@@ -4,7 +4,7 @@
   <div class="contributors">
     <h1>Contributors on Behalf of <%= @ccla_signature.organization.name %></h1>
 
-    <% if current_user &&  policy(@ccla_signature).show? %>
+    <% if current_user &&  policy(@ccla_signature.organization).view_cclas? %>
       <%= render "organization_tabs", ccla_signature: @ccla_signature %>
     <% else %>
       <%= link_to "Return to list of CCLA Signing Companies", ccla_signatures_path, class: "button radius tiny" %>


### PR DESCRIPTION
:fork_and_knife: 

The authorizer for CclaSignature has been moved to Organization. This updates
a condition still using the old authorizer.

The reason this issue was not caught was because of the lack of feature specs
surrounding the Contribute section. This is something that I will add and improve,
and I apologize for not writing any.
