### PR TITLE
Only show profiles where both User and Account exist

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -60,6 +60,6 @@ class UsersController < ApplicationController
   private
 
   def assign_user
-    @user = Account.for('chef_oauth2').with_username(params[:id]).first!.user
+    @user = Account.for('chef_oauth2').joins(:user).with_username(params[:id]).first!.user
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -23,6 +23,16 @@ describe UsersController do
 
       expect(assigns[:cookbooks]).to include(followed_cookbook)
     end
+
+    it '404s when when a user somehow has a Chef account but does not exist' do
+      username = user.username
+
+      User.where(id: user.id).delete_all
+
+      get :show, id: user.username, user_tab_string: 'activity'
+
+      expect(response).to render_template('exceptions/404.html.erb')
+    end
   end
 
   describe 'GET #tools' do


### PR DESCRIPTION
:fork_and_knife: 

This is a branch off d65edd72398dc58276b263ff827371ae4eb0ab7a that will address an unusual `Account` which seems to have lost its associated `User`. Will be looking into that further.

Once this is green, I'll deploy without merging to get the fix out, and will keep this branch/PR around until we're all set to push out a new release from master.
