### PR TITLE
Trigger equalizer on tab callback

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,7 +31,13 @@
 Foundation.global.namespace = '';
 
 $(function(){
-  $(document).foundation();
+  $(document).foundation({
+    tab: {
+      callback: function(tab) {
+        $(document).foundation('equalizer');
+      }
+    }
+  });
 
   // Ensure client side validation isn't stronger
   // than serverside validation.


### PR DESCRIPTION
:fork_and_knife: To ensure that tab content doesn't flow beyond parent containers equalizer should be triggered whenever a tab is toggled.
