### PR TITLE
Create the /status end-point and add status: ok

### DIFF
--- a/app/views/api/v1/health/show.json.jbuilder
+++ b/app/views/api/v1/health/show.json.jbuilder
@@ -1,3 +1,4 @@
+json.status 'ok'
 json.supermarket @supermarket_health
 json.sidekiq @sidekiq_health
 json.postgresql @postgresql_health

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Supermarket::Application.routes.draw do
 
   get 'cookbooks-directory' => 'cookbooks#directory'
   get 'universe' => 'api/v1/universe#index', defaults: { format: :json }
+  get 'status' => 'api/v1/health#show', defaults: { format: :json }
 
   resources :cookbooks, only: [:index, :show, :update] do
     resources :collaborators, only: [:index, :new, :create, :destroy] do

--- a/spec/api/status_spec.rb
+++ b/spec/api/status_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'GET /status' do
+  it 'returns a 200' do
+    get 'status'
+
+    expect(response.status.to_i).to eql(200)
+  end
+
+  it 'returns a status ok' do
+    get 'status'
+
+    expect(json_body).to include('status' => 'ok')
+  end
+end


### PR DESCRIPTION
:fork_and_knife: 

The /status end-point is just another way to access the /api/v1/health
end-point. This commit also adds the "status": "ok" info to the response as
well.

Closes #553.
