### PR TITLE
Use monospace typeface in markdown fields

### DIFF
--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -51,3 +51,7 @@ blockquote {
   padding: rem-calc(9 20 0 19);
   border: solid 1px #ddd;
 }
+
+.monospace {
+  font-family: Consolas,"Liberation Mono",Courier,monospace;
+}

--- a/app/views/tools/_form.html.erb
+++ b/app/views/tools/_form.html.erb
@@ -33,7 +33,7 @@
 
   <div class="instructions-field">
     <%= f.label :instructions %>
-    <%= f.text_area :instructions, placeholder: 'Install & Usage Instructions (Supports Markdown)', title: 'Instructions', rows: 20 %>
+    <%= f.text_area :instructions, placeholder: 'Install & Usage Instructions (Supports Markdown)', class: 'monospace', title: 'Instructions', rows: 20 %>
   </div>
 
   <section>


### PR DESCRIPTION
:fork_and_knife:

Closes #727.

Looks like:

![screen shot 2014-08-07 at 1 28 43 pm](https://cloud.githubusercontent.com/assets/928367/3846080/2ef514ce-1e59-11e4-99a1-4fd97a865f15.png)
