### PR TITLE
Make followed cookbook activity feed conform to atom spec

### DIFF
--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -19,7 +19,11 @@
           <li>
             <div>
               <%= link_to gravatar_for(cookbook_version.owner), cookbook_version.owner %>
-              <%= link_to cookbook_version.owner.username, cookbook_version.owner %> released <span>v<%= cookbook_version.version %></span> of the <%= link_to cookbook_version.name, cookbook_version.cookbook %> cookbook
+              <%= t('cookbook.activity',
+                    maintainer: link_to(cookbook_version.cookbook.maintainer, cookbook_version.owner),
+                    version: cookbook_version.version,
+                    cookbook: link_to(cookbook_version.name, cookbook_version.cookbook)
+                   ).html_safe %>
             </div>
             <small class="date"><%= cookbook_version.created_at.to_s(:longish) %></small>
           </li>

--- a/app/views/users/followed_cookbook_activity.atom.builder
+++ b/app/views/users/followed_cookbook_activity.atom.builder
@@ -4,10 +4,15 @@ atom_feed language: 'en-US' do |feed|
 
   @followed_cookbook_activity.each do |cookbook_version|
     feed.entry cookbook_version, url: cookbook_version_url(cookbook_version.cookbook, cookbook_version.version) do |entry|
-      entry.title cookbook_version.cookbook.name
-      entry.maintainer cookbook_version.cookbook.maintainer
-      entry.description cookbook_version.description
-      entry.version cookbook_version.version
+      entry.title t('cookbook.activity',
+                    maintainer: cookbook_version.cookbook.maintainer,
+                    version: cookbook_version.version,
+                    cookbook: cookbook_version.cookbook.name
+                   )
+      entry.author do |author|
+        author.name cookbook_version.cookbook.maintainer
+        author.uri user_url(cookbook_version.cookbook.owner)
+      end
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
     deprecated: "%{cookbook} deprecated in favor of %{replacement_cookbook}."
     featured: "%{cookbook} is now %{state}."
     deprecate_with_deprecated_failure: "This cookbook cannot be deprecated in favor of a deprecated cookbook."
+    activity: "%{maintainer} released v%{version} of the %{cookbook} cookbook."
   contributor_requests:
     accept:
       success: "%{username} is now authorized to contribute on behalf of %{organization}."

--- a/spec/views/users/followed_cookbook_activity.atom.builder_spec.rb
+++ b/spec/views/users/followed_cookbook_activity.atom.builder_spec.rb
@@ -55,10 +55,9 @@ describe 'users/followed_cookbook_activity.atom.builder' do
 
     activity = xml_body['feed']['entry'].first
 
-    expect(activity['title']).to eql(test_cookbook.name)
-    expect(activity['maintainer']).to eql(test_cookbook.maintainer)
-    expect(activity['description']).to eql(test_cookbook.description)
-    expect(activity['version']).to eql(test_cookbook.cookbook_versions.first.version)
+    expect(activity['title']).to match(/#{test_cookbook.name}/)
+    expect(activity['author']['name']).to eql(test_cookbook.maintainer)
+    expect(activity['author']['uri']).to eql(user_url(test_cookbook.owner))
     expect(activity['link']['href']).
       to eql(cookbook_version_url(test_cookbook, test_cookbook.cookbook_versions.first.version))
   end


### PR DESCRIPTION
:fork_and_knife: Move maintainer information into author tag, remove non standard tags. This is what an entry now looks like.

``` xml
<entry>
  <id>tag:localhost,2005:CookbookVersion/5386</id>
  <published>2014-06-24T15:28:26Z</published>
  <updated>2014-06-24T15:28:26Z</updated>
  <link rel="alternate" type="text/html" href="http://localhost:3000/cookbooks/nginx/versions/0.1.0"/>
  <title>supermarket released v0.1.0 of the nginx cookbook</title>
  <author>
    <name>supermarket</name>
    <uri>http://localhost:3000/users/supermarket</uri>
  </author>
</entry>
```
