### PR TITLE
Adjust download cookbook button URL

### DIFF
--- a/app/views/cookbooks/_sidebar.html.erb
+++ b/app/views/cookbooks/_sidebar.html.erb
@@ -168,6 +168,6 @@
       <i class="fa fa-download"></i> <%= number_with_delimiter(version.download_count) %> Downloads of Version <%= version.version %>
       <small><%= number_with_delimiter(cookbook.download_count) %> Total Downloads</small>
     </h4>
-    <%= link_to "Download Cookbook", download_cookbook_path(cookbook), class: 'button secondary radius expand button_download_cookbook' %>
+    <%= link_to "Download Cookbook", { action: 'download' }, class: 'button secondary radius expand button_download_cookbook' %>
   </div>
 </div>


### PR DESCRIPTION
:fork_and_knife: Since this button is used on the cookbook version and cookbook view rather than linking to the cookbook download path just link to the download action for the current controller, either cookbooks or cookbook versions. The URL will then adjust depending on if you're viewing a cookbook or a cookbook version.
