### PR TITLE
Support tool slugs as route params

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require fastclick
 //= require modernizr
 //= require foundation.min
+//= require jquery.slugit
 //= require checkbox
 //= require cookbookShow
 //= require cookbookFollowing
@@ -28,6 +29,7 @@
 //= require collaborators
 //= require cookbookDeprecate
 //= require organizations
+//= require tools
 
 // Hack to resolve bug with Foundation. Resolved in master
 // here: https://github.com/zurb/foundation/issues/4684 so

--- a/app/assets/javascripts/tools.js
+++ b/app/assets/javascripts/tools.js
@@ -1,0 +1,3 @@
+$(function() {
+  $('#tool_name').slugIt({output: '#tool_slug'});
+});

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -1,5 +1,6 @@
 class ToolsController < ApplicationController
   before_filter :authenticate_user!, except: [:index, :show]
+  before_filter :assign_tool, only: [:show, :update, :edit, :destroy]
 
   #
   # GET /tools
@@ -41,7 +42,6 @@ class ToolsController < ApplicationController
   # Display the detail page for a +Tool+.
   #
   def show
-    @tool = Tool.find(params[:id])
     @other_tools = @tool.others_from_this_owner
   end
 
@@ -70,7 +70,6 @@ class ToolsController < ApplicationController
   # Display the form for editing an existing +Tool+.
   #
   def edit
-    @tool = Tool.find(params[:id])
     @user = current_user
 
     authorize! @tool
@@ -82,7 +81,6 @@ class ToolsController < ApplicationController
   # Updates an existing +Tool+.
   #
   def update
-    @tool = Tool.find(params[:id])
     @user = current_user
 
     authorize! @tool
@@ -103,8 +101,6 @@ class ToolsController < ApplicationController
   # Deletes a +Tool+.
   #
   def destroy
-    @tool = Tool.find(params[:id])
-
     authorize! @tool
 
     @tool.destroy
@@ -122,10 +118,18 @@ class ToolsController < ApplicationController
   def tool_params
     params.require(:tool).permit(
       :name,
+      :slug,
       :type,
       :description,
       :source_url,
       :instructions
     )
+  end
+
+  #
+  # Assigns a +Tool+ based on the slug.
+  #
+  def assign_tool
+    @tool = Tool.find_by(slug: params[:id])
   end
 end

--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -11,6 +11,7 @@ class Tool < ActiveRecord::Base
   # --------------------
   validates :name, uniqueness: { case_sensitive: false }, presence: true
   validates :type, inclusion: { in: ALLOWED_TYPES }
+  validates :slug, presence: true, uniqueness: { case_sensitive: false }, format: /\A[\w_-]+\z/i
   validates :source_url, url: {
     allow_blank: true,
     allow_nil: true
@@ -20,6 +21,7 @@ class Tool < ActiveRecord::Base
   # --------------------
   before_validation :copy_name_to_lowercase_name
   before_validation :strip_name_whitespace
+  before_validation :lowercase_slug
 
   #
   # Query tools by case-insensitive name.
@@ -59,6 +61,15 @@ class Tool < ActiveRecord::Base
     Tool.where('user_id = ? AND id <> ?', user_id, id).order(:name)
   end
 
+  #
+  # Returns the slug of the +Tool+.
+  #
+  # @return [String] the slug of the +Tool+
+  #
+  def to_param
+    slug
+  end
+
   private
 
   #
@@ -79,5 +90,12 @@ class Tool < ActiveRecord::Base
   #
   def strip_name_whitespace
     self.name = name.to_s.strip
+  end
+
+  #
+  # Slugs should always be lowercase.
+  #
+  def lowercase_slug
+    self.slug = slug.to_s.downcase
   end
 end

--- a/app/views/tools/_form.html.erb
+++ b/app/views/tools/_form.html.erb
@@ -7,6 +7,12 @@
     <small class="error">Name is required.</small>
   </div>
 
+  <div class="slug-field">
+    <%= f.label :slug %>
+    <%= f.text_field :slug, placeholder: 'Slug *', title: 'Slug', required: '' %>
+    <small class="error">Slug is required.</small>
+  </div>
+
   <div class="type-field">
     <% Tool::ALLOWED_TYPES.each_with_index do |type, index| %>
       <%= f.radio_button :type, type, index == 0 ? { checked: true } : {} %>

--- a/db/migrate/20140730174846_add_slug_to_tools.rb
+++ b/db/migrate/20140730174846_add_slug_to_tools.rb
@@ -1,0 +1,14 @@
+class AddSlugToTools < ActiveRecord::Migration
+  def up
+    add_column :tools, :slug, :string
+    add_index :tools, :slug, unique: true
+
+    Tool.all.each do |tool|
+      tool.update_attribute(:slug, "#{tool.id}-#{tool.name.parameterize}")
+    end
+  end
+
+  def down
+    remove_column :tools, :slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140724193305) do
+ActiveRecord::Schema.define(version: 20140730174846) do
 
   create_table "accounts", force: true do |t|
     t.integer  "user_id"
@@ -314,9 +314,11 @@ ActiveRecord::Schema.define(version: 20140724193305) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "lowercase_name"
+    t.string   "slug"
   end
 
   add_index "tools", ["lowercase_name"], name: "index_tools_on_lowercase_name", unique: true, using: :btree
+  add_index "tools", ["slug"], name: "index_tools_on_slug", unique: true, using: :btree
   add_index "tools", ["user_id"], name: "index_tools_on_user_id", using: :btree
 
   create_table "users", force: true do |t|

--- a/spec/controllers/tools_controller_spec.rb
+++ b/spec/controllers/tools_controller_spec.rb
@@ -103,6 +103,7 @@ describe ToolsController do
           :create,
           tool: {
             name: 'butter',
+            slug: 'butter',
             type: 'ohai_plugin',
             description: 'Great plugin.',
             source_url: 'http://example.com',
@@ -117,6 +118,7 @@ describe ToolsController do
         :create,
         tool: {
           name: 'butter',
+          slug: 'butter',
           type: 'ohai_plugin',
           description: 'Great plugin.',
           source_url: 'http://example.com',

--- a/spec/factories/tool.rb
+++ b/spec/factories/tool.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :tool do
     association :owner, factory: :user
     sequence(:name) { |n| "butter-#{n}" }
+    sequence(:slug) { |n| "butter-#{n}" }
     type 'ohai_plugin'
     description 'Great plugin for ohai.'
     source_url 'http://example.com'

--- a/spec/features/tool_creation_spec.rb
+++ b/spec/features/tool_creation_spec.rb
@@ -11,6 +11,7 @@ describe 'creating a tool' do
 
     within '.new_tool' do
       fill_in 'tool_name', with: 'butter'
+      fill_in 'tool_slug', with: 'butter'
       choose 'Knife Plugin'
       fill_in 'tool_description', with: 'Easily cut with knife'
       fill_in 'tool_source_url', with: 'http://example.com'

--- a/spec/models/tool_spec.rb
+++ b/spec/models/tool_spec.rb
@@ -8,6 +8,9 @@ describe Tool do
   context 'validations' do
     it { should validate_presence_of(:name) }
     it { should ensure_inclusion_of(:type).in_array(Tool::ALLOWED_TYPES) }
+    it { should_not allow_value('great tool').for(:slug) }
+    it { should allow_value('great-tool').for(:slug) }
+    it { should validate_uniqueness_of(:slug) }
 
     it 'validates the uniqueness of name' do
       create(:tool)

--- a/vendor/assets/javascripts/jquery.slugit.js
+++ b/vendor/assets/javascripts/jquery.slugit.js
@@ -1,0 +1,175 @@
+/*
+ * jQuery slugIt plug-in 1.0
+ *
+ * Copyright (c) 2010 Diego Kuperman
+ *
+ * Inspired by perl module Text::Unidecode and Django urlfy.js
+ *
+ * Licensed under the BSD license:
+ *      http://www.opensource.org/licenses/bsd-license.php
+ */
+
+jQuery.fn.slugIt = function(options) {
+    var defaults = {
+        events: 'keypress keyup',
+        output: '#slug',
+        separator: '-',
+        map:    false,
+        before: false,
+        after: false
+    };
+
+    var opts  = jQuery.extend(defaults, options);
+
+    var chars = latin_map();
+        chars = jQuery.extend(chars, greek_map());
+        chars = jQuery.extend(chars, turkish_map());
+        chars = jQuery.extend(chars, russian_map());
+        chars = jQuery.extend(chars, ukranian_map());
+        chars = jQuery.extend(chars, czech_map());
+        chars = jQuery.extend(chars, latvian_map());
+        chars = jQuery.extend(chars, polish_map());
+        chars = jQuery.extend(chars, symbols_map());
+        chars = jQuery.extend(chars, currency_map());
+
+    if ( opts.map ) {
+        chars = jQuery.extend(chars, opts.map);
+    }
+
+    jQuery(this).bind(defaults.events, function() {
+        var text = jQuery(this).val();
+
+        if ( opts.before ) text = opts.before(text);
+        text = jQuery.trim(text.toString());
+
+        var slug = new String();
+        for (var i = 0; i < text.length; i++) {
+            if ( chars[text.charAt(i)] ) { slug += chars[text.charAt(i)] }
+            else                         { slug += text.charAt(i) }
+        }
+
+        // Ensure separator is composable into regexes
+        var sep_esc  = opts.separator.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+        var re_trail = new RegExp('^'+ sep_esc +'+|'+ sep_esc +'+$', 'g');
+        var re_multi = new RegExp(sep_esc +'+', 'g');
+
+        slug = slug.replace(/[^-\w\d\$\*\(\)\'\!\_]/g, opts.separator);  // swap spaces and unwanted chars
+        slug = slug.replace(re_trail, '');                               // trim leading/trailing separators
+        slug = slug.replace(re_multi, opts.separator);                   // eliminate repeated separatos
+        slug = slug.toLowerCase();                                       // convert sting to lower case
+
+        if ( opts.after ) slug = opts.after(slug);
+
+        if ( typeof opts.output == "function" ) {
+          opts.output(slug)
+        } else {
+          jQuery(opts.output).val(slug);         // input or textarea
+          jQuery(opts.output).html(slug);        // other dom elements
+        }
+
+        return this;
+    });
+
+    function latin_map() {
+        return {
+            'À': 'A', 'Á': 'A', 'Â': 'A', 'Ã': 'A', 'Ä': 'A', 'Å': 'A', 'Æ': 'AE', 'Ç':
+            'C', 'È': 'E', 'É': 'E', 'Ê': 'E', 'Ë': 'E', 'Ì': 'I', 'Í': 'I', 'Î': 'I',
+            'Ï': 'I', 'Ð': 'D', 'Ñ': 'N', 'Ò': 'O', 'Ó': 'O', 'Ô': 'O', 'Õ': 'O', 'Ö':
+            'O', 'Ő': 'O', 'Ø': 'O', 'Ù': 'U', 'Ú': 'U', 'Û': 'U', 'Ü': 'U', 'Ű': 'U',
+            'Ý': 'Y', 'Þ': 'TH', 'ß': 'ss', 'à':'a', 'á':'a', 'â': 'a', 'ã': 'a', 'ä':
+            'a', 'å': 'a', 'æ': 'ae', 'ç': 'c', 'è': 'e', 'é': 'e', 'ê': 'e', 'ë': 'e',
+            'ì': 'i', 'í': 'i', 'î': 'i', 'ï': 'i', 'ð': 'd', 'ñ': 'n', 'ò': 'o', 'ó':
+            'o', 'ô': 'o', 'õ': 'o', 'ö': 'o', 'ő': 'o', 'ø': 'o', 'ù': 'u', 'ú': 'u',
+            'û': 'u', 'ü': 'u', 'ű': 'u', 'ý': 'y', 'þ': 'th', 'ÿ': 'y'
+        };
+    }
+
+    function greek_map() {
+        return {
+            'α':'a', 'β':'b', 'γ':'g', 'δ':'d', 'ε':'e', 'ζ':'z', 'η':'h', 'θ':'8',
+            'ι':'i', 'κ':'k', 'λ':'l', 'μ':'m', 'ν':'n', 'ξ':'3', 'ο':'o', 'π':'p',
+            'ρ':'r', 'σ':'s', 'τ':'t', 'υ':'y', 'φ':'f', 'χ':'x', 'ψ':'ps', 'ω':'w',
+            'ά':'a', 'έ':'e', 'ί':'i', 'ό':'o', 'ύ':'y', 'ή':'h', 'ώ':'w', 'ς':'s',
+            'ϊ':'i', 'ΰ':'y', 'ϋ':'y', 'ΐ':'i',
+            'Α':'A', 'Β':'B', 'Γ':'G', 'Δ':'D', 'Ε':'E', 'Ζ':'Z', 'Η':'H', 'Θ':'8',
+            'Ι':'I', 'Κ':'K', 'Λ':'L', 'Μ':'M', 'Ν':'N', 'Ξ':'3', 'Ο':'O', 'Π':'P',
+            'Ρ':'R', 'Σ':'S', 'Τ':'T', 'Υ':'Y', 'Φ':'F', 'Χ':'X', 'Ψ':'PS', 'Ω':'W',
+            'Ά':'A', 'Έ':'E', 'Ί':'I', 'Ό':'O', 'Ύ':'Y', 'Ή':'H', 'Ώ':'W', 'Ϊ':'I',
+            'Ϋ':'Y'
+        };
+    }
+
+    function turkish_map() {
+        return {
+            'ş':'s', 'Ş':'S', 'ı':'i', 'İ':'I', 'ç':'c', 'Ç':'C', 'ü':'u', 'Ü':'U',
+            'ö':'o', 'Ö':'O', 'ğ':'g', 'Ğ':'G'
+        };
+    }
+
+    function russian_map() {
+        return {
+            'а':'a', 'б':'b', 'в':'v', 'г':'g', 'д':'d', 'е':'e', 'ё':'yo', 'ж':'zh',
+            'з':'z', 'и':'i', 'й':'j', 'к':'k', 'л':'l', 'м':'m', 'н':'n', 'о':'o',
+            'п':'p', 'р':'r', 'с':'s', 'т':'t', 'у':'u', 'ф':'f', 'х':'h', 'ц':'c',
+            'ч':'ch', 'ш':'sh', 'щ':'sh', 'ъ':'', 'ы':'y', 'ь':'', 'э':'e', 'ю':'yu',
+            'я':'ya',
+            'А':'A', 'Б':'B', 'В':'V', 'Г':'G', 'Д':'D', 'Е':'E', 'Ё':'Yo', 'Ж':'Zh',
+            'З':'Z', 'И':'I', 'Й':'J', 'К':'K', 'Л':'L', 'М':'M', 'Н':'N', 'О':'O',
+            'П':'P', 'Р':'R', 'С':'S', 'Т':'T', 'У':'U', 'Ф':'F', 'Х':'H', 'Ц':'C',
+            'Ч':'Ch', 'Ш':'Sh', 'Щ':'Sh', 'Ъ':'', 'Ы':'Y', 'Ь':'', 'Э':'E', 'Ю':'Yu',
+            'Я':'Ya'
+        };
+    }
+
+    function ukranian_map() {
+        return {
+            'Є':'Ye', 'І':'I', 'Ї':'Yi', 'Ґ':'G', 'є':'ye', 'і':'i', 'ї':'yi', 'ґ':'g'
+        };
+    }
+
+    function czech_map() {
+        return {
+            'č':'c', 'ď':'d', 'ě':'e', 'ň': 'n', 'ř':'r', 'š':'s', 'ť':'t', 'ů':'u',
+            'ž':'z', 'Č':'C', 'Ď':'D', 'Ě':'E', 'Ň': 'N', 'Ř':'R', 'Š':'S', 'Ť':'T',
+            'Ů':'U', 'Ž':'Z'
+        };
+    }
+
+    function polish_map() {
+        return {
+            'ą':'a', 'ć':'c', 'ę':'e', 'ł':'l', 'ń':'n', 'ó':'o', 'ś':'s', 'ź':'z',
+            'ż':'z', 'Ą':'A', 'Ć':'C', 'Ę':'e', 'Ł':'L', 'Ń':'N', 'Ó':'o', 'Ś':'S',
+            'Ź':'Z', 'Ż':'Z'
+        };
+    }
+
+    function latvian_map() {
+        return {
+            'ā':'a', 'č':'c', 'ē':'e', 'ģ':'g', 'ī':'i', 'ķ':'k', 'ļ':'l', 'ņ':'n',
+            'š':'s', 'ū':'u', 'ž':'z', 'Ā':'A', 'Č':'C', 'Ē':'E', 'Ģ':'G', 'Ī':'i',
+            'Ķ':'k', 'Ļ':'L', 'Ņ':'N', 'Š':'S', 'Ū':'u', 'Ž':'Z'
+        };
+    }
+
+    function currency_map() {
+        return {
+            '€': 'euro', '$': 'dollar', '₢': 'cruzeiro', '₣': 'french franc', '£': 'pound',
+            '₤': 'lira', '₥': 'mill', '₦': 'naira', '₧': 'peseta', '₨': 'rupee',
+            '₩': 'won', '₪': 'new shequel', '₫': 'dong', '₭': 'kip', '₮': 'tugrik',
+            '₯': 'drachma', '₰': 'penny', '₱': 'peso', '₲': 'guarani', '₳': 'austral',
+            '₴': 'hryvnia', '₵': 'cedi', '¢': 'cent', '¥': 'yen', '元': 'yuan',
+            '円': 'yen', '﷼': 'rial', '₠': 'ecu', '¤': 'currency', '฿': 'baht'
+        };
+    }
+
+    function symbols_map() {
+        return {
+            '©':'(c)', 'œ': 'oe', 'Œ': 'OE', '∑': 'sum', '®': '(r)', '†': '+',
+            '“': '"', '”': '"', '‘': "'", '’': "'", '∂': 'd', 'ƒ': 'f', '™': 'tm',
+            '℠': 'sm', '…': '...', '˚': 'o', 'º': 'o', 'ª': 'a', '•': '*',
+            '∆': 'delta', '∞': 'infinity', '♥': 'love', '&': 'and'
+        };
+    }
+
+  return this;
+}


### PR DESCRIPTION
:fork_and_knife: A slug will now be generated from the tool name, which can be changed by the user. The tool slug is used as the tools route param.

![slug](https://cloud.githubusercontent.com/assets/316507/3754148/76346066-1818-11e4-9f43-29b22b5d4f14.gif)
