### PR TITLE
Show correct CLA counts

### DIFF
--- a/app/views/application/_contributors_list_heading.html.erb
+++ b/app/views/application/_contributors_list_heading.html.erb
@@ -13,12 +13,12 @@
   </dd>
   <dd class="<%= "active" if current_page?(icla_signatures_path) %>">
     <%= link_to icla_signatures_path, rel: 'individual-contributors' do %>
-      Individuals <span><%= @icla_signatures ? @icla_signatures.count : IclaSignature.by_user.count %></span>
+      Individuals <span><%= IclaSignature.by_user.count %></span>
     <% end %>
   </dd>
   <dd class="<%= "active" if current_page?(ccla_signatures_path) %>">
     <%= link_to ccla_signatures_path, rel: 'companies' do %>
-      Companies <span><%= @ccla_signatures ? @ccla_signatures.count : CclaSignature.by_organization.count %></span>
+      Companies <span><%= CclaSignature.by_organization.count %></span>
     <% end %>
   </dd>
 </dl>


### PR DESCRIPTION
:fork_and_knife: Now that we're paginating CLAs if we use count on the instance variable it will only show the number of CLAs for the current page so we should count all CLAs instead for the tab counts.
