### PR TITLE
Allow configurable Chef OAuth2 URL

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -5,10 +5,17 @@ Rails.application.config.middleware.use(OmniAuth::Builder) do
     ENV['GITHUB_SECRET']
   )
 
+  # Use an alternate URL for the Chef OAuth2 service if one is provided
+  client_options = {}
+  if ENV['CHEF_OAUTH2_URL'].present?
+    client_options[:site] = ENV['CHEF_OAUTH2_URL']
+  end
+
   provider(
     :chef_oauth2,
     ENV['CHEF_OAUTH2_APP_ID'],
-    ENV['CHEF_OAUTH2_SECRET']
+    ENV['CHEF_OAUTH2_SECRET'],
+    client_options: client_options
   )
 end
 


### PR DESCRIPTION
This allows you to set CHEF_OAUTH2_URL to an alternate URL if you're authenticating against a service other than https://id.opscode.com.

The `client_options` given are merged with the ones in [the omniauth-chef-oauth2 configuration](https://github.com/opscode/omniauth-chef-oauth2/blob/9a881294c8e8bcba4f0293eb73fc08d1067bd80b/lib/omniauth/strategies/chef_oauth2.rb#L9-L13).

Leaving this undocumented for now, as we'll be adding a section to the README or another doc on how to use this with your private Supermarket once that's more feasible.
