### PR TITLE
Cleanup styles from big style refactor

### DIFF
--- a/app/assets/stylesheets/structure.scss
+++ b/app/assets/stylesheets/structure.scss
@@ -166,7 +166,7 @@ fieldset {
     margin: rem-calc(20 0 20 0);
   }
 
-  p a, p a:visited, ul:not(.f-dropdown) a, ul:not(.f-dropdown) a:visited, ol a, ol a:visited {
+  p a, p a:visited, .pretty a, .pretty a:visited {
     color: $secondary_gray;
     text-decoration: underline;
   }

--- a/app/views/contributors/_sidebar.html.erb
+++ b/app/views/contributors/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <div class="sidebar" data-equalizer-watch>
   <h3>Chef's Open Source Projects</h3>
 
-  <ul>
+  <ul class="pretty">
     <% Curry::Repository.all.each do |repository| %>
       <li class="repository"><%= link_to repository.full_name, "https://github.com/#{repository.owner}/#{repository.name}", target: "_blank" %></li>
     <% end %>
@@ -18,7 +18,7 @@
       <p>You have not signed the Individual Contributor License Agreement (ICLA) yet. If you are interested in contributing to Chef's open source projects as an individual, <%= link_to "you must sign the ICLA", new_icla_signature_path %>.</p>
     <% end %>
 
-    <ul>
+    <ul class="pretty">
       <% if current_user.signed_icla? %>
         <li>
           <%= link_to "Signed ICLA on #{current_user.latest_icla_signature.signed_at.to_s(:longish)}", current_user.latest_icla_signature, rel: 'icla-signature' %>

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -60,7 +60,7 @@
     <% end %>
 
     <h4>Resources</h4>
-    <ul class="resources">
+    <ul class="pretty">
       <li><%= link_to 'Join IRC', 'irc://irc.freenode.net/chef' %></li>
       <li><%= link_to 'View botbot IRC Logs', 'https://botbot.me/freenode/chef', target: 'blank' %></li>
       <li><%= link_to 'Getting Started with Chef and Cookbooks', 'https://wiki.opscode.com/display/ChefCN/Creating+New+Cookbooks', target: 'blank' %></li>


### PR DESCRIPTION
:fork_and_knife: I noticed a few minor things that needed to be cleaned up from the big sidebar style clean up of 2014. Namely this changes so the gray underlined links in the sidebar are only default within p tags and ul, ol tags that have the pretty class, this prevents the cookbook listings on the dashboard and such from taking on this style.
