### PR TITLE
Sort Curry results

### DIFF
--- a/app/controllers/curry/repositories_controller.rb
+++ b/app/controllers/curry/repositories_controller.rb
@@ -8,7 +8,7 @@ class Curry::RepositoriesController < ApplicationController
   # Displays the Curry::Repositories index
   #
   def index
-    @repositories = Curry::Repository.all.sort_by {|r| r.full_name}
+    @repositories = Curry::Repository.all.sort_by { |r| r.full_name }
     @repository = Curry::Repository.new
   end
 
@@ -28,7 +28,7 @@ class Curry::RepositoriesController < ApplicationController
                   notice: t('curry.repositories.subscribe.success')
     else
       @repository = subscriber.repository
-      @repositories = Curry::Repository.all.sort_by {|r| r.full_name}
+      @repositories = Curry::Repository.all.sort_by { |r| r.full_name }
 
       flash.now[:alert] = t('curry.repositories.subscribe.failure')
 


### PR DESCRIPTION
:fork_and_knife: When viewing watched repositories it isn't always clear that you
actually added the repo. This gives a sort order so you can visually
identify that the repo you just added is on the list.
