### PR TITLE
Support a paperclip alias URL if a CDN URL is configured

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -8,18 +8,30 @@ end
   end
 
   if configured
-    ::Paperclip::Attachment.default_options.update(
+    options = {
       storage: 's3',
       s3_credentials: {
         bucket: ENV['S3_BUCKET'],
         access_key_id: ENV['S3_ACCESS_KEY_ID'],
         secret_access_key: ENV['S3_SECRET_ACCESS_KEY']
       },
-      url: ':s3_path_url',
       path: path,
       bucket: ENV['S3_BUCKET'],
       s3_protocol: ENV['PROTOCOL']
-    )
+    }
+
+    if ENV['CDN_URL'].present?
+      options = options.merge(
+        url: ':s3_alias_url',
+        s3_host_alias: ENV['CDN_URL']
+      )
+    else
+      options = options.merge(
+        url: ':s3_path_url'
+      )
+    end
+
+    ::Paperclip::Attachment.default_options.update(options)
   else
     ::Paperclip::Attachment.default_options.update(
       storage: :filesystem,

--- a/docs/CONFIGURING.md
+++ b/docs/CONFIGURING.md
@@ -57,6 +57,8 @@ the test suite.
   artifacts.
 * `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY` are the keys required to put
   files in the above bucket.
+* `CDN_URL` Used to configure a CDN URL for use with Paperclip. Downloads
+will be aliased with this URL, something like `static.getchef.com`.
 
 ## Configuring Curry
 


### PR DESCRIPTION
:fork_and_knife: Paperclip should use a CDN alias URL is one is configured.
