### PR TITLE
Add secondary order column to most followed and most downloaded

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -26,8 +26,8 @@ class Cookbook < ActiveRecord::Base
     reorder({
       'recently_updated' => 'updated_at DESC',
       'recently_added' => 'id DESC',
-      'most_downloaded' => '(web_download_count + api_download_count) DESC',
-      'most_followed' => 'cookbook_followers_count DESC'
+      'most_downloaded' => '(web_download_count + api_download_count) DESC, id ASC',
+      'most_followed' => 'cookbook_followers_count DESC, id ASC'
     }.fetch(ordering, 'name ASC'))
   }
 

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -313,6 +313,22 @@ describe Cookbook do
       expect(Cookbook.ordered_by('most_followed').map(&:name)).
         to eql(%w(great cookbook))
     end
+
+    it 'orders secondarily by id when cookbook follower counts are equal' do
+      great.update_attributes(cookbook_followers_count: 100)
+      cookbook.update_attributes(cookbook_followers_count: 100)
+
+      expect(Cookbook.ordered_by('most_followed').map(&:name)).
+        to eql(%w(great cookbook))
+    end
+
+    it 'orders secondarily by id when download counts are equal' do
+      great.update_attributes(web_download_count: 5, api_download_count: 100)
+      cookbook.update_attributes(web_download_count: 5, api_download_count: 100)
+
+      expect(Cookbook.ordered_by('most_followed').map(&:name)).
+        to eql(%w(great cookbook))
+    end
   end
 
   describe '.owned_by' do


### PR DESCRIPTION
:fork_and_knife: So ordering is consistent when follower or download counts are the same this orders most followed and most downloaded sorts by id as well so Postgres doesn't just choose each query.
