### PR TITLE
Use table for pending CLA requests

### DIFF
--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -91,15 +91,15 @@
 
         <% if @pending_requests.present? %>
           <hr />
-          <h2>Pending Requests To Join a Company</h2>
+          <h3>Pending Requests To Join a Company</h3>
 
           <p>Requests to join a company to contribute on behalf of.</p>
 
-          <ul class="pending-requests">
+          <table class="pending-requests">
             <% @pending_requests.each do |request| %>
-              <li class="pending-request">You requested to join <%= link_to request.organization.name, contributors_ccla_signature_path(request.organization) %> on <%= request.created_at.to_s(:longish) %></li>
+              <tr class="pending-request"><td>You requested to join <%= link_to request.organization.name, contributors_ccla_signature_path(request.organization) %> on <%= request.created_at.to_s(:longish) %></td></tr>
             <% end %>
-          </ul>
+          </table>
         <% end %>
 
       </div>


### PR DESCRIPTION
:fork_and_knife: To be consistent with the UI throughout the manage profile view use a table for pending CLA requests instead of a ul.

![screen shot 2014-07-24 at 3 25 18 pm](https://cloud.githubusercontent.com/assets/316507/3693519/6921dcaa-1368-11e4-8ad1-50008973d430.png)
