### PR TITLE
Organization cleanup

### DIFF
--- a/app/assets/javascripts/organizations.js
+++ b/app/assets/javascripts/organizations.js
@@ -17,10 +17,10 @@ $(function () {
       }
     },
     formatSelection: function(obj, container) {
-      return obj.company;
+      return obj.name;
     },
-    formatResult: function(obj, container) {
-      return obj.company;
+    formatResult: function(obj, container, query) {
+      return obj.name + ', signed on ' + obj.signed_at;
     }
   }
 

--- a/app/models/ccla_signature.rb
+++ b/app/models/ccla_signature.rb
@@ -9,18 +9,18 @@ class CclaSignature < ActiveRecord::Base
 
   # Validations
   # --------------------
-  validates_presence_of :user
-  validates_presence_of :first_name
-  validates_presence_of :last_name
-  validates_presence_of :email
-  validates_presence_of :phone
-  validates_presence_of :company
-  validates_presence_of :address_line_1
-  validates_presence_of :city
-  validates_presence_of :state
-  validates_presence_of :zip
-  validates_presence_of :country
-  validates_acceptance_of :agreement, allow_nil: false, on: :create
+  validates :user, presence: true
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :email, presence: true
+  validates :phone, presence: true
+  validates :company, presence: true
+  validates :address_line_1, presence: true
+  validates :city, presence: true
+  validates :state, presence: true
+  validates :zip, presence: true
+  validates :country, presence: true
+  validates :agreement, acceptance: true, allow_nil: false, on: :create
 
   # Accessors
   # --------------------

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -25,7 +25,6 @@ class Organization < ActiveRecord::Base
   def name
     latest_ccla_signature.company
   end
-  alias_method :company, :name
 
   #
   # Retrieve the latest CCLA signature if they have signed a CCLA.

--- a/app/views/organizations/index.json.jbuilder
+++ b/app/views/organizations/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.array! @ccla_signatures do |signature|
+  json.id signature.organization_id
+  json.name signature.company
+  json.signed_at signature.signed_at.to_s(:long)
+end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -12,7 +12,7 @@
       <%= form_for @organization, url: { action: 'combine' }, method: :put do |f| %>
         <div class="row collapse">
           <div class="small-10 columns">
-            <%= f.hidden_field :combine_with_id, class: 'transfer-ccla-organization', 'data-url' => organizations_path %>
+            <%= f.hidden_field :combine_with_id, class: 'transfer-ccla-organization', 'data-url' => organizations_path(exclude_id: @organization) %>
           </div>
           <div class="small-2 columns">
             <%= f.submit 'Combine', class: 'button postfix radius' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,9 @@ en:
       collaborates: "You aren't a collaborator on any cookbooks."
       follows: "You don't follow any cookbooks."
   requires_linked_github: "You need to link your GitHub account."
+  organizations:
+    combined: "%{org_to_combine} was successfully merged into %{combined_with}."
+    deleted: "%{organization} was successfully deleted."
   organization_invitations:
     invites:
       success: "Successfully sent invitations"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Supermarket::Application.routes.draw do
-  VERSION_PATTERN = /latest|([0-9_\-\.]+)/
+  VERSION_PATTERN = /latest|([0-9_\-\.]+)/ unless defined?(VERSION_PATTERN)
 
   if Rails.env.development?
     mount MailPreview => 'mail_view'

--- a/spec/authorizers/organization_authorizer_spec.rb
+++ b/spec/authorizers/organization_authorizer_spec.rb
@@ -29,6 +29,10 @@ describe OrganizationAuthorizer do
     it { should permit_authorization(:view_cclas) }
     it { should permit_authorization(:resign_ccla) }
     it { should permit_authorization(:manage_contributors) }
+    it { should_not permit_authorization(:manage_organization) }
+    it { should_not permit_authorization(:show) }
+    it { should_not permit_authorization(:destroy) }
+    it { should_not permit_authorization(:combine) }
   end
 
   context 'as an organization contributor' do
@@ -43,13 +47,20 @@ describe OrganizationAuthorizer do
     it { should permit_authorization(:view_cclas) }
     it { should_not permit_authorization(:resign_ccla) }
     it { should_not permit_authorization(:manage_contributors) }
+    it { should_not permit_authorization(:manage_organization) }
+    it { should_not permit_authorization(:show) }
+    it { should_not permit_authorization(:destroy) }
+    it { should_not permit_authorization(:combine) }
   end
 
-  context 'as a non-admin' do
+  context 'as a totally random person' do
     let(:user) { build(:user) }
 
     subject { described_class.new(user, record) }
 
+    it { should_not permit_authorization(:view_cclas) }
+    it { should_not permit_authorization(:resign_ccla) }
+    it { should_not permit_authorization(:manage_contributors) }
     it { should_not permit_authorization(:manage_organization) }
     it { should_not permit_authorization(:show) }
     it { should_not permit_authorization(:destroy) }

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+
+describe OrganizationsController do
+  let!(:org1) { create(:organization) }
+  let!(:org2) { create(:organization) }
+  let!(:ccla_signature1) { create(:ccla_signature, organization: org1, company: 'International House of Pancakes') }
+  let!(:ccla_signature2) { create(:ccla_signature, organization: org2, company: "Bob's House of Pancakes") }
+  let!(:admin) { create(:user, roles: 'admin') }
+
+  describe 'GET #index' do
+    it 'succeeds' do
+      get :index, format: :json
+      expect(response).to be_success
+    end
+
+    it 'assigns organizations' do
+      get :index, format: :json
+      expect(assigns(:ccla_signatures)).to include(ccla_signature1, ccla_signature2)
+    end
+
+    it 'filters organizations when you pass in a search parameter' do
+      get :index, q: 'international', format: :json
+      expect(assigns(:ccla_signatures)).to include(ccla_signature1)
+    end
+
+    it 'excludes the current organization from search results' do
+      get :index, exclude_id: org1.id, format: :json
+      expect(assigns(:ccla_signatures).to_a).to_not include(ccla_signature1)
+    end
+  end
+
+  describe 'GET #show' do
+    before do
+      sign_in admin
+      get :show, id: org1
+    end
+
+    it 'assigns the organization' do
+      expect(assigns(:organization)).to eql(org1)
+    end
+
+    it 'succeeds' do
+      expect(response).to be_success
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    before { sign_in admin }
+
+    it 'assigns the organization' do
+      delete :destroy, id: org1
+      expect(assigns(:organization)).to eql(org1)
+    end
+
+    it 'deletes the organization' do
+      expect do
+        delete :destroy, id: org1
+      end.to change(Organization, :count).by(-1)
+    end
+
+    it 'redirects to the CCLA signatures page' do
+      delete :destroy, id: org1
+      expect(response).to redirect_to(ccla_signatures_path)
+    end
+
+    it 'contains a helpful flash message' do
+      delete :destroy, id: org1
+      expect(request.flash[:notice]).to_not be_nil
+    end
+  end
+
+  describe 'PUT #combine' do
+    before { sign_in admin }
+
+    it 'assigns the organization' do
+      put :combine, id: org1, organization: { combine_with_id: org2 }
+      expect(assigns(:organization)).to eql(org1)
+    end
+
+    it 'deletes the second organization' do
+      expect do
+        put :combine, id: org1, organization: { combine_with_id: org2 }
+      end.to change(Organization, :count).by(-1)
+    end
+
+    it 'combines the two organizations together' do
+      expect(Organization).to receive(:find).with(org1.id.to_s) { org1 }
+      expect(Organization).to receive(:find).with(org2.id.to_s) { org2 }
+      expect(org1).to receive(:combine!).with(org2)
+      put :combine, id: org1, organization: { combine_with_id: org2 }
+    end
+
+    it 'redirects to the CCLA signatures page' do
+      put :combine, id: org1, organization: { combine_with_id: org2 }
+      expect(response).to redirect_to(ccla_signatures_path)
+    end
+
+    it 'contains a helpful flash message' do
+      put :combine, id: org1, organization: { combine_with_id: org2 }
+      expect(request.flash[:notice]).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
:fork_and_knife: 

A bunch of stuff happening here.
- adding a "signed on" date to the organization drop down menu when picking one to combine
- I18N flash messages for organization deletion and combining
- disallow combining an org with itself
- OrganizationsController is a bit more internally consistent
- random Rails refactorings because why not
- more specs
