### PR TITLE
Display collaborator language when present.

### DIFF
--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -92,11 +92,12 @@
         </table>
       </div>
       <div class="content" id="collaborations">
-        <p>The cookbooks you are a collaborator on.</p>
 
         <% if current_user.collaborated_cookbooks.empty? %>
           <p>You are currently not a collaborator on any cookbooks. Once you are, they will be listed here.</p>
         <% else %>
+          <p>The cookbooks you are a collaborator on.</p>
+
           <table>
             <% current_user.collaborated_cookbooks.each do |cookbook| %>
               <tr>


### PR DESCRIPTION
:fork_and_knife: 

When viewing Manage Profile > Collaborations, only display information about
cookbook collaboration when the user collaborates on cookbooks. This makes the
page a little more straight-forward when empty.
