### PR TITLE
Tool names shouldn't include leading or trailing whitespace

### DIFF
--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -15,6 +15,7 @@ class Tool < ActiveRecord::Base
   # Callbacks
   # --------------------
   before_validation :copy_name_to_lowercase_name
+  before_validation :strip_name_whitespace
 
   #
   # Query tools by case-insensitive name.
@@ -66,5 +67,13 @@ class Tool < ActiveRecord::Base
   #
   def copy_name_to_lowercase_name
     self.lowercase_name = name.to_s.downcase
+  end
+
+  #
+  # Mostly for purposes of uniqueness validation, names shouldn't
+  # contain leading or trailing whitespace.
+  #
+  def strip_name_whitespace
+    self.name = name.to_s.strip
   end
 end

--- a/spec/models/tool_spec.rb
+++ b/spec/models/tool_spec.rb
@@ -22,6 +22,13 @@ describe Tool do
     end
   end
 
+  describe '#name' do
+    it "doesn't contain leading or trailing whitespace" do
+      tool = create(:tool, name: ' Dingus ')
+      expect(tool.name).to eql('Dingus')
+    end
+  end
+
   describe '.with_name' do
     it 'is case-insensitive' do
       tool = create(:tool, name: 'DINGUS')


### PR DESCRIPTION
:fork_and_knife: 
