### PR TITLE
Display the current_user's tools in the dashboard sidebar.

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -23,6 +23,7 @@ class PagesController < ApplicationController
   def dashboard
     @cookbooks = current_user.owned_cookbooks.limit(5)
     @collaborated_cookbooks = current_user.collaborated_cookbooks.limit(5)
+    @tools = current_user.tools.limit(5)
     @followed_cookbook_activity = current_user.followed_cookbook_versions.order('created_at DESC').limit(50)
   end
 end

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -57,6 +57,18 @@
       </p>
     <% end %>
 
+    <% if ENV['TOOLS_ENABLED'] == 'true' %>
+      <h3>Tools You Maintain</h3>
+      <% if @tools.any? %>
+        <ul class="tools_listing">
+          <%= render partial: 'tools/simple_tool', collection: @tools, as: 'tool' %>
+        </ul>
+        <%= link_to 'View All Tools You Maintain', tools_user_path(current_user), class: 'button radius small expand' %>
+      <% else %>
+        <p>It looks like you have not added any Tools to Supermarket. <%= link_to "Add your Tools", new_tool_path %> if you maintain any knife plugins, ohai plugins or chef tools.</p>
+      <% end %>
+    <% end %>
+
     <h4>Resources</h4>
     <ul class="pretty">
       <li><%= link_to 'Join IRC', 'irc://irc.freenode.net/chef' %></li>

--- a/app/views/tools/_simple_tool.html.erb
+++ b/app/views/tools/_simple_tool.html.erb
@@ -1,0 +1,3 @@
+<li>
+  <%= link_to tool.name, tools_user_path(tool.user) %>
+</li>

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -50,6 +50,12 @@ describe PagesController do
 
         expect(assigns[:collaborated_cookbooks]).to_not be_nil
       end
+
+      it 'assigns tools' do
+        get :dashboard
+
+        expect(assigns[:tools]).to_not be_nil
+      end
     end
 
     context 'user is not signed in' do


### PR DESCRIPTION
:fork_and_knife: 

This deviates from [the design](https://projects.invisionapp.com/share/YR11UBDT2#/screens) of tools in the dashboard, but I think it does a more effective job at simply displaying the current user's tools in the Dashboard.

What does everyone else think?

Note: the simple tool partial lists to the user's tools list because the tool show does not exist at this time. We will want to change that.
