### PR TITLE
Have Cookbook#description return nil

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -69,7 +69,7 @@ class Cookbook < ActiveRecord::Base
 
   # Delegations
   # --------------------
-  delegate :description, to: :latest_cookbook_version
+  delegate :description, to: :latest_cookbook_version, allow_nil: true
 
   # Validations
   # --------------------

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -118,6 +118,21 @@ describe Cookbook do
     it { should validate_presence_of(:category) }
   end
 
+  describe '#description' do
+    it 'is delegated to the latest cookbook version' do
+      cookbook = Cookbook.new
+      cookbook.cookbook_versions << create(:cookbook_version, description: 'Best cookbook eva')
+
+      expect(cookbook.description).to eql('Best cookbook eva')
+    end
+
+    it 'returns nil if latest cookbook version is nil' do
+      cookbook = Cookbook.new
+
+      expect(cookbook.description).to eql(nil)
+    end
+  end
+
   describe '#lowercase_name' do
     it 'is set as part of the saving lifecycle' do
       cookbook = Cookbook.new(name: 'Apache')


### PR DESCRIPTION
:fork_and_knife: There is an edge case where `latest_cookbook_version` can be `nil` because it was deleted after a Cookbook has been initialized so if description is called it's delegated to `latest_cookbook_version` which is nil and it raises an exception. This enables the `allow_nil` option to the description delegate so rather than raising an exception description will just return nil.
