### PR TITLE
Enable deep linking on Foundation tabs

### DIFF
--- a/app/views/cookbooks/_main.html.erb
+++ b/app/views/cookbooks/_main.html.erb
@@ -48,7 +48,7 @@
 
   <p><%= cookbook.description %></p>
 
-  <dl class="tabs" data-tab>
+  <dl class="tabs" data-tab data-options="deep_linking:true">
     <dd class="active"><a href="#readme">README</a></dd>
     <dd><a href="#dependencies" rel="cookbook_dependencies">Dependencies</a></dd>
   </dl>

--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -6,7 +6,7 @@
   <div class="main" data-equalizer-watch>
     <h1>Manage Profile</h1>
 
-    <dl class="tabs radius" data-tab>
+    <dl class="tabs radius" data-tab data-options="deep_linking:true">
       <dd class="active"><a href="#profile" rel="manage_profile">Edit Profile</a></dd>
       <dd><a href="#github-accounts" rel="manage_github_accounts">GitHub Accounts</a></dd>
       <dd><a href="#agreements" rel="manage_agreements">Agreements</a></dd>


### PR DESCRIPTION
:fork_and_knife: So you can link directly to a Foundation tab, enable deep linking data attribute.
