### PR TITLE
Organizations index should be CclaSignatures json index

### DIFF
--- a/app/assets/javascripts/organizations.js
+++ b/app/assets/javascripts/organizations.js
@@ -10,17 +10,20 @@ $(function () {
       dataType: 'json',
       quietMillis: 200,
       data: function (term, page) {
-        return { q: term };
+        return {q: term};
       },
       results: function (data, page) {
         return {results: data};
       }
     },
     formatSelection: function(obj, container) {
-      return obj.name;
+      return obj.company + ', signed on ' + obj.signed_at;
     },
     formatResult: function(obj, container, query) {
-      return obj.name + ', signed on ' + obj.signed_at;
+      return obj.company + ', signed on ' + obj.signed_at;
+    },
+    id: function(obj) {
+      return obj.organization_id
     }
   }
 

--- a/app/controllers/ccla_signatures_controller.rb
+++ b/app/controllers/ccla_signatures_controller.rb
@@ -9,6 +9,19 @@ class CclaSignaturesController < ApplicationController
   #
   def index
     @ccla_signatures = CclaSignature.by_organization
+
+    if params[:q]
+      @ccla_signatures = @ccla_signatures.search(params[:q])
+    end
+
+    if params[:exclude_id]
+      @ccla_signatures = @ccla_signatures.where('organization_id <> ?', params[:exclude_id])
+    end
+
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
 
   #

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -4,23 +4,6 @@ class OrganizationsController < ApplicationController
   skip_before_filter :verify_authenticity_token, only: [:index]
 
   #
-  # GET /organizations
-  #
-  # Lists out all organizations.
-  #
-  def index
-    @ccla_signatures = if params[:q]
-                         CclaSignature.search(params[:q])
-                       else
-                         CclaSignature.all
-                       end
-
-    if params[:exclude_id]
-      @ccla_signatures = @ccla_signatures.where('organization_id <> ?', params[:exclude_id])
-    end
-  end
-
-  #
   # GET /organizations/:id
   #
   # Shows the management page for an organization, allowing deletion and

--- a/app/views/ccla_signatures/index.json.jbuilder
+++ b/app/views/ccla_signatures/index.json.jbuilder
@@ -1,0 +1,6 @@
+json.array! @ccla_signatures do |signature|
+  json.id signature.id
+  json.organization_id signature.organization_id
+  json.company signature.company
+  json.signed_at signature.signed_at.to_s(:longish)
+end

--- a/app/views/organizations/index.json.jbuilder
+++ b/app/views/organizations/index.json.jbuilder
@@ -1,5 +1,0 @@
-json.array! @ccla_signatures do |signature|
-  json.id signature.organization_id
-  json.name signature.company
-  json.signed_at signature.signed_at.to_s(:long)
-end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -12,7 +12,7 @@
       <%= form_for @organization, url: { action: 'combine' }, method: :put do |f| %>
         <div class="row collapse">
           <div class="small-10 columns">
-            <%= f.hidden_field :combine_with_id, class: 'transfer-ccla-organization', 'data-url' => organizations_path(exclude_id: @organization) %>
+            <%= f.hidden_field :combine_with_id, class: 'transfer-ccla-organization', 'data-url' => ccla_signatures_path(exclude_id: @organization) %>
           </div>
           <div class="small-2 columns">
             <%= f.submit 'Combine', class: 'button postfix radius' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,7 +107,7 @@ Supermarket::Application.routes.draw do
     end
   end
 
-  resources :organizations, only: [:index, :show, :destroy] do
+  resources :organizations, only: [:show, :destroy] do
     member do
       put :combine
     end

--- a/spec/controllers/ccla_signatures_controller_spec.rb
+++ b/spec/controllers/ccla_signatures_controller_spec.rb
@@ -3,14 +3,42 @@ require 'spec_helper'
 describe CclaSignaturesController do
   context 'routes not requiring authentication' do
     describe 'GET #index' do
-      let(:ccla_signature) { create(:ccla_signature) }
-      before { get :index }
+      let!(:org1) { create(:organization) }
+      let!(:org2) { create(:organization) }
+      let!(:ccla_signature1) { create(:ccla_signature, organization: org1, company: 'International House of Pancakes') }
+      let!(:ccla_signature2) { create(:ccla_signature, organization: org2, company: "Bob's House of Pancakes") }
 
-      it { should respond_with(200) }
-      it { should render_template('index') }
+      context 'the format is html' do
+        before { get :index }
 
-      it 'assigns @ccla_signatures' do
-        expect(assigns(:ccla_signatures)).to include(ccla_signature)
+        it { should respond_with(200) }
+        it { should render_template('index') }
+
+        it 'assigns @ccla_signatures' do
+          expect(assigns(:ccla_signatures)).to include(ccla_signature1)
+        end
+      end
+
+      context 'the format is json' do
+        it 'succeeds' do
+          get :index, format: :json
+          expect(response).to be_success
+        end
+
+        it 'assigns organizations' do
+          get :index, format: :json
+          expect(assigns(:ccla_signatures)).to include(ccla_signature1, ccla_signature2)
+        end
+
+        it 'filters organizations when you pass in a search parameter' do
+          get :index, q: 'international', format: :json
+          expect(assigns(:ccla_signatures)).to include(ccla_signature1)
+        end
+
+        it 'excludes the current organization from search results' do
+          get :index, exclude_id: org1.id, format: :json
+          expect(assigns(:ccla_signatures).to_a).to_not include(ccla_signature1)
+        end
       end
     end
 

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -3,31 +3,7 @@ require 'spec_helper'
 describe OrganizationsController do
   let!(:org1) { create(:organization) }
   let!(:org2) { create(:organization) }
-  let!(:ccla_signature1) { create(:ccla_signature, organization: org1, company: 'International House of Pancakes') }
-  let!(:ccla_signature2) { create(:ccla_signature, organization: org2, company: "Bob's House of Pancakes") }
   let!(:admin) { create(:user, roles: 'admin') }
-
-  describe 'GET #index' do
-    it 'succeeds' do
-      get :index, format: :json
-      expect(response).to be_success
-    end
-
-    it 'assigns organizations' do
-      get :index, format: :json
-      expect(assigns(:ccla_signatures)).to include(ccla_signature1, ccla_signature2)
-    end
-
-    it 'filters organizations when you pass in a search parameter' do
-      get :index, q: 'international', format: :json
-      expect(assigns(:ccla_signatures)).to include(ccla_signature1)
-    end
-
-    it 'excludes the current organization from search results' do
-      get :index, exclude_id: org1.id, format: :json
-      expect(assigns(:ccla_signatures).to_a).to_not include(ccla_signature1)
-    end
-  end
 
   describe 'GET #show' do
     before do


### PR DESCRIPTION
:fork_and_knife: Since organizations index actually returns `CclaSignature`s what is now the organizations index should be the json format of the `CclaSignaturesController`. This feature now also now uses the `CclaSignature.by_organization` scope so the `CclaSignature`s returned are unique by organization, this should resolve any current confusion surrounding this feature.

_This should address the last two QA items on [this card](https://trello.com/c/VrGr5RM4/211-allow-supermarket-admins-to-combine-ccla-organizations), mainly just the use of `CclaSignature.by_organization` addresses these issues. Moving the action to the CclaSignatures isn't related to the bug but it seemed to make more sense and it allows us to use the same scope call that's already being used for the HTML response._
