### PR TITLE
Add more useful account error messages

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -14,8 +14,7 @@ class AccountsController < ApplicationController
       redirect_to after_link_location, notice: "Successfully
         connected #{request.env['omniauth.auth']['provider']}."
     else
-      redirect_to edit_profile_path, alert: "Something went wrong
-        while connecting #{request.env['omniauth.auth']['provider']}"
+      redirect_to edit_profile_path, alert: account.errors.full_messages.join(', ')
     end
   end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -9,10 +9,26 @@ class Account < ActiveRecord::Base
   validates :uid, presence: true
   validates :provider, presence: true
   validates :oauth_token, presence: true
-  validates :provider, uniqueness: { scope: :username }
+  validate :unique_username_and_provider, on: :create
 
   # Scope
   # --------------------
   scope :for, ->(id) { where(provider: id) }
   scope :with_username, ->(username) { where(username: username) }
+
+  private
+
+  #
+  # If an account already exists with the same username and provider
+  # then add a helpful error message to the records base errors.
+  #
+  def unique_username_and_provider
+    if Account.exists?(provider: provider, username: username)
+      errors[:base] << I18n.t(
+        'account.already_connected',
+        provider: provider.titleize,
+        username: username
+      )
+    end
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,8 @@ en:
     must_be_signed_in: "You must be signed in to do that."
     made_admin: "%{name} is now an admin."
     revoked_admin: "%{name} is no longer an admin."
+  account:
+    already_connected: "The %{provider} account (%{username}) you're trying to link is already linked to another Supermarket user."
   cookbook:
     transfered_ownership: "%{cookbook} transfered to %{user}."
   profile:

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -10,7 +10,14 @@ describe Account do
     it { should validate_presence_of(:uid) }
     it { should validate_presence_of(:provider) }
     it { should validate_presence_of(:oauth_token) }
-    it { should validate_uniqueness_of(:provider).scoped_to(:username) }
+
+    it 'validates the uniqueness of username scoped to provider with a custom error message' do
+      create(:account, provider: 'github', username: 'johndoe')
+      account = build(:account, provider: 'github', username: 'johndoe')
+      account.save
+
+      expect(account.errors.full_messages.to_s).to match(/The Github account \(johndoe\)/)
+    end
   end
 
   context 'scopes' do


### PR DESCRIPTION
:fork_and_knife: Currently if a account fails to save it just displays an error with a generic error message. This makes two changes to improve error messages when connecting an account (currently only GitHub).
1. Display any and all error messages from ActiveRecord validations in the flash alert.
2. Use a custom validator instead of the standard uniqueness validation in order to add a custom error message that includes the account provider and username in question so the user understands that this account is already linked in Supermarket.

![screen shot 2014-07-14 at 10 16 51 am](https://cloud.githubusercontent.com/assets/316507/3573942/ec60cb38-0b77-11e4-9f27-75b0dbf1aaff.png)
