### PR TITLE
404 when a Tool does not exist by the given slug

### DIFF
--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -130,6 +130,6 @@ class ToolsController < ApplicationController
   # Assigns a +Tool+ based on the slug.
   #
   def assign_tool
-    @tool = Tool.find_by(slug: params[:id])
+    @tool = Tool.find_by!(slug: params[:id])
   end
 end

--- a/spec/controllers/tools_controller_spec.rb
+++ b/spec/controllers/tools_controller_spec.rb
@@ -44,19 +44,30 @@ describe ToolsController do
   end
 
   describe 'GET #show' do
-    let(:tool) { create(:tool) }
-    before { get :show, id: tool }
+    context 'when the tool exists' do
+      let(:tool) { create(:tool) }
 
-    it 'responds with a 200' do
-      expect(response).to be_success
+      before { get :show, id: tool }
+
+      it 'responds with a 200' do
+        expect(response).to be_success
+      end
+
+      it 'assigns a new tool' do
+        expect(assigns(:tool)).to_not be_nil
+      end
+
+      it 'assigns other tools' do
+        expect(assigns(:other_tools)).to_not be_nil
+      end
     end
 
-    it 'assigns a new tool' do
-      expect(assigns(:tool)).to_not be_nil
-    end
+    context 'when the tool does not exist' do
+      it '404s' do
+        get :show, id: 'dorfle'
 
-    it 'assigns other tools' do
-      expect(assigns(:other_tools)).to_not be_nil
+        expect(response.status.to_i).to eql(404)
+      end
     end
   end
 


### PR DESCRIPTION
:fork_and_knife: 

This fixes 500s caused by trying to access a Tool by a non-existent slug.
