### PR TITLE
trackLink doesn't work with ajax

### DIFF
--- a/app/assets/javascripts/cookbookFollowing.js
+++ b/app/assets/javascripts/cookbookFollowing.js
@@ -1,5 +1,24 @@
 $(function() {
   /*
+   * Track following and unfollowing cookbooks in Segment.IO
+   *
+   */
+  var trackFollows = function(obj) {
+    if (window.analytics) {
+      var id = $(obj).attr('id');
+      var txt;
+
+      if (id == 'follow_cookbook') {
+        txt = 'Followed Cookbook';
+      } else {
+        txt = 'Unfollowed Cookbook';
+      }
+
+      analytics.track(txt, {cookbook: $(obj).data('cookbook')});
+    }
+  };
+
+  /*
    * Adds a disabled class when the user clicks a follow or unfollow button
    * so they know a request is in progress and they don't click follow or unfollow
    * twice.
@@ -14,6 +33,7 @@ $(function() {
    */
   $('body').delegate('.cookbook_partial .follow', 'ajax:success', function(e, data, status, xhr) {
     var cookbookId = '#' + $(this).data('cookbook');
+    trackFollows(this);
 
     $.get(window.location.href, function(response) {
       $(cookbookId).replaceWith($(response).find(cookbookId));
@@ -25,6 +45,8 @@ $(function() {
    * the followbutton which includes the follow count with server side rendred HTML.
    */
   $('body').delegate('.cookbook_show .follow', 'ajax:success', function(e, data, status, xhr) {
+    trackFollows(this);
+
     $.get(window.location.href, function(response) {
       $('.followbutton').replaceWith($(response).find('.followbutton'));
     }, 'html');

--- a/app/views/application/_segment.io.html.erb
+++ b/app/views/application/_segment.io.html.erb
@@ -26,16 +26,4 @@
       organization: $(this).data('organization')
     });
   });
-
-  analytics.trackLink($('#follow_cookbook'), function() {
-    analytics.track('Followed Cookbook', {
-      cookbook: $(this).data('cookbook')
-    });
-  });
-
-  analytics.trackLink($('#unfollow_cookbook'), function() {
-    analytics.track('Unfollowed Cookbook', {
-      cookbook: $(this).data('cookbook')
-    });
-  });
 </script>


### PR DESCRIPTION
:fork_and_knife: 

This fixes https://github.com/opscode/supermarket/issues/533

The root cause was that `trackLink`, which is part of Segment.IO's javascript library doesn't play well with AJAX requests.  Make a note for future reference.

At some point in the future, it'd be nice to optimize those `ajax:success` callbacks to not make another request to the same page and parse the entire response body just to get the updated button state.  We can likely just re-render a new button in a partial in the response from `follow`/`unfollow`.

For now though, this will fix the 404.
