### PR TITLE
The ApplicationController should always respond with HTML

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,11 +23,7 @@ class ApplicationController < ActionController::Base
       options[:notice] = error.message
     end
 
-    respond_to do |format|
-      format.any do
-        render 'exceptions/404.html.erb', options
-      end
-    end
+    render 'exceptions/404.html.erb', options
   end
 
   def after_sign_in_path_for(_resource)


### PR DESCRIPTION
:fork_and_knife:

The respond_to block would respond to JSON requests with the HTML text, but that HTML would not be rendered in the browser due to the response content type. We definitely want the HTML to be rendered.
