### PR TITLE
Enable and test other GHFM features

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -2,9 +2,9 @@ module MarkdownHelper
   #
   # Make auto-links target=_blank
   #
-  class TargetBlankRenderer < Redcarpet::Render::HTML
+  class SupermarketRenderer < Redcarpet::Render::HTML
     def initialize(extensions = {})
-      super extensions.merge(link_attributes: { target: '_blank' })
+      super extensions.merge(link_attributes: { target: '_blank' }, with_toc_data: true, hard_wrap: true)
     end
   end
 
@@ -17,10 +17,13 @@ module MarkdownHelper
   #
   def render_markdown(text)
     Redcarpet::Markdown.new(
-      TargetBlankRenderer,
+      SupermarketRenderer,
       autolink: true,
       fenced_code_blocks: true,
-      tables: true
+      tables: true,
+      no_intra_emphasis: true,
+      strikethrough: true,
+      superscript: true
     ).render(
       text
     ).html_safe

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe MarkdownHelper do
   describe '#render_markdown' do
     it 'renders markdown' do
-      expect(helper.render_markdown('# Test')).to eq("<h1>Test</h1>\n")
+      expect(helper.render_markdown('# Test')).to match(/h1/)
     end
 
     it 'renders fenced code blocks' do
@@ -31,5 +31,30 @@ $ bundle exec rake spec:all
     EOH
 
     expect(helper.render_markdown(table)).to match(/<table>/)
+  end
+
+  it 'adds br tags on hard wraps' do
+    markdown = <<-EOH
+This is a hard
+wrap.
+    EOH
+
+    expect(helper.render_markdown(markdown)).to match(/<br>/)
+  end
+
+  it "doesn't emphasize underscored words" do
+    expect(helper.render_markdown('some_long_method_name')).to_not match(/<em>/)
+  end
+
+  it 'adds HTML anchors to headers' do
+    expect(helper.render_markdown('# Tests')).to match(/id="tests"/)
+  end
+
+  it 'strikesthrough text using ~~ with a del tag' do
+    expect(helper.render_markdown('~~Ignore This~~')).to match(/<del>/)
+  end
+
+  it 'superscripts text using ^ with a sup tag' do
+    expect(helper.render_markdown('Supermarket^2')).to match(/<sup>/)
   end
 end


### PR DESCRIPTION
:fork_and_knife: Enable and test other GitHub Flavored Markdown features in Redcarpet.
