### PR TITLE
Remove hard_wrap option

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -4,7 +4,7 @@ module MarkdownHelper
   #
   class SupermarketRenderer < Redcarpet::Render::HTML
     def initialize(extensions = {})
-      super extensions.merge(link_attributes: { target: '_blank' }, with_toc_data: true, hard_wrap: true)
+      super extensions.merge(link_attributes: { target: '_blank' }, with_toc_data: true)
     end
   end
 

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -33,13 +33,13 @@ $ bundle exec rake spec:all
     expect(helper.render_markdown(table)).to match(/<table>/)
   end
 
-  it 'adds br tags on hard wraps' do
+  it "doesn't adds br tags on hard wraps" do
     markdown = <<-EOH
-This is a hard
+There is no hard
 wrap.
     EOH
 
-    expect(helper.render_markdown(markdown)).to match(/<br>/)
+    expect(helper.render_markdown(markdown)).to_not match(/<br>/)
   end
 
   it "doesn't emphasize underscored words" do


### PR DESCRIPTION
I try to limit all lines in markdown files to 80 characters.

Unfortunately, with the `hard_wrap` option, `<br>` tags are inserted for all new lines, which is not the default Markdown behavior ([see doc](https://github.com/vmg/redcarpet#darling-i-packed-you-a-couple-renderers-for-lunch)).

Here is an exemple of a [README](https://raw.githubusercontent.com/odolbeau/cookbook-statsdaemon/master/README.md) with [a pretty bad renderer](https://supermarket.getchef.com/cookbooks/statsdaemon).
