### PR TITLE
Add user id to server side segment io events

### DIFF
--- a/app/controllers/api/v1/cookbook_uploads_controller.rb
+++ b/app/controllers/api/v1/cookbook_uploads_controller.rb
@@ -61,6 +61,7 @@ class Api::V1::CookbookUploadsController < Api::V1Controller
 
           SegmentIO.track_server_event(
             'cookbook_version_published',
+            current_user,
             cookbook: @cookbook.name
           )
 
@@ -98,6 +99,7 @@ class Api::V1::CookbookUploadsController < Api::V1Controller
         CookbookDeletionWorker.perform_async(@cookbook.as_json)
         SegmentIO.track_server_event(
           'cookbook_deleted',
+          current_user,
           cookbook: @cookbook.name
         )
 

--- a/app/controllers/api/v1/cookbook_versions_controller.rb
+++ b/app/controllers/api/v1/cookbook_versions_controller.rb
@@ -27,6 +27,7 @@ class Api::V1::CookbookVersionsController < Api::V1Controller
 
     SegmentIO.track_server_event(
       'cookbook_version_api_download',
+      current_user,
       cookbook: @cookbook.name,
       version: @cookbook_version.version
     )

--- a/app/controllers/cookbook_versions_controller.rb
+++ b/app/controllers/cookbook_versions_controller.rb
@@ -12,6 +12,7 @@ class CookbookVersionsController < ApplicationController
 
     SegmentIO.track_server_event(
       'cookbook_version_web_download',
+      current_user,
       cookbook: @cookbook.name,
       version: @version.version
     )

--- a/lib/supermarket/segment_io_agent.rb
+++ b/lib/supermarket/segment_io_agent.rb
@@ -44,17 +44,19 @@ module Supermarket
 
     #
     # Tracks an event with the given +name+ and +properties+ as having been
-    # performed by the "web_server" user.
+    # performed by a user or anonymous.
     #
     # @param name [String] the name of the event
+    # @param user [User] the user that triggered the event
     # @param properties [Hash] the properties, if any, associated with the event
     #
-    def track_server_event(name, properties = {})
-      @last_event = { name: name, properties: properties }
+    def track_server_event(name, user, properties = {})
+      user_id = user ? user.id : 'anonymous'
+      @last_event = { name: name, user_id: user_id, properties: properties }
 
       if enabled?
         @segment_io.track(
-          user_id: 'web_server',
+          user_id: user_id,
           event: name,
           properties: properties
         )

--- a/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
@@ -78,6 +78,7 @@ describe Api::V1::CookbookVersionsController do
 
       expect(SegmentIO.last_event).to eql(
         name: 'cookbook_version_api_download',
+        user_id: 'anonymous',
         properties: {
           cookbook: cookbook.name,
           version: version.version

--- a/spec/controllers/cookbook_versions_controller_spec.rb
+++ b/spec/controllers/cookbook_versions_controller_spec.rb
@@ -4,6 +4,8 @@ describe CookbookVersionsController do
   describe '#download' do
     let(:cookbook) { create(:cookbook) }
     let(:version) { create(:cookbook_version, cookbook: cookbook) }
+    let(:user) { create(:user) }
+    before { sign_in user }
 
     it '302s to the latest cookbook version file' do
       get :download, cookbook_id: cookbook.name, version: version.to_param
@@ -29,6 +31,7 @@ describe CookbookVersionsController do
 
       expect(SegmentIO.last_event).to eql(
         name: 'cookbook_version_web_download',
+        user_id: user.id,
         properties: {
           cookbook: cookbook.name,
           version: version.version

--- a/spec/lib/supermarket/segment_io_agent_spec.rb
+++ b/spec/lib/supermarket/segment_io_agent_spec.rb
@@ -26,8 +26,16 @@ describe Supermarket::SegmentIoAgent do
   it 'keeps track of the last event tracked' do
     config = double('Supermarket::Config', segment_io_write_key: nil)
     agent = Supermarket::SegmentIoAgent.new(config)
-    agent.track_server_event('tick', time: 1)
+    agent.track_server_event('tick', nil, time: 1)
 
-    expect(agent.last_event).to eql(name: 'tick', properties: { time: 1 })
+    expect(agent.last_event).to eql(name: 'tick', user_id: 'anonymous', properties: { time: 1 })
+  end
+
+  it 'tracks what user triggered the event' do
+    config = double('Supermarket::Config', segment_io_write_key: nil)
+    agent = Supermarket::SegmentIoAgent.new(config)
+    agent.track_server_event('tick', double('User', id: 123), time: 1)
+
+    expect(agent.last_event[:user_id]).to eql(123)
   end
 end


### PR DESCRIPTION
:fork_and_knife: Server side segment io events now include the current users id if a user is currently logged in otherwise it is tracked as anonymous.
