### PR TITLE
Drop verified_cookbook_versions table

### DIFF
--- a/db/migrate/20140717181555_remove_verified_cookbook_versions.rb
+++ b/db/migrate/20140717181555_remove_verified_cookbook_versions.rb
@@ -1,0 +1,7 @@
+class RemoveVerifiedCookbookVersions < ActiveRecord::Migration
+  def change
+    if table_exists?(:verified_cookbook_versions)
+      drop_table :verified_cookbook_versions
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140715221702) do
+ActiveRecord::Schema.define(version: 20140717181555) do
 
   create_table "accounts", force: true do |t|
     t.integer  "user_id"


### PR DESCRIPTION
:fork_and_knife: 

The commit that introduced the table was later reverted, but that doesn't drop the table. There's no need for the table anymore, so for folks who ran the migration to add it, this migration will remove it.
