### PR TITLE
Display message about oc-id when users sign out.

### DIFF
--- a/app/assets/stylesheets/welcome.css.scss
+++ b/app/assets/stylesheets/welcome.css.scss
@@ -1,5 +1,6 @@
 @import "common";
 @import "foundation/components/grid";
+@import "compass/css3/border-radius";
 
 .sign_up_in {
   padding-bottom: rem-calc(55);
@@ -44,5 +45,21 @@
     div {
       @include grid-column($columns: 12);
     }
+  }
+}
+
+.signout-message {
+  @include border-radius(rem-calc(2));
+
+  border: 4px solid $primary_red;
+  color: $primary_red;
+  display: block;
+  margin: rem-calc(0 0 32 0);
+  padding: rem-calc(18 9 18 9);
+
+  p {
+    font-size: rem-calc(18);
+    text-align: center;
+    margin: 0;
   }
 }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,7 +28,7 @@ class SessionsController < ApplicationController
   #
   def destroy
     reset_session
-    redirect_to redirect_path, notice: t('user.signed_out')
+    redirect_to root_path(signout: true), notice: t('user.signed_out')
   end
 
   private

--- a/app/views/pages/welcome.html.erb
+++ b/app/views/pages/welcome.html.erb
@@ -2,6 +2,12 @@
 <%= provide :description, "Supermarket is Chef's open-source community platform. Find, explore and view Chef cookbooks for all of your ops needs." %>
 
 <div class="page withspace">
+  <% if params[:signout] == "true" %>
+    <div class="signout-message">
+      <p>You have been signed out of Supermarket but are still signed in to your Chef account. Visit <a href="https://id.opscode.com">https://id.opscode.com</a> to sign out completely.</p>
+    </div>
+  <% end %>
+
   <section class="sign_up_in">
     <h2 class="text-center">Welcome to Supermarket. Find, explore and view Chef cookbooks for all of your ops needs.</h2>
 

--- a/spec/features/signout_spec.rb
+++ b/spec/features/signout_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_feature_helper'
+
+describe 'signing out' do
+  it 'displays a message about oc-id' do
+    sign_in(create(:user))
+    sign_out
+
+    expect(page).to have_content('id.opscode.com')
+  end
+end


### PR DESCRIPTION
:fork_and_knife: 

Signing out of Supermarket does not sign users out of oc-id, which is the
expected behavior. However, it is not clear when signing out that this is the
behavior. This commit displays a message when a user is signed out letting them
know they need to go to id.opscode.com to signout completely.

Closes #682.

What it looks like:

![screen shot 2014-07-31 at 9 50 55 am](https://cloud.githubusercontent.com/assets/928367/3765404/422b664a-18bb-11e4-8161-8dd4d8a63194.png)

This has been added in addition to the flash message because the flash message disappears after some time. This is more permanent and prominent.
