### PR TITLE
Require application.js before segment io

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,10 +62,10 @@
       </div>
     </div>
 
+    <%= javascript_include_tag 'application' %>
+
     <% if Supermarket::Config.segment_io_write_key %>
       <%= render partial: 'segment.io' %>
     <% end %>
-
-    <%= javascript_include_tag "application" %>
   </body>
 </html>


### PR DESCRIPTION
:fork_and_knife: The segment io events depend on jQuery so application.js needs to be included in the page before the segment io partial.
