### PR TITLE
Don't assign categories in cookbooks controller

### DIFF
--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -1,5 +1,4 @@
 class CookbooksController < ApplicationController
-  before_filter :assign_categories
   before_filter :assign_cookbook, except: [:index, :directory]
   before_filter :store_location_then_authenticate_user!, only: [:follow, :unfollow]
 
@@ -244,10 +243,6 @@ class CookbooksController < ApplicationController
   end
 
   private
-
-  def assign_categories
-    @categories ||= Category.all
-  end
 
   def assign_cookbook
     @cookbook ||= Cookbook.with_name(params[:id]).first!

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -171,10 +171,6 @@ describe CookbooksController do
       expect(assigns[:featured_cookbooks]).to_not be_nil
     end
 
-    it 'assigns @categories' do
-      expect(assigns[:categories]).to_not be_nil
-    end
-
     it 'sends cookbook count to the view' do
       expect(assigns[:cookbook_count]).to_not be_nil
     end


### PR DESCRIPTION
:fork_and_knife: We're no longer using categories so there is no need to assign them in the cookbooks controller.
