### PR TITLE
URLs in the universe API use the same scheme as Supermarket

### DIFF
--- a/app/controllers/api/v1/universe_controller.rb
+++ b/app/controllers/api/v1/universe_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::UniverseController < Api::V1Controller
   #
   def index
     universe = Rails.cache.fetch(CACHE_KEY) do
-      Universe.generate(protocol: (request.ssl? ? 'https' : 'http'))
+      Universe.generate(protocol: ENV.fetch('PROTOCOL', 'http'))
     end
 
     SegmentIO.track_server_event('universe_api_visit', current_user)


### PR DESCRIPTION
:fork_and_knife:

The Universe API is accessible via HTTP, but that does not necessarily mean that the whole app is accessible via HTTP. In particular, in production, download URLs are only accessible via HTTPS. This PR prevents an HTTP request from warming the cache with insecure download URLs, which end up breaking Berkshelf clients which do not follow the HTTP to HTTPS redirect.
