### PR TITLE
Remove cookbook partial gravatar styles.

### DIFF
--- a/app/assets/stylesheets/cookbooks/cookbook.scss
+++ b/app/assets/stylesheets/cookbooks/cookbook.scss
@@ -86,10 +86,6 @@
     }
 
     .gravatar {
-      background-color: $primary_gray;
-      border: rem-calc(3) solid white;
-      @include box-shadow(rgba(0,0,0,.2) 0 rem-calc(1) rem-calc(1));
-      @include border-radius(rem-calc(24));
       @include box-sizing(content-box);
       width: rem-calc(24);
     }


### PR DESCRIPTION
:fork_and_knife:

The cookbook partial gravatar styles deviate from the other styles, which breaks
the consistency of the gravatar. This removes the shadow and outline to make it
consistent.
