### PR TITLE
Persist install selection

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,6 +28,7 @@
 //= require select2.min
 //= require collaborators
 //= require cookbookDeprecate
+//= require cookbookInstallTabs
 //= require organizations
 //= require tools
 //= require searchToggle

--- a/app/assets/javascripts/cookbookInstallTabs.js
+++ b/app/assets/javascripts/cookbookInstallTabs.js
@@ -1,0 +1,14 @@
+$(function() {
+  $(".persist-install-method dd a").click(function() {
+    var href = $(this).attr("href");
+    var preference = href.replace("#", "");
+
+    $.ajax({
+      type: "POST",
+      url: $(".installs").data('update-url'),
+      data: { "preference": preference },
+      dataType: "json"
+    });
+  });
+});
+

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,5 +1,5 @@
 class ProfileController < ApplicationController
-  before_filter :authenticate_user!
+  before_filter :authenticate_user!, except: [:update_install_preference]
 
   #
   # PATCH /profile
@@ -24,6 +24,21 @@ class ProfileController < ApplicationController
     @pending_requests = @user.pending_contributor_requests
   end
 
+  #
+  # POST /profile/update_install_preference
+  #
+  # Update the current_user's install preference
+  #
+  def update_install_preference
+    if current_user.present?
+      current_user.update_install_preference(preference_param)
+
+      head(200)
+    else
+      head(404)
+    end
+  end
+
   private
 
   #
@@ -40,5 +55,9 @@ class ProfileController < ApplicationController
       :jira_username,
       :email_notifications
     )
+  end
+
+  def preference_param
+    params.require(:preference)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ActiveRecord::Base
   include Authorizable
   include PgSearch
 
+  ALLOWED_INSTALL_PREFERENCES = %w(berkshelf knife librarian)
+
   # Associations
   # --------------------
   has_many :accounts
@@ -326,5 +328,23 @@ class User < ActiveRecord::Base
 
   def to_param
     username
+  end
+
+  #
+  # Updates the user's cookbook install preference to that specified in the
+  # parameter if that parameter is part of the
+  # +User::ALLOWED_INSTALL_PREFERENCES+.
+  #
+  # @param [String] preference - the value to update it to
+  #
+  # @return [Boolean] whether or not the user was successfully updated
+  #
+  def update_install_preference(preference)
+    if ALLOWED_INSTALL_PREFERENCES.include?(preference)
+      self.install_preference = preference
+      save
+    else
+      false
+    end
   end
 end

--- a/app/views/cookbooks/_installs.html.erb
+++ b/app/views/cookbooks/_installs.html.erb
@@ -1,0 +1,59 @@
+<div class="installs" data-update-url="<%= update_install_preference_profile_url %>">
+  <dl data-tab data-options="deep_linking:true; scroll_to_content: false;" class="<%= 'persist-install-method' if current_user %>">
+    <% if current_user && current_user.install_preference.present? %>
+      <dd class="<%= current_user.install_preference == 'berkshelf' ? 'active' : '' %>">
+        <a href="#berkshelf" class="button tiny secondary">Berkshelf</a>
+      </dd>
+
+      <dd class="<%= current_user.install_preference == 'librarian' ? 'active' : '' %>">
+        <a href="#librarian" class="button tiny secondary">Librarian</a>
+      </dd>
+
+      <dd class="<%= current_user.install_preference == 'knife' ? 'active' : '' %>">
+        <a href="#knife" class="button tiny secondary">Knife</a>
+      </dd>
+    <% else %>
+      <dd class="active">
+        <a href="#berkshelf" class="button tiny secondary">Berkshelf</a>
+      </dd>
+
+      <dd>
+        <a href="#librarian" class="button tiny secondary">Librarian</a>
+      </dd>
+
+      <dd>
+        <a href="#knife" class="button tiny secondary">Knife</a>
+      </dd>
+    <% end %>
+  </dl>
+
+  <div class="tabs-content">
+    <% if current_user && current_user.install_preference.present? %>
+      <div class="content <%= current_user.install_preference == 'berkshelf' ? 'active' : '' %>" id="berkshelf">
+        <pre class="install">cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</pre>
+      </div>
+
+      <div class="content <%= current_user.install_preference == 'librarian' ? 'active' : '' %>" id="librarian">
+        <pre class="install">cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</pre>
+      </div>
+
+      <div class="content <%= current_user.install_preference == 'knife' ? 'active' : '' %>" id="knife">
+        <pre class="install">knife cookbook site install <%= cookbook.name %></pre>
+        <pre class="install">knife cookbook site download <%= cookbook.name %></pre>
+      </div>
+    <% else %>
+      <div class="content active" id="berkshelf">
+        <pre class="install">cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</pre>
+      </div>
+
+      <div class="content" id="librarian">
+        <pre class="install">cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</pre>
+      </div>
+
+      <div class="content" id="knife">
+        <pre class="install">knife cookbook site install <%= cookbook.name %></pre>
+        <pre class="install">knife cookbook site download <%= cookbook.name %></pre>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/cookbooks/_main.html.erb
+++ b/app/views/cookbooks/_main.html.erb
@@ -46,26 +46,7 @@
 
   <p><%= cookbook.description %></p>
 
-  <div class="installs">
-    <dl data-tab data-options="deep_linking:true; scroll_to_content: false;">
-      <dd class="active"><a href="#berkshelf" class="button tiny secondary">Berkshelf</a></dd>
-      <dd><a href="#librarian" class="button tiny secondary">Librarian</a></dd>
-      <dd><a href="#knife" class="button tiny secondary">Knife</a></dd>
-    </dl>
-
-    <div class="tabs-content">
-      <div class="content active" id="berkshelf">
-        <pre class="install">cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</pre>
-      </div>
-      <div class="content" id="librarian">
-        <pre class="install">cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</pre>
-      </div>
-      <div class="content" id="knife">
-        <pre class="install">knife cookbook site install <%= cookbook.name %></pre>
-        <pre class="install">knife cookbook site download <%= cookbook.name %></pre>
-      </div>
-    </div>
-  </div>
+  <%= render 'cookbooks/installs', cookbook: cookbook %>
 
   <dl class="tabs" data-tab data-options="deep_linking:true">
     <dd class="active"><a href="#readme">README</a></dd>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,8 @@ Supermarket::Application.routes.draw do
   resources :tools, constraints: proc { ENV['TOOLS_ENABLED'] == 'true' }
 
   resource :profile, controller: 'profile', only: [:update, :edit] do
+    post :update_install_preference, format: :json
+
     collection do
       patch :change_password
       get :link_github, path: 'link-github'

--- a/db/migrate/20140807125138_add_install_preference_to_user.rb
+++ b/db/migrate/20140807125138_add_install_preference_to_user.rb
@@ -1,0 +1,5 @@
+class AddInstallPreferenceToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :install_preference, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140805212826) do
+ActiveRecord::Schema.define(version: 20140807125138) do
 
   create_table "accounts", force: true do |t|
     t.integer  "user_id"
@@ -337,6 +337,7 @@ ActiveRecord::Schema.define(version: 20140805212826) do
     t.string   "twitter_username"
     t.text     "public_key"
     t.boolean  "email_notifications", default: true
+    t.string   "install_preference"
   end
 
 end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -91,4 +91,30 @@ describe ProfileController do
       end
     end
   end
+
+  describe 'POST #update_install_preference' do
+    context 'user signed in' do
+      before { sign_in user }
+
+      it 'returns a 200 on successful update' do
+        post :update_install_preference, preference: 'knife'
+
+        expect(response.status.to_i).to eql(200)
+      end
+
+      it "updates the user's install preference" do
+        post :update_install_preference, preference: 'knife'
+
+        expect(user.install_preference).to eql('knife')
+      end
+    end
+
+    context 'user not signed in' do
+      it 'returns a 404' do
+        post :update_install_preference, preference: 'knife'
+
+        expect(response.status.to_i).to eql(404)
+      end
+    end
+  end
 end

--- a/spec/features/cookbook_install_select_spec.rb
+++ b/spec/features/cookbook_install_select_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_feature_helper'
+
+describe 'selecting cookbook install selection type' do
+  it "persists the user's selected install type", use_poltergeist: true do
+    sign_in(create(:user))
+    cookbook = create(:cookbook)
+    cookbook_two = create(:cookbook)
+
+    visit cookbook_path(cookbook)
+
+    within('.installs') do
+      click_on 'Knife'
+    end
+
+    visit cookbook_path(cookbook_two)
+
+    expect(page).to have_selector('#knife.active')
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -493,4 +493,25 @@ describe User do
       expect(pending_requests.to_a).to_not include(accepted_contributor_request)
     end
   end
+
+  describe '#update_install_preference' do
+    it 'returns true if the user is saved' do
+      user = build(:user)
+
+      expect(user.update_install_preference('knife')).to be true
+    end
+
+    it 'returns false if the preference is not a valid one' do
+      user = build(:user)
+
+      expect(user.update_install_preference('wut')).to be false
+    end
+
+    it 'updates the install preference to what is specified' do
+      user = create(:user)
+      user.update_install_preference('knife')
+
+      expect(user.reload.install_preference).to eql('knife')
+    end
+  end
 end


### PR DESCRIPTION
:fork_and_knife: 

When a signed in user clicks the install instructions for a cookbook, persist their selection on their account.

todo:
- [x] update the installs view to be less nutso
- [x] get the feature spec passing

Trello card: https://trello.com/c/l7YoGfzK
