### PR TITLE
Allow the universe API endpoint to be filtered.

### DIFF
--- a/app/controllers/api/v1/universe_controller.rb
+++ b/app/controllers/api/v1/universe_controller.rb
@@ -6,33 +6,29 @@ class Api::V1::UniverseController < Api::V1Controller
   # Berkshelf API response. It will have cookbooks, all their versions, and
   # dependency/platform information.
   #
-  def index
-    universe = universe_cache.fetch do
-      Universe.generate(protocol: universe_cache.protocol)
-    end
-
-    SegmentIO.track_server_event('universe_api_visit', current_user)
-    Universe.track_hit
-
-    render json: MultiJson.dump(universe)
-  end
-
-  #
-  # POST /universe?cookbooks=redis,postgres
-  #
-  # Returns a JSON response that should be compatible with the current
-  # Berkshelf API response. Takes a cookbooks parameter (a comma separated list of cookbook
+  # Takes an optional cookbooks parameter (a comma separated list of cookbook
   # names). This will only return cookbook information related to the requested
   # cookbooks. If no cookbooks are specified, it will return all cookbooks and
   # their dependencies.
   #
-  def search
+  # @example
+  #
+  #   GET /universe
+  #   GET /universe?cookbooks=redis,postgres
+  #
+  def index
     cookbooks = params.fetch(:cookbooks, nil)
 
-    universe = Universe.generate(
-      protocol: universe_cache.protocol,
-      cookbooks: cookbooks
-    )
+    if cookbooks.nil?
+      universe = universe_cache.fetch do
+        Universe.generate(protocol: universe_cache.protocol)
+      end
+    else
+      universe = Universe.generate(
+        protocol: universe_cache.protocol,
+        cookbooks: cookbooks
+      )
+    end
 
     SegmentIO.track_server_event('universe_api_visit', current_user)
     Universe.track_hit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,6 @@ Supermarket::Application.routes.draw do
 
   get 'cookbooks-directory' => 'cookbooks#directory'
   get 'universe' => 'api/v1/universe#index', defaults: { format: :json }
-  post 'universe' => 'api/v1/universe#search', defaults: { format: :json }
 
   resources :cookbooks, only: [:index, :show, :update] do
     resources :collaborators, only: [:index, :new, :create, :destroy] do

--- a/spec/api/universe_spec.rb
+++ b/spec/api/universe_spec.rb
@@ -100,7 +100,7 @@ describe 'GET /universe' do
   end
 
   it 'can be filtered by cookbook names' do
-    post '/universe', format: :json, cookbooks: 'redis,apt'
+    get '/universe', format: :json, cookbooks: 'redis,apt'
 
     body = json_body
 


### PR DESCRIPTION
:fork_and_knife: 

When issuing a GET request to the /universe endpoint, allow the request to
filtered based upon specified cookbooks. One or more cookbooks can be requested
with a comma separated list.

Example:

`GET /universe?cookbooks=ruby,java,clojure`

Trello card: https://trello.com/c/pWTIRvzx

Closes #504.

![i-have-no-idea-what-im-doing-dog](https://cloud.githubusercontent.com/assets/928367/3769199/4c51ef1c-18df-11e4-8267-ed852b765756.jpg)
