### PR TITLE
Stop DataImportWorker jobs from recurring

### DIFF
--- a/app/workers/data_import_worker.rb
+++ b/app/workers/data_import_worker.rb
@@ -3,13 +3,6 @@
 #
 class DataImportWorker
   include Sidekiq::Worker
-  include Sidetiq::Schedulable
-
-  recurrence do
-    hours = (0..23).step(3)
-
-    daily.hour_of_day(*hours)
-  end
 
   #
   # Invokes the supermarket:migrate Rake task


### PR DESCRIPTION
:fork_and_knife: 

Following the cutover from community.opscode.com to Supermarket, it's no longer necessary for the `DataImportWorker` to reschedule itself. At some point in the near future we can remove the worker entirely, but we want to do this first so that Sidetiq does not try to queue jobs for a non-existent worker.
