### PR TITLE
Rescue invalid IRC log dates

### DIFF
--- a/app/controllers/irc_logs_controller.rb
+++ b/app/controllers/irc_logs_controller.rb
@@ -30,15 +30,21 @@ class IrcLogsController < ApplicationController
 
     channel = params[:channel]
     date_str = params.fetch(:date, nil)
-    date = Date.parse(date_str) unless date_str.nil?
-    cutoff_date = Date.parse('2013-08-08')
 
-    if date_str.nil?
-      redirect_to(botbot_base_url + channel)
-    elsif date > cutoff_date
-      redirect_to(botbot_base_url + channel + '/' + date_str)
+    begin
+      date = Date.parse(date_str) unless date_str.nil?
+    rescue ArgumentError
+      not_found!
     else
-      redirect_to(github_repo_url)
+      cutoff_date = Date.parse('2013-08-08')
+
+      if date_str.nil?
+        redirect_to(botbot_base_url + channel)
+      elsif date > cutoff_date
+        redirect_to(botbot_base_url + channel + '/' + date_str)
+      else
+        redirect_to(github_repo_url)
+      end
     end
   end
 end

--- a/spec/controllers/irc_logs_controller_spec.rb
+++ b/spec/controllers/irc_logs_controller_spec.rb
@@ -28,10 +28,15 @@ describe IrcLogsController do
     end
 
     it 'redirects to the GitHub repo archive if the date is before August 8th, 2013' do
-
       get :show, channel: 'chef', date: '2012-09-24'
 
       expect(response).to redirect_to(github_repo_url)
+    end
+
+    it 'returns a 404 if an invalid date is given' do
+      get :show, channel: 'chef', date: '2012-08-'
+
+      expect(response.status).to eql(404)
     end
   end
 end


### PR DESCRIPTION
:fork_and_knife: Potentially an invalid IRC log date could be passed as a param to the `IrcLogsController`. Rescue this and return a 404.
