### PR TITLE
Refactor Curry::PullRequestAnnotator

### DIFF
--- a/app/models/curry/add_authorized_label.rb
+++ b/app/models/curry/add_authorized_label.rb
@@ -1,0 +1,26 @@
+#
+# Adds the ENV['CURRY_SUCCESS_LABEL'] label to a Pull Request
+#
+class Curry::AddAuthorizedLabel
+  #
+  # Creates a new +Curry::AddAuthorizedLabel+
+  #
+  # @param octokit [Octokit::Client]
+  # @param pull_request [Curry::PullRequest]
+  #
+  def initialize(octokit, pull_request)
+    @octokit = octokit
+    @pull_request = pull_request
+  end
+
+  #
+  # Performs the action of adding the label
+  #
+  def call
+    @octokit.add_labels_to_an_issue(
+      @pull_request.repository.full_name,
+      @pull_request.number,
+      [ENV['CURRY_SUCCESS_LABEL']]
+    )
+  end
+end

--- a/app/models/curry/authorized_commit_author_comment.rb
+++ b/app/models/curry/authorized_commit_author_comment.rb
@@ -1,0 +1,48 @@
+#
+# Responsible for adding a comment to a Pull Request indicating
+# that all commit authors are authorized to contribute
+#
+class Curry::AuthorizedCommitAuthorComment
+  #
+  # Creates a new +Curry::AuthorizedCommitAuthorComment+
+  #
+  # @param octokit [Octokit::Client]
+  # @param pull_request [Curry::PullRequest]
+  # @param unauthorized_commit_authors [Array<Curry::CommitAuthor>]
+  #
+  def initialize(octokit, pull_request, unauthorized_commit_authors)
+    @octokit = octokit
+    @pull_request = pull_request
+    @unauthorized_commit_authors = unauthorized_commit_authors
+  end
+
+  #
+  # Adds a comment to the given +pull_request+ and adds a record of the comment
+  # internally
+  #
+  def call
+    @octokit.add_comment(
+      @pull_request.repository.full_name,
+      @pull_request.number,
+      comment_body
+    ).tap do |comment|
+      @pull_request.comments.create!(github_id: comment.id)
+    end
+  end
+
+  private
+
+  #
+  # The comment text
+  #
+  # @return [String]
+  #
+  def comment_body
+    %(
+      Hi. Your friendly Curry bot here. Just letting you know that all commit
+      authors have become authorized to contribute. I have added the
+      "#{ENV['CURRY_SUCCESS_LABEL']}" label to this issue so it can easily be
+      found in the future.
+    ).squish
+  end
+end

--- a/app/models/curry/pull_request_comment.rb
+++ b/app/models/curry/pull_request_comment.rb
@@ -20,4 +20,36 @@ class Curry::PullRequestComment < ActiveRecord::Base
   def required_authorization?
     unauthorized_commit_authors.any?
   end
+
+  #
+  # Updates the comment's +unauthorized_commit_authors+ to reflect the given
+  # +commit_authors+
+  #
+  # @param commit_authors [Array<Curry::CommitAuthor>]
+  #
+  def addresses!(commit_authors)
+    identifiers = commit_authors.map do |commit_author|
+      [commit_author.login, commit_author.email]
+    end.flatten.compact
+
+    assign_attributes(unauthorized_commit_authors: identifiers)
+
+    save!
+  end
+
+  #
+  # Determines if this comment addressed exactly the given collection of commit
+  # authors
+  #
+  # @param commit_authors [Array<Curry::CommitAuthor>]
+  #
+  # @return [Boolean]
+  #
+  def addressed_only?(commit_authors)
+    identifiers = commit_authors.map do |commit_author|
+      [commit_author.login, commit_author.email]
+    end.flatten.compact
+
+    Set.new(identifiers) == mentioned_commit_authors
+  end
 end

--- a/app/models/curry/remove_authorized_label.rb
+++ b/app/models/curry/remove_authorized_label.rb
@@ -1,0 +1,51 @@
+require 'octokit'
+require 'set'
+
+#
+# Removes the ENV['CURRY_SUCCESS_LABEL'] label from a Pull Request
+#
+class Curry::RemoveAuthorizedLabel
+  #
+  # Creates a new +Curry::RemoveAuthorizedLabel+
+  #
+  # @param octokit [Octokit::Client]
+  # @param pull_request [Curry::PullRequest]
+  #
+  def initialize(octokit, pull_request)
+    @octokit = octokit
+    @pull_request = pull_request
+  end
+
+  #
+  # Performs the action of removing the label
+  #
+  def call
+    begin
+      if existing_labels.include?(ENV['CURRY_SUCCESS_LABEL'])
+        @octokit.remove_label(
+          @pull_request.repository.full_name,
+          @pull_request.number,
+          ENV['CURRY_SUCCESS_LABEL']
+        )
+      end
+    rescue Octokit::NotFound
+      Rails.logger.info 'Label not on issue.'
+    end
+  end
+
+  private
+
+  #
+  # The set of labels on the Pull Request
+  #
+  # @return [Set<String>]
+  #
+  def existing_labels
+    Set.new(
+      @octokit.labels_for_issue(
+        @pull_request.repository.full_name,
+        @pull_request.number
+      ).map(&:name)
+    )
+  end
+end

--- a/app/models/curry/unauthorized_commit_author_comment.rb
+++ b/app/models/curry/unauthorized_commit_author_comment.rb
@@ -1,0 +1,71 @@
+require 'octokit'
+
+#
+# Responsible for adding a comment to a Pull Request
+#
+class Curry::UnauthorizedCommitAuthorComment
+  #
+  # Creates a new +Curry::UnauthorizedCommitAuthorComment+
+  #
+  # @param octokit [Octokit::Client]
+  # @param pull_request [Curry::PullRequest]
+  # @param unauthorized_commit_authors [Array<Curry::CommitAuthor>]
+  #
+  def initialize(octokit, pull_request, unauthorized_commit_authors)
+    @octokit = octokit
+    @pull_request = pull_request
+    @unauthorized_commit_authors = unauthorized_commit_authors
+  end
+
+  #
+  # Adds a comment to the given +pull_request+ and adds a record of the comment
+  # internally
+  #
+  def call
+    @octokit.add_comment(
+      @pull_request.repository.full_name,
+      @pull_request.number,
+      comment_body
+    ).tap do |comment|
+      @pull_request.comments.new(github_id: comment.id).tap do |curry_comment|
+        curry_comment.addresses!(@unauthorized_commit_authors)
+      end
+    end
+  end
+
+  private
+
+  def comment_body
+    [].tap do |parts|
+      parts << %(
+        Hi. Your friendly Curry bot here. Just letting you know that there are
+        commit authors in this Pull Request who appear to not have signed a Chef
+        CLA.
+      ).squish
+
+      if @unauthorized_commit_authors.any?(&:email)
+        parts << %(
+          There are #{@unauthorized_commit_authors.count(&:email)} commit
+          author(s) whose commits are authored by a non GitHub-verified email
+          address in this Pull Request. Chef will have to verify by hand that
+          they have signed a Chef CLA.
+        ).squish
+      end
+
+      if @unauthorized_commit_authors.any?(&:login)
+        parts << 'The following GitHub users do not appear to have signed a CLA:'
+
+        author_list = @unauthorized_commit_authors.
+          select(&:login).
+          map(&:login).
+          map do |login|
+          "* @#{login}"
+        end
+
+        parts << author_list.join("\n")
+      end
+
+      parts << "[Please sign the CLA here.](#{ENV['CURRY_CLA_LOCATION']})"
+    end.join("\n\n")
+  end
+end

--- a/app/models/curry/update_unauthorized_commit_author_comment.rb
+++ b/app/models/curry/update_unauthorized_commit_author_comment.rb
@@ -1,0 +1,20 @@
+#
+# Updates the +updated_at+ timestamp of the latest comment on a Pull Request
+#
+class Curry::UpdateUnauthorizedCommitAuthorComment
+  #
+  # Creates a new +Curry::UpdateUnauthorizedCommitAuthorComment+
+  #
+  # @param comment [Curry::PullRequestComment]
+  #
+  def initialize(comment)
+    @comment = comment
+  end
+
+  #
+  # Performs the action of updating the comment
+  #
+  def call
+    @comment.touch
+  end
+end

--- a/app/workers/curry/cla_validation_worker.rb
+++ b/app/workers/curry/cla_validation_worker.rb
@@ -1,3 +1,5 @@
+require 'octokit'
+
 class Curry::ClaValidationWorker
   include Sidekiq::Worker
 


### PR DESCRIPTION
:fork_and_knife: 

Instead of putting annotation actions in the annotator, we split them out into classes for each action. It's probably easier to follow what's going on by looking at the [new annotator](https://github.com/opscode/supermarket/blob/factor-curry-annotations/app/models/curry/pull_request_annotator.rb) before looking through the [Files changed](https://github.com/opscode/supermarket/pull/696/files).

---

The purpose of this refactoring is to make it easy to separate Curry's annotation decision-making process from its annotation-making process. One reason we might want to make these phases distinct is so that we can test them independently. This will be especially handy for exhaustively testing how Curry makes decisions without leaning on VCR and brittle assumptions about hard-coded GitHub repos.
