### PR TITLE
Refactor follow/unfollow button AJAX

### DIFF
--- a/app/assets/javascripts/cookbookFollowing.js
+++ b/app/assets/javascripts/cookbookFollowing.js
@@ -32,12 +32,12 @@ $(function() {
    * the partial in question with server side rendered HTML.
    */
   $('body').delegate('.listing .follow', 'ajax:success', function(e, data, status, xhr) {
-    var cookbookId = '#' + $(this).data('cookbook');
+    var followCountId = '#' + $(this).data('cookbook') + '-follow-count';
+    var followButtonId = '#' + $(this).data('cookbook') + '-follow-button';
     trackFollows(this);
 
-    $.get(window.location.href, function(response) {
-      $(cookbookId).replaceWith($(response).find(cookbookId));
-    }, 'html');
+    $(followCountId).replaceWith($(data).filter(followCountId));
+    $(followButtonId).replaceWith($(data).filter(followButtonId));
   });
 
   /*
@@ -46,9 +46,6 @@ $(function() {
    */
   $('body').delegate('.cookbook_show .follow', 'ajax:success', function(e, data, status, xhr) {
     trackFollows(this);
-
-    $.get(window.location.href, function(response) {
-      $('.followbutton').replaceWith($(response).find('.followbutton'));
-    }, 'html');
+    $('.followbutton').replaceWith(data);
   });
 });

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -120,7 +120,7 @@ class CookbooksController < ApplicationController
   def follow
     @cookbook.cookbook_followers.create(user: current_user)
 
-    head 200
+    render_follow_button
   end
 
   #
@@ -133,7 +133,7 @@ class CookbooksController < ApplicationController
       where(user: current_user).first!
     cookbook_follower.destroy
 
-    head 200
+    render_follow_button
   end
 
   #
@@ -200,5 +200,17 @@ class CookbooksController < ApplicationController
 
   def cookbook_deprecation_params
     params.require(:cookbook).permit(:replacement)
+  end
+
+  def render_follow_button
+    # In order to refresh the follower count the cookbook must be
+    # reloaded before rendering.
+    @cookbook.reload
+
+    if params[:list].present?
+      render partial: 'follow_button_list', locals: { cookbook: @cookbook }
+    else
+      render partial: 'follow_button_show', locals: { cookbook: @cookbook }
+    end
   end
 end

--- a/app/helpers/cookbooks_helper.rb
+++ b/app/helpers/cookbooks_helper.rb
@@ -75,12 +75,13 @@ module CookbooksHelper
   #   <% end %>
   #
   # @param cookbook [Cookbook] the Cookbook to follow or unfollow
+  # @param params [Hash] any additional query params to add to the follow button
   # @yieldparam following [Boolean] whether or not the +current_user+ is
   #   following the given +Cookbook+
   #
   # @return [String] a link based on the following state for the current cookbook.
   #
-  def follow_button_for(cookbook, &block)
+  def follow_button_for(cookbook, params = {}, &block)
     fa_icon = content_tag(:i, '', class: 'fa fa-users')
     followers_count = cookbook.cookbook_followers_count.to_s
     followers_count_span = content_tag(
@@ -91,7 +92,7 @@ module CookbooksHelper
 
     unless current_user
       return link_to(
-        follow_cookbook_path(cookbook),
+        follow_cookbook_path(cookbook, params),
         method: 'put',
         rel: 'sign-in-to-follow',
         class: 'button radius tiny follow',
@@ -108,7 +109,7 @@ module CookbooksHelper
 
     if cookbook.followed_by?(current_user)
       link_to(
-        unfollow_cookbook_path(cookbook),
+        unfollow_cookbook_path(cookbook, params),
         method: 'delete',
         rel: 'unfollow',
         class: 'button radius tiny follow',
@@ -124,7 +125,7 @@ module CookbooksHelper
       end
     else
       link_to(
-        follow_cookbook_path(cookbook),
+        follow_cookbook_path(cookbook, params),
         method: 'put',
         rel: 'follow',
         class: 'button radius tiny follow',

--- a/app/views/cookbooks/_cookbook.html.erb
+++ b/app/views/cookbooks/_cookbook.html.erb
@@ -1,4 +1,4 @@
-<li id="<%= cookbook.name %>">
+<li>
   <div class="header">
     <div class="header-content">
       <h2 class="title">
@@ -61,16 +61,7 @@
           <%= cookbook.download_count %>
           <h5><%= "Download".pluralize(cookbook.download_count) %></h5>
         </li>
-        <li>
-          <i class="fa fa-group"></i>
-          <%= cookbook.cookbook_followers_count %>
-          <h5><%= "Follower".pluralize(cookbook.cookbook_followers_count) %></h5>
-        </li>
-        <li>
-          <%= follow_button_for(cookbook) do |following| %>
-            <%= following ? "Unfollow" : "Follow" %>
-          <% end %>
-        </li>
+        <%= render 'cookbooks/follow_button_list', cookbook: cookbook %>
       </ul>
     </div>
   </div>

--- a/app/views/cookbooks/_follow_button_list.html.erb
+++ b/app/views/cookbooks/_follow_button_list.html.erb
@@ -1,0 +1,10 @@
+<li id="<%= cookbook.name %>-follow-count">
+  <i class="fa fa-group"></i>
+  <%= cookbook.cookbook_followers_count %>
+  <h5><%= "Follower".pluralize(cookbook.cookbook_followers_count) %></h5>
+</li>
+<li id="<%= cookbook.name %>-follow-button">
+  <%= follow_button_for(cookbook, list: true) do |following| %>
+    <%= following ? "Unfollow" : "Follow" %>
+  <% end %>
+</li>

--- a/app/views/cookbooks/_follow_button_show.html.erb
+++ b/app/views/cookbooks/_follow_button_show.html.erb
@@ -1,0 +1,3 @@
+<small class="followbutton">
+  <%= follow_button_for(cookbook) %>
+</small>

--- a/app/views/cookbooks/_main.html.erb
+++ b/app/views/cookbooks/_main.html.erb
@@ -40,9 +40,7 @@
         </li>
       </ul>
     </small>
-    <small class="followbutton">
-      <%= follow_button_for(cookbook) %>
-    </small>
+    <%= render 'follow_button_show', cookbook: @cookbook %>
   </h1>
 
   <pre class="install">knife cookbook site install <%= cookbook.name %></pre>

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -267,6 +267,18 @@ describe CookbooksController do
 
         expect(response.status.to_i).to eql(200)
       end
+
+      it 'renders the show follow button partial' do
+        put :follow, id: cookbook
+
+        expect(response).to render_template('cookbooks/_follow_button_show')
+      end
+
+      it 'renders the list follow button partial if the list param is present' do
+        put :follow, id: cookbook, list: true
+
+        expect(response).to render_template('cookbooks/_follow_button_list')
+      end
     end
 
     context 'a user is not signed in' do
@@ -308,6 +320,18 @@ describe CookbooksController do
         delete :follow, id: cookbook
 
         expect(response.status.to_i).to eql(200)
+      end
+
+      it 'renders the show follow button partial' do
+        delete :follow, id: cookbook
+
+        expect(response).to render_template('cookbooks/_follow_button_show')
+      end
+
+      it 'renders the list follow button partial if the list param is present' do
+        put :follow, id: cookbook, list: true
+
+        expect(response).to render_template('cookbooks/_follow_button_list')
       end
     end
 

--- a/spec/helpers/cookbooks_helper_spec.rb
+++ b/spec/helpers/cookbooks_helper_spec.rb
@@ -35,6 +35,18 @@ describe CookbooksHelper do
       expect(helper.follow_button_for(cookbook)).to match(/follow/)
     end
 
+    it 'returns a follow button with query params if any are given' do
+      cookbook = double(
+        :cookbook,
+        followed_by?: false,
+        cookbook_followers_count: 100,
+        name: 'redis'
+      )
+      helper.stub(:current_user) { true }
+
+      expect(helper.follow_button_for(cookbook, list: true)).to match(/\?list=true/)
+    end
+
     it 'returns an unfollow button if the current user follows the given cookbook' do
       cookbook = double(
         :cookbook,


### PR DESCRIPTION
:fork_and_knife: Rather than re-rendering the entire view and manipulating the dom upon a successful follow/unfollow request this moves the follow buttons (for the show view and the partial) into a partial and renders them upon a successful follow/unfollow then inserts the results into the dom.
