### PR TITLE
Add utf8-cleaner gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'semverse'
 gem 'sitemap_generator'
 gem 'redis-rails'
 gem 'yajl-ruby'
+gem 'utf8-cleaner'
 
 gem 'sentry-raven', '~> 0.8.0', require: false
 gem 'analytics-ruby', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,6 +406,7 @@ GEM
     unicorn-rails (1.1.0)
       rack
       unicorn
+    utf8-cleaner (0.0.9)
     uuidtools (2.1.4)
     validate_url (0.2.0)
       activemodel (>= 3.0.0)
@@ -479,6 +480,7 @@ DEPENDENCIES
   uglifier (~> 2.2)
   unicorn
   unicorn-rails
+  utf8-cleaner
   validate_url
   vcr
   virtus


### PR DESCRIPTION
:fork_and_knife: If you make a request to Supermarket with invalid utf8 params it will raise an exception because of a Rails bug explained here: http://dev.mensfeld.pl/2014/03/rack-argument-error-invalid-byte-sequence-in-utf-8. The utf8-cleaner gem sanitizes invalid utf8 strings preventing these exceptions.
