### PR TITLE
Remove usermenu z-index

### DIFF
--- a/app/assets/stylesheets/appheader.scss
+++ b/app/assets/stylesheets/appheader.scss
@@ -157,7 +157,6 @@
   margin-left: rem-calc(20);
   position: relative;
   @include single-transition(color, $speed: 100ms);
-  z-index: 101;
 
   &:hover {
     .userdropdown { display: block; }


### PR DESCRIPTION
:fork_and_knife: The z-index for the usermenu is no longer needed and it is causing a bug when modals are open so this removes the z-index declaration.

From

![screen shot 2014-07-22 at 3 15 49 pm](https://cloud.githubusercontent.com/assets/316507/3663637/24203ed8-11d5-11e4-84f0-6945d6bc2a52.png)

To

![screen shot 2014-07-22 at 3 20 20 pm](https://cloud.githubusercontent.com/assets/316507/3663651/3b7353c2-11d5-11e4-9ce3-813ef6d43dc2.png)
