### PR TITLE
Whitelist GitHub hook actions instead of blacklist

### DIFF
--- a/app/controllers/curry/pull_request_updates_controller.rb
+++ b/app/controllers/curry/pull_request_updates_controller.rb
@@ -16,7 +16,7 @@ class Curry::PullRequestUpdatesController < ApplicationController
       pull_request_update_params
     )
 
-    if pull_request_update.persisted? && !pull_request_update.closing?
+    if pull_request_update.persisted? && pull_request_update.requires_action?
       Curry::ImportPullRequestCommitAuthorsWorker.perform_async(
         pull_request_update.pull_request.id
       )

--- a/app/models/curry/pull_request_update.rb
+++ b/app/models/curry/pull_request_update.rb
@@ -4,12 +4,17 @@ class Curry::PullRequestUpdate < ActiveRecord::Base
 
   belongs_to :pull_request
 
+  # The actions that we want Curry to take action on when a pull request is
+  # updated
+  WHITE_LIST_ACTIONS = %w(opened reopened synchronize)
+
   #
-  # Determine if the update closed the Pull Request
+  # Determine if the update is something that should require Curry to take
+  # action
   #
-  # @return [Boolean]
+  # @return [Boolean] whether or not this is an update that requires action
   #
-  def closing?
-    action == 'closed'
+  def requires_action?
+    WHITE_LIST_ACTIONS.include?(action)
   end
 end

--- a/spec/controllers/curry/pull_request_updates_controller_spec.rb
+++ b/spec/controllers/curry/pull_request_updates_controller_spec.rb
@@ -18,7 +18,6 @@ describe Curry::PullRequestUpdatesController do
     end
 
     context 'when the action is not "closed"' do
-
       let(:payload) do
         File.read('spec/support/request_fixtures/github_open_pull_request.json')
       end

--- a/spec/models/curry/pull_request_update_spec.rb
+++ b/spec/models/curry/pull_request_update_spec.rb
@@ -6,13 +6,21 @@ describe Curry::PullRequestUpdate do
     it { should validate_presence_of(:pull_request_id) }
   end
 
-  describe '#closing?' do
-    it 'is true when the action is "closed"' do
-      expect(Curry::PullRequestUpdate.new(action: 'closed').closing?).to be true
+  describe '#requires_action?' do
+    it 'is false when the action is "closed"' do
+      expect(Curry::PullRequestUpdate.new(action: 'closed').requires_action?).to be false
     end
 
-    it 'is false when the action is not "closed"' do
-      expect(Curry::PullRequestUpdate.new(action: 'opened').closing?).to be false
+    it 'is true when the action is "opened"' do
+      expect(Curry::PullRequestUpdate.new(action: 'opened').requires_action?).to be true
+    end
+
+    it 'is true when the action is "reopened"' do
+      expect(Curry::PullRequestUpdate.new(action: 'reopened').requires_action?).to be true
+    end
+
+    it 'is true when the action is "synchronize"' do
+      expect(Curry::PullRequestUpdate.new(action: 'synchronize').requires_action?).to be true
     end
   end
 end


### PR DESCRIPTION
:fork_and_knife: 

If/when GitHub adds new pubsub hook actions, do not automatically take action on
them.

This should fix Curry going nuts.
