### PR TITLE
Improve cookbook search ranking

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -51,13 +51,15 @@ class Cookbook < ActiveRecord::Base
       name: 'A'
     },
     associated_against: {
-      cookbook_versions: { description: 'C' },
-      chef_account: { username: 'B' }
+      chef_account: { username: 'B' },
+      cookbook_versions: { description: 'C' }
     },
     using: {
-      tsearch: { dictionary: 'english' },
-      trigram: { threshold: 0.05 }
-    }
+      tsearch: { dictionary: 'english', only: [:username, :description], prefix: true },
+      trigram: { only: [:name] }
+    },
+    ranked_by: ':trigram + (0.5 * :tsearch)',
+    order_within_rank: 'cookbooks.name'
   )
 
   # Callbacks

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,8 +6,14 @@ FactoryGirl.define do
 
     sequence(:email) { |n| "johndoe#{n}@example.com" }
 
-    after(:create) do |user, _evaluator|
-      create(:account, provider: 'chef_oauth2', user: user)
+    ignore do
+      create_chef_account true
+    end
+
+    after(:create) do |user, evaluator|
+      if evaluator.create_chef_account
+        create(:account, provider: 'chef_oauth2', user: user)
+      end
     end
 
     factory :admin, class: User do

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -319,7 +319,7 @@ describe Cookbook do
         :cookbook,
         name: 'redis',
         category: create(:category, name: 'datastore'),
-        owner: create(:user, chef_account: create(:account, provider: 'chef_oauth2', username: 'johndoe')),
+        owner: create(:user, chef_account: create(:account, provider: 'chef_oauth2', username: 'johndoe'), create_chef_account: false),
         cookbook_versions: [
           create(
             :cookbook_version,
@@ -334,7 +334,7 @@ describe Cookbook do
         :cookbook,
         name: 'redisio',
         category: create(:category, name: 'datastore'),
-        owner: create(:user, chef_account: create(:account, provider: 'chef_oauth2', username: 'fanny')),
+        owner: create(:user, chef_account: create(:account, provider: 'chef_oauth2', username: 'fanny'), create_chef_account: false),
         cookbook_versions: [
           create(
             :cookbook_version,


### PR DESCRIPTION
:fork_and_knife: Only use trigram search for cookbook names add tie breaker when ranks are the same rank primarily by `:trigram` giving greater precedence to cookbook names.

This still isn't perfect but the results are far better than they currently are and it should resolve [these](https://trello.com/c/2ZKcy1OW/375-make-cookbook-search-better-match-user-expectations) unexpected results. I get the sense that in order to get the best results possible we either need to move away from abstracting search with `pg_search` so we can have more control over the queries being generated or move to something with more robust ranking like solr.
