### PR TITLE
Move end on contributors view

### DIFF
--- a/app/views/ccla_signatures/contributors.html.erb
+++ b/app/views/ccla_signatures/contributors.html.erb
@@ -13,8 +13,8 @@
         <% elsif current_user && current_user.requested_to_join?(@ccla_signature.organization) %>
           <%= render partial: 'pending_approval' %>
         <% end %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </div>
 
   <% if current_user && policy(@ccla_signature.organization).view_cclas? %>


### PR DESCRIPTION
:fork_and_knife: The end for the JOIN_CCLA_ENABLED feature flag was misplaced messing with the HTML markup, this fixes it.

From

![Madness](http://i.cwebber.net/Contributors_on_Behalf_of_Schuberg_Philis_B.V._-_Chef_Supermarket_2014-07-28_08-53-29_2014-07-28_08-53-32.jpg)

To

![Normal](http://f.cl.ly/items/0H3m2P2Y3e2S0j0H0g03/Screen%20Shot%202014-07-28%20at%203.12.55%20PM.png)
