### PR TITLE
Cookbook versions should be sorted the same on cookbook version show

### DIFF
--- a/app/controllers/cookbook_versions_controller.rb
+++ b/app/controllers/cookbook_versions_controller.rb
@@ -26,7 +26,7 @@ class CookbookVersionsController < ApplicationController
   # Displays information about this particular cookbook version
   #
   def show
-    @cookbook_versions = @cookbook.cookbook_versions
+    @cookbook_versions = @cookbook.sorted_cookbook_versions
     @owner = @cookbook.owner
     @collaborators = @cookbook.collaborators
     @supported_platforms = @version.supported_platforms


### PR DESCRIPTION
:fork_and_knife: We're using `Cookbook#sorted_cookbook_versions` on cookbook show but not on cookbook version show this is really confusing so this changes cookbook version show to use the same scope.
