### PR TITLE
Make copy for version downloads clearer

### DIFF
--- a/app/views/cookbooks/_sidebar.html.erb
+++ b/app/views/cookbooks/_sidebar.html.erb
@@ -137,8 +137,8 @@
     <p><%= version.license %></p>
 
     <h4 class="cookbook_show_sidebar_downloads">
-      <i class="fa fa-download"></i> <%= version.download_count %> Downloads of Version <%= version.version %>
-      <small><%= cookbook.download_count %> Total Downloads</small>
+      <i class="fa fa-download"></i> <%= number_with_delimiter(version.download_count) %> Downloads of Version <%= version.version %>
+      <small><%= number_with_delimiter(cookbook.download_count) %> Total Downloads</small>
     </h4>
     <%= link_to "Download Cookbook", download_cookbook_path(cookbook), class: 'button secondary radius expand button_download_cookbook' %>
   </div>


### PR DESCRIPTION
:fork_and_knife: We currently display the number of downloads for the current version being viewed so we should make the copy more clear to convey that. Know looks like:

![screen shot 2014-07-22 at 3 09 33 pm](https://cloud.githubusercontent.com/assets/316507/3663509/c6ccf29a-11d3-11e4-8306-8fe389462f14.png)
