### PR TITLE
Render 404.html.erb only if not in development.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,8 @@ class ApplicationController < ActionController::Base
   protected
 
   def not_found!(error = nil)
+    raise error if error && Rails.env.development?
+
     options = { status: 404 }
 
     if error


### PR DESCRIPTION
:fork_and_knife: 

Rails can help w/ some useful error pages in development, so let's still display
them.
