### PR TITLE
Use the ICLA Signature record for names in table.

### DIFF
--- a/app/views/icla_signatures/index.html.erb
+++ b/app/views/icla_signatures/index.html.erb
@@ -18,7 +18,7 @@
           <tbody>
             <% @icla_signatures.each do |icla_signature| %>
               <tr class="contributor">
-                <td><%= link_to "#{icla_signature.user.first_name} #{icla_signature.user.last_name}", icla_signature.user %></td>
+                <td><%= link_to "#{icla_signature.first_name} #{icla_signature.last_name}", icla_signature.user %></td>
                 <td><%= icla_signature.signed_at.to_date.to_s(:long) %></td>
                 <td>
                   <% icla_signature.user.accounts.for('github').each do |account| %>


### PR DESCRIPTION
:fork_and_knife: 

A user may or may not have a first and last name in their user record. The ICLA
Signature record for that user should _always_ have a first and last name (as
it is required). This updates the ICLA signers table to use the first and last
name from the signature record instead of the user record.
