### PR TITLE
Do not pass arguments to edit_profile_path

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -14,7 +14,7 @@ class AccountsController < ApplicationController
       redirect_to after_link_location, notice: "Successfully
         connected #{request.env['omniauth.auth']['provider']}."
     else
-      redirect_to edit_profile_path(current_user), alert: "Something went wrong
+      redirect_to edit_profile_path, alert: "Something went wrong
         while connecting #{request.env['omniauth.auth']['provider']}"
     end
   end
@@ -34,6 +34,6 @@ class AccountsController < ApplicationController
   private
 
   def after_link_location
-    stored_location || edit_profile_path(current_user)
+    stored_location || edit_profile_path
   end
 end

--- a/spec/controllers/accounts_controller_spec.rb
+++ b/spec/controllers/accounts_controller_spec.rb
@@ -18,7 +18,7 @@ describe AccountsController do
     it 'redirects to the user profile on success by default' do
       post :create, provider: 'github'
 
-      expect(response).to redirect_to(edit_profile_path(user))
+      expect(response).to redirect_to(edit_profile_path)
     end
 
     it 'redirects to the stored location for the user on success if set' do


### PR DESCRIPTION
:fork_and_knife: 

The profile routes are defined by a `resource` (not `resources`), so passing in a `User` to the `edit_profile_path` route helper results in URLs like /profile/edit.foobar. It technically works, but is not correct.
