### PR TITLE
Separate cache keys for the universe endpoint

### DIFF
--- a/app/controllers/api/v1/cookbook_uploads_controller.rb
+++ b/app/controllers/api/v1/cookbook_uploads_controller.rb
@@ -65,7 +65,7 @@ class Api::V1::CookbookUploadsController < Api::V1Controller
             cookbook: @cookbook.name
           )
 
-          UniverseCache.delete
+          universe_cache.delete
 
           render :create, status: 201
         end
@@ -103,7 +103,7 @@ class Api::V1::CookbookUploadsController < Api::V1Controller
           cookbook: @cookbook.name
         )
 
-        UniverseCache.delete
+        universe_cache.delete
       end
     end
   end
@@ -123,6 +123,10 @@ class Api::V1::CookbookUploadsController < Api::V1Controller
   end
 
   private
+
+  def universe_cache
+    UniverseCache.new(request.protocol)
+  end
 
   def error(body, status = 400)
     render json: body, status: status

--- a/app/controllers/api/v1/universe_controller.rb
+++ b/app/controllers/api/v1/universe_controller.rb
@@ -7,13 +7,19 @@ class Api::V1::UniverseController < Api::V1Controller
   # dependency/platform information.
   #
   def index
-    universe = UniverseCache.fetch do
-      Universe.generate(protocol: UniverseCache.protocol)
+    universe = universe_cache.fetch do
+      Universe.generate(protocol: universe_cache.protocol)
     end
 
     SegmentIO.track_server_event('universe_api_visit', current_user)
     Universe.track_hit
 
     render json: MultiJson.dump(universe)
+  end
+
+  private
+
+  def universe_cache
+    UniverseCache.new(request.protocol)
   end
 end

--- a/app/models/universe_cache.rb
+++ b/app/models/universe_cache.rb
@@ -1,5 +1,7 @@
-module UniverseCache
-  module_function
+class UniverseCache
+  def initialize(protocol)
+    @raw_protocol = protocol
+  end
 
   #
   # Fetch something from the cache
@@ -30,11 +32,12 @@ module UniverseCache
   end
 
   #
-  # Returns the protocol to use, based on the environment variables
+  # Returns the protocol in a way appropriate for cache key usage, e.g. for
+  # a protocol string of "http://", this method will return "http"
   #
-  # @return [String] HTTP protocol to use
+  # @return [String] the protocol string
   #
   def protocol
-    ENV.fetch('PROTOCOL', 'http')
+    @protocol ||= @raw_protocol[0..-4]
   end
 end

--- a/spec/api/universe_spec.rb
+++ b/spec/api/universe_spec.rb
@@ -58,23 +58,17 @@ describe 'GET /universe' do
   it 'has an http specific cache key' do
     expect(Rails.cache).to receive(:fetch).with('http-universe')
 
-    with_env('PROTOCOL' => 'http') do
-      get '/universe', format: :json
-    end
+    get '/universe', format: :json
   end
 
   it 'has an https specific cache key' do
     expect(Rails.cache).to receive(:fetch).with('https-universe')
 
-    with_env('PROTOCOL' => 'https') do
-      get '/universe', format: :json
-    end
+    get '/universe', { format: :json }, 'HTTPS' => 'on'
   end
 
   it "returns https URLs when ENV['PROTOCOL']=https" do
-    with_env('PROTOCOL' => 'https') do
-      get '/universe', format: :json
-    end
+    get '/universe', { format: :json }, 'HTTPS' => 'on'
 
     expect(response).to be_success
     expect(json_body['redis']['1.2.0']['location_path']).to match(%r{https://.*/api/v1})

--- a/spec/controllers/api/v1/cookbook_uploads_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbook_uploads_controller_spec.rb
@@ -34,7 +34,7 @@ describe Api::V1::CookbookUploadsController do
       end
 
       it 'regenerates the universe cache' do
-        expect(UniverseCache).to receive(:delete)
+        expect_any_instance_of(UniverseCache).to receive(:delete)
         post :create, cookbook: 'cookbook', tarball: 'tarball', format: :json
       end
     end
@@ -137,7 +137,7 @@ describe Api::V1::CookbookUploadsController do
       end
 
       it 'regenerates the universe cache' do
-        expect(UniverseCache).to receive(:delete)
+        expect_any_instance_of(UniverseCache).to receive(:delete)
         unshare
       end
     end


### PR DESCRIPTION
:fork_and_knife: 

https://trello.com/c/eU13FGwZ/315-maintain-two-cache-keys-for-the-berkshelf-universe-api-one-for-http-and-one-for-https

Previously, there was only one cache key.  Now there are two:  one for HTTP and one for HTTPS.
