### PR TITLE
Add resource class to cookbook version show

### DIFF
--- a/app/views/cookbook_versions/show.html.erb
+++ b/app/views/cookbook_versions/show.html.erb
@@ -1,7 +1,7 @@
 <%= provide(:title, "#{@cookbook.name} Cookbook") %>
 <%= provide(:description, "#{@cookbook.name} Cookbook (#{@version.version}) #{@version.supported_platforms.map(&:name).join(', ')}".strip) %>
 
-<div class="page cookbook_show" data-equalizer>
+<div class="page resource cookbook_show" data-equalizer>
   <%= render 'cookbooks/main', cookbook: @cookbook, version: @version, cookbook_versions: @cookbook_versions %>
   <%= render 'cookbooks/sidebar', cookbook: @cookbook, version: @version, supported_platforms: @supported_platforms, owner: @owner, collaborators: @collaborators %>
 </div>


### PR DESCRIPTION
:fork_and_knife: The resource class contains a bunch of useful styles for resource show views without things just don't look quite right.

From

![screen shot 2014-07-23 at 7 32 03 am](https://cloud.githubusercontent.com/assets/316507/3672307/4fdfc6fa-125d-11e4-9dec-98b3c1ddbb2d.png)

To

![screen shot 2014-07-23 at 7 32 17 am](https://cloud.githubusercontent.com/assets/316507/3672309/534901bc-125d-11e4-8804-66a2084fc696.png)
