### PR TITLE
Give .env.production precedence over .env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'unicorn'
 gem 'unicorn-rails'
 gem 'foreman'
 gem 'pundit'
-gem 'dotenv-rails'
+gem 'dotenv'
 gem 'coveralls', require: false
 gem 'octokit', github: 'octokit/octokit.rb', require: false
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,8 +163,6 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.3)
     dotenv (0.10.0)
-    dotenv-rails (0.10.0)
-      dotenv (= 0.10.0)
     equalizer (0.0.9)
     erubis (2.7.0)
     execjs (2.0.2)
@@ -460,7 +458,7 @@ DEPENDENCIES
   compass-rails
   coveralls
   database_cleaner
-  dotenv-rails
+  dotenv
   factory_girl
   faker
   foreman

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,14 @@
 require File.expand_path('../boot', __FILE__)
 
+require 'dotenv'
+
 require 'rails'
+
+Dotenv.load('.env', ".env.#{Rails.env}").tap do |env|
+  if env.empty?
+    fail 'Cannot run Supermarket without a .env file.'
+  end
+end
 
 %w(
   active_record


### PR DESCRIPTION
:fork_and_knife: 

This is the last step in switching to Dotenv, and makes it so that the cookbook-generated environment variables take precedence over the repo defaults.
