### PR TITLE
Default unicorn to port 3000 in development

### DIFF
--- a/config/unicorn/development.rb
+++ b/config/unicorn/development.rb
@@ -24,3 +24,5 @@ after_fork do |_server, _worker|
   defined?(ActiveRecord::Base) &&
     ActiveRecord::Base.establish_connection
 end
+
+listen Integer(ENV['PORT'] || 3000)


### PR DESCRIPTION
![Unicorn](http://a.tgcdn.net/images/products/additional/large/1107_unicorn_head_mask_inuse.jpg)

:fork_and_knife: Unicorn should listen on PORT or 3000 by default in development
