### PR TITLE
Specify path in transfer ownership form

### DIFF
--- a/app/views/cookbooks/_sidebar.html.erb
+++ b/app/views/cookbooks/_sidebar.html.erb
@@ -40,7 +40,7 @@
         <h1>Transfer Ownership</h1>
         <a class="close-reveal-modal">&#215;</a>
 
-        <%= form_for cookbook, url: { action: 'transfer_ownership' }, method: :put do |f| %>
+        <%= form_for cookbook, url: transfer_ownership_cookbook_path(cookbook), method: :put do |f| %>
           <div class="row collapse">
             <div class="small-9 columns">
               <%= f.hidden_field :user_id, class: 'collaborators', 'data-url' => cookbook_collaborators_path(cookbook, eligible_for: 'ownership') %>


### PR DESCRIPTION
:fork_and_knife: When in the cookbook version view the transfer ownership form is unable to resolve a URL so this specifies the path instead.
