### PR TITLE
Revise signout message

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -28,7 +28,10 @@ class SessionsController < ApplicationController
   #
   def destroy
     reset_session
-    redirect_to root_path(signout: true), notice: t('user.signed_out')
+
+    flash[:signout] = true
+
+    redirect_to root_path, notice: t('user.signed_out')
   end
 
   private

--- a/app/views/pages/welcome.html.erb
+++ b/app/views/pages/welcome.html.erb
@@ -2,7 +2,7 @@
 <%= provide :description, "Supermarket is Chef's open-source community platform. Find, explore and view Chef cookbooks for all of your ops needs." %>
 
 <div class="page withspace">
-  <% if params[:signout] == "true" %>
+  <% if flash[:signout] %>
     <div class="signout-message">
       <p>You have been signed out of Supermarket but may still be signed in to your Chef account. Visit <a href="https://id.opscode.com">https://id.opscode.com</a> to sign out completely.</p>
     </div>


### PR DESCRIPTION
:fork_and_knife:

This makes a small adjustment to the language in the callout shown after a user signs out, and uses a flash variable instead of a URL parameter to trigger the message.
