### PR TITLE
Allow tool install instructions to be Markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'sitemap_generator'
 gem 'redis-rails'
 gem 'yajl-ruby'
 gem 'utf8-cleaner'
+gem 'rinku', require: 'rails_rinku'
 
 gem 'sentry-raven', '~> 0.8.0', require: false
 gem 'analytics-ruby', '~> 1.0.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -323,6 +323,7 @@ GEM
     rest-client (1.6.8)
       mime-types (~> 1.16)
       rdoc (>= 2.4.2)
+    rinku (1.7.3)
     rspec-core (3.0.3)
       rspec-support (~> 3.0.0)
     rspec-expectations (3.0.3)
@@ -473,6 +474,7 @@ DEPENDENCIES
   rails (~> 4.1.4)
   redcarpet
   redis-rails
+  rinku
   rspec-rails (~> 3.0.2)
   rubocop (>= 0.23.0)
   sass-rails (~> 4.0.1)

--- a/app/assets/stylesheets/listing.scss
+++ b/app/assets/stylesheets/listing.scss
@@ -128,12 +128,13 @@
       p {
         color: $concrete;
         font-size: rem-calc(16);
-        margin: rem-calc(0 0 20 0);
+        margin: 0;
       }
 
       code.install {
         display: block;
         font-weight: normal;
+        margin-top: rem-calc(20);
         padding: rem-calc(8 16 8 16);
       }
     }

--- a/app/assets/stylesheets/resource.scss
+++ b/app/assets/stylesheets/resource.scss
@@ -114,7 +114,7 @@
   .heading {
     border: none;
     font-size: rem-calc(30);
-    margin-bottom: rem-calc(50);
+    margin-bottom: rem-calc(15);
     position: relative;
     z-index: 1;
 

--- a/app/assets/stylesheets/structure.scss
+++ b/app/assets/stylesheets/structure.scss
@@ -41,6 +41,10 @@ fieldset {
   }
 }
 
+textarea {
+  line-height: rem-calc(20);
+}
+
 code, pre {
   @include border-radius(rem-calc(3));
   background-color: darken($primary_blue, 5%);

--- a/app/views/tools/_form.html.erb
+++ b/app/views/tools/_form.html.erb
@@ -33,7 +33,7 @@
 
   <div class="instructions-field">
     <%= f.label :instructions %>
-    <%= f.text_area :instructions, placeholder: 'Install & Usage Instructions', title: 'Instructions', rows: 6 %>
+    <%= f.text_area :instructions, placeholder: 'Install & Usage Instructions (Supports Markdown)', title: 'Instructions', rows: 20 %>
   </div>
 
   <section>

--- a/app/views/tools/_main.html.erb
+++ b/app/views/tools/_main.html.erb
@@ -4,9 +4,10 @@
     <small><%= tool.type.titleize %></small>
   </h1>
 
-  <% if tool.instructions.present? %>
-    <pre class="install"><%= tool.instructions %></pre>
-  <% end %>
+  <%= auto_link(simple_format(tool.description)) %>
 
-  <%= simple_format tool.description %>
+  <% if tool.instructions.present? %>
+    <h3>Install & Usage Instructions</h3>
+    <%= render_markdown tool.instructions %>
+  <% end %>
 </div>

--- a/app/views/tools/_tool.html.erb
+++ b/app/views/tools/_tool.html.erb
@@ -19,9 +19,6 @@
     <div class="body">
       <div class="body-content">
         <%= simple_format tool.description %>
-        <% if tool.instructions.present? %>
-          <code class="install"><%= tool.instructions %></code>
-        <% end %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
:fork_and_knife: Tool install instructions will now be rendered as Markdown. Since this could potentially become rather lengthy and truncating Markdown won't work so well this removes the install instructions from the tool partial. Also auto_link tool descriptions with the help of rinku.

![screen shot 2014-08-06 at 3 50 40 pm](https://cloud.githubusercontent.com/assets/316507/3833030/03f99d78-1da3-11e4-8604-4efe19acb790.png)
