### PR TITLE
Don't track API downloads in Segment.IO

### DIFF
--- a/app/controllers/api/v1/cookbook_versions_controller.rb
+++ b/app/controllers/api/v1/cookbook_versions_controller.rb
@@ -25,13 +25,6 @@ class Api::V1::CookbookVersionsController < Api::V1Controller
     CookbookVersion.increment_counter(:api_download_count, @cookbook_version.id)
     Cookbook.increment_counter(:api_download_count, @cookbook.id)
 
-    SegmentIO.track_server_event(
-      'cookbook_version_api_download',
-      current_user,
-      cookbook: @cookbook.name,
-      version: @cookbook_version.version
-    )
-
     redirect_to @cookbook_version.tarball.url
   end
 end

--- a/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
@@ -73,19 +73,6 @@ describe Api::V1::CookbookVersionsController do
       end.to change { cookbook.reload.api_download_count }.by(1)
     end
 
-    it 'tracks the download in SegmentIO' do
-      get :download, cookbook: cookbook.name, version: version.to_param, format: :json
-
-      expect(SegmentIO.last_event).to eql(
-        name: 'cookbook_version_api_download',
-        user_id: 'anonymous',
-        properties: {
-          cookbook: cookbook.name,
-          version: version.version
-        }
-      )
-    end
-
     it '404s when the cookbook does not exist' do
       get :download, cookbook: 'snarfle', version: '100.1.1', format: :json
 


### PR DESCRIPTION
:fork_and_knife: 

Eventually we'll move all this stuff to StatsD. For now, we remove the noisiest metric.
