### PR TITLE
Support followed cookbook activity feed for users

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -20,27 +20,22 @@
       margin-bottom: 0;
     }
   }
-}
 
-.activity_heading {
-  @include clearfix;
-  border-bottom: rem-calc(2) solid lighten($secondary_gray, 35%);
-
-  a {
-    float: right;
-    font: $bold rem-calc(12) $default_font;
+  .buttons a {
     text-decoration: underline;
   }
 
-  @media #{$mobile-only} {
+  @media #{$small-down} {
     a {
       display: none;
     }
   }
 
-  h3 {
-    float: left;
-    margin-bottom: rem-calc(20);
+  @media #{$large-down} {
+    .heading-with-buttons .title small {
+      display: inline-block;
+      margin-left: 0;
+    }
   }
 }
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -24,6 +24,6 @@ class PagesController < ApplicationController
     @cookbooks = current_user.owned_cookbooks.limit(5)
     @collaborated_cookbooks = current_user.collaborated_cookbooks.limit(5)
     @tools = current_user.tools.limit(5)
-    @followed_cookbook_activity = current_user.followed_cookbook_versions.order('created_at DESC').limit(50)
+    @followed_cookbook_activity = current_user.followed_cookbook_versions.limit(50)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,6 +32,16 @@ class UsersController < ApplicationController
   end
 
   #
+  # GET /users/:id/followed_cookbook_activity
+  #
+  # Displays a feed of cookbook activity for the
+  # cookbooks the specified user follows.
+  #
+  def followed_cookbook_activity
+    @followed_cookbook_activity = @user.followed_cookbook_versions.limit(50)
+  end
+
+  #
   # PUT /users/:id/make_admin
   #
   # Assigns the admin role to a given user then redirects back to

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,7 +61,9 @@ class User < ActiveRecord::Base
   # @return [CookbookVersion]
   #
   def followed_cookbook_versions
-    CookbookVersion.joins(:cookbook).merge(followed_cookbooks)
+    CookbookVersion.joins(:cookbook).
+      merge(followed_cookbooks).
+      order('created_at DESC')
   end
 
   #

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -2,11 +2,16 @@
 
 <div class="page dashboard" data-equalizer>
   <div class="main" data-equalizer-watch>
-    <div class="activity_heading">
-      <h3>Followed Cookbooks Activity</h3>
-      <% if @followed_cookbook_activity.any? %>
-        <%= link_to "You're Following #{pluralize(current_user.followed_cookbooks.count, 'Cookbook')}", user_path(current_user, tab: 'follows') %>
-      <% end %>
+    <div class="heading-with-buttons">
+      <h3 class="title">
+        Followed Cookbooks Activity
+        <small><%= link_to '<i class="fa fa-rss"></i> rss'.html_safe, followed_cookbook_activity_user_path(current_user, format: 'atom'), class: 'rss_feed_link show-for-medium-up' %></small>
+      </h3>
+      <div class="buttons">
+        <% if @followed_cookbook_activity.any? %>
+          <%= link_to "You're Following #{pluralize(current_user.followed_cookbooks.count, 'Cookbook')}", user_path(current_user, tab: 'follows') %>
+        <% end %>
+      </div>
     </div>
     <% if @followed_cookbook_activity.any? %>
       <ul class="activity_list">

--- a/app/views/users/followed_cookbook_activity.atom.builder
+++ b/app/views/users/followed_cookbook_activity.atom.builder
@@ -1,0 +1,13 @@
+atom_feed language: 'en-US' do |feed|
+  feed.title "#{@user.username}'s Followed Cookbook Activity"
+  feed.updated Time.now
+
+  @followed_cookbook_activity.each do |cookbook_version|
+    feed.entry cookbook_version, url: cookbook_version_url(cookbook_version.cookbook, cookbook_version.version) do |entry|
+      entry.title cookbook_version.cookbook.name
+      entry.maintainer cookbook_version.cookbook.maintainer
+      entry.description cookbook_version.description
+      entry.version cookbook_version.version
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Supermarket::Application.routes.draw do
 
       put :make_admin
       delete :revoke_admin
+      get :followed_cookbook_activity, format: :atom
     end
 
     resources :accounts, only: [:destroy]

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -51,6 +51,20 @@ describe UsersController do
     end
   end
 
+  describe 'GET #followed_cookbook_activity' do
+    it 'assigns a user' do
+      get :tools, id: user.username
+
+      expect(assigns[:user]).to eql(user)
+    end
+
+    it "assigns a user's followed cookbook activity" do
+      get :followed_cookbook_activity, id: user.username
+
+      expect(assigns[:followed_cookbook_activity]).to_not be_nil
+    end
+  end
+
   describe 'PUT #make_admin' do
     let(:user) { create(:user) }
 

--- a/spec/views/users/followed_cookbook_activity.atom.builder_spec.rb
+++ b/spec/views/users/followed_cookbook_activity.atom.builder_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe 'users/followed_cookbook_activity.atom.builder' do
+  let(:test_cookbook) do
+    create(
+      :cookbook,
+      name: 'test',
+      cookbook_versions: [
+        create(:cookbook_version, description: 'test cookbook')
+      ],
+      cookbook_versions_count: 0
+    )
+  end
+
+  let(:test_cookbook2) do
+    create(
+      :cookbook,
+      name: 'test-2',
+      cookbook_versions: [
+        create(:cookbook_version, description: 'test cookbook')
+      ],
+      cookbook_versions_count: 0
+    )
+  end
+
+  before do
+    assign(
+      :followed_cookbook_activity,
+      [test_cookbook.cookbook_versions.first, test_cookbook2.cookbook_versions.first]
+    )
+
+    assign(:user, double(User, username: 'johndoe'))
+  end
+
+  it 'displays the feed title' do
+    render
+
+    expect(xml_body['feed']['title']).to eql("johndoe's Followed Cookbook Activity")
+  end
+
+  it 'displays when the feed was updated' do
+    render
+
+    expect(Date.parse(xml_body['feed']['updated'])).to_not be_nil
+  end
+
+  it 'displays followed cookbook activity entries' do
+    render
+
+    expect(xml_body['feed']['entry'].count).to eql(2)
+  end
+
+  it 'displays information about cookbook activity' do
+    render
+
+    activity = xml_body['feed']['entry'].first
+
+    expect(activity['title']).to eql(test_cookbook.name)
+    expect(activity['maintainer']).to eql(test_cookbook.maintainer)
+    expect(activity['description']).to eql(test_cookbook.description)
+    expect(activity['version']).to eql(test_cookbook.cookbook_versions.first.version)
+    expect(activity['link']['href']).
+      to eql(cookbook_version_url(test_cookbook, test_cookbook.cookbook_versions.first.version))
+  end
+end


### PR DESCRIPTION
:fork_and_knife: Users should be able to subscribe to a feed that contains all of the cookbook activity for cookbooks that they follow.

![screen shot 2014-07-24 at 2 54 38 pm](https://cloud.githubusercontent.com/assets/316507/3693323/e4b87656-1365-11e4-8089-54740f0276d7.png)
