### PR TITLE
Change cookbooks/directory to cookbooks-directory

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Supermarket::Application.routes.draw do
     end
   end
 
-  get 'cookbooks/directory' => 'cookbooks#directory'
+  get 'cookbooks-directory' => 'cookbooks#directory'
   get 'universe' => 'api/v1/universe#index', defaults: { format: :json }
 
   resources :cookbooks, only: [:index, :show, :update] do


### PR DESCRIPTION
:fork_and_knife: To prevent namespace issues with with a cookbook named directory this changes the cookbooks directory route to cookbooks-directory.
