### PR TITLE
Render replacement cookbook URL in API

### DIFF
--- a/app/views/api/v1/cookbooks/show.json.jbuilder
+++ b/app/views/api/v1/cookbooks/show.json.jbuilder
@@ -1,5 +1,8 @@
 json.partial! 'cookbook'
 json.deprecated @cookbook.deprecated
+if @cookbook.deprecated? && @cookbook.replacement.present?
+  json.replacement api_v1_cookbook_url(@cookbook.replacement)
+end
 json.versions Array(@cookbook_versions_urls)
 json.metrics do
   json.downloads do

--- a/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
@@ -7,7 +7,8 @@ describe 'api/v1/cookbooks/show' do
       name: 'redis',
       source_url: 'http://example.com',
       issues_url: 'http://example.com',
-      deprecated: false,
+      deprecated: true,
+      replacement: create(:cookbook),
       web_download_count: 2,
       api_download_count: 32
     )
@@ -92,7 +93,12 @@ describe 'api/v1/cookbooks/show' do
 
   it "displays the cookbook's deprecation status" do
     deprecated = json_body['deprecated']
-    expect(deprecated).to eql(false)
+    expect(deprecated).to eql(true)
+  end
+
+  it "displays the cookbook's replacement cookbook" do
+    replacement = json_body['replacement']
+    expect(replacement).to eql(api_v1_cookbook_url(cookbook.replacement))
   end
 
   it "displays the cookbook's versions" do


### PR DESCRIPTION
:fork_and_knife: 

When a cookbook is deprecated, display the replacement cookbook in the cookbook
show API.

Fixes #725

Fixes https://github.com/opscode/chef/issues/1755
