### PR TITLE
Produce protocol-relative Markdown images

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -3,8 +3,29 @@ module MarkdownHelper
   # Make auto-links target=_blank
   #
   class SupermarketRenderer < Redcarpet::Render::HTML
+    include ActionView::Helpers::TagHelper
+
     def initialize(extensions = {})
       super extensions.merge(link_attributes: { target: '_blank' }, with_toc_data: true, hard_wrap: true)
+    end
+
+    #
+    # Create an image tag with a protocol-relative URL
+    #
+    # @param url [String] the image URL
+    # @param title [String, nil] the image title
+    # @param alt [String, nil] the image's alternative text
+    #
+    # @return [String] an image tag
+    #
+    def image(url, title, alt)
+      options = {
+        src: relative_url = url.sub(/\Ahttps?:/, ''),
+        alt: String(alt),
+        title: title
+      }
+
+      tag(:img, options, true)
     end
   end
 

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -57,4 +57,27 @@ wrap.
   it 'superscripts text using ^ with a sup tag' do
     expect(helper.render_markdown('Supermarket^2')).to match(/<sup>/)
   end
+
+  it 'uses protocol-relative URLs for images served over HTTP' do
+    html = helper.render_markdown('![](http://img.example.com)')
+
+    expect(html).to include('<img alt="" src="//img.example.com">')
+  end
+
+  it 'uses protocol-relative URLs for images served over HTTPS' do
+    html = helper.render_markdown('![](https://img.example.com)')
+
+    expect(html).to include('<img alt="" src="//img.example.com">')
+  end
+
+  it 'escapes attribute values' do
+    html = helper.render_markdown('!["><"]("><" "><")')
+    attribute = '&quot;&gt;&lt;&quot;'
+
+    escaped_html = %(
+      <img alt="#{attribute}" src="#{attribute}" title="&gt;&lt;">
+    ).squish
+
+    expect(html).to include(escaped_html)
+  end
 end


### PR DESCRIPTION
:construction: 

This is a stab at fixing #528. We're already using a custom Redcarpet renderer; this extends it to implement a Supermarket-specific image tag callback ([docs](https://github.com/vmg/redcarpet/#span-level-calls)). Unfortunately, as is noted in vmg/redcarpet#51, it's not possible to simply create the protocol-relative URL and call `super`.

With this approach I believe Supermarket will not display images from servers that cannot serve HTTPS traffic.
