### PR TITLE
Eager load versions, owners and accounts

### DIFF
--- a/app/controllers/api/v1/cookbooks_controller.rb
+++ b/app/controllers/api/v1/cookbooks_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::CookbooksController < Api::V1Controller
   #
   def index
     @total = Cookbook.count
-    @cookbooks = Cookbook.includes(:cookbook_versions, owner: :chef_account).ordered_by(@order).limit(@items).offset(@start)
+    @cookbooks = Cookbook.index(order: @order, limit: @items, start: @start)
 
     if params[:user]
       @cookbooks = @cookbooks.owned_by(params[:user])

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -34,6 +34,13 @@ class Cookbook < ActiveRecord::Base
     joins(owner: :chef_account).where('accounts.username = ?', username)
   }
 
+  scope :index, lambda { |opts = {}|
+    includes(:cookbook_versions, owner: :chef_account)
+    .ordered_by(opts.fetch(:order, 'name ASC'))
+    .limit(opts.fetch(:limit, 10))
+    .offset(opts.fetch(:start, 0))
+  }
+
   # Search
   # --------------------
   pg_search_scope(


### PR DESCRIPTION
:fork_and_knife: 

https://trello.com/c/6Lb83mKx/241-cookbooks-api-index-breaks-if-a-cookbook-is-deleted-while-the-index-is-being-rendered

This is an alternate solution to https://github.com/opscode/supermarket/pull/532
