### PR TITLE
Wrap cookbook install snippet only in <code> tags.

### DIFF
--- a/app/assets/stylesheets/cookbooks/cookbook.scss
+++ b/app/assets/stylesheets/cookbooks/cookbook.scss
@@ -24,6 +24,12 @@
     font-size: rem-calc(16);
     margin: rem-calc(0 0 20 0);
   }
+
+  code.cookbook_install {
+    display: block;
+    font-weight: normal;
+    padding: rem-calc(8 16 8 16);
+  }
 }
 
 @media #{$mobile-only} {

--- a/app/views/cookbooks/_cookbook.html.erb
+++ b/app/views/cookbooks/_cookbook.html.erb
@@ -22,7 +22,7 @@
       <p>
         <%= cookbook.description %>
       </p>
-      <code><pre>cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</pre></code>
+      <code class="cookbook_install">cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</code>
     </div>
   </div>
   <div class="cookbook_footer">


### PR DESCRIPTION
:fork_and_knife: 

This adjusts the cookbook install snippet to only wrap it in <code> tags with a
class to style it as expected. This fixes a regression introduced in
8874fa78ee86fca0b4754c12da50684b0d1bf71b
