### PR TITLE
Use polymorphic_url instead of url_for for collaboration mailer

### DIFF
--- a/app/mailers/mail_preview.rb
+++ b/app/mailers/mail_preview.rb
@@ -56,6 +56,10 @@ if Rails.env.development?
       ContributorRequestMailer.request_declined_email(contributor_request)
     end
 
+    def collaborator_email
+      CollaboratorMailer.added_email(collaborator)
+    end
+
     private
 
     def organization
@@ -88,6 +92,10 @@ if Rails.env.development?
 
     def cookbook_follower
       CookbookFollower.where(user: user).first!
+    end
+
+    def collaborator
+      Collaborator.where(user: user, resourceable: cookbook).first_or_create!
     end
   end
 end

--- a/app/views/collaborator_mailer/added_email.html.erb
+++ b/app/views/collaborator_mailer/added_email.html.erb
@@ -1,3 +1,3 @@
 <h1>Collaborator Notification</h1>
 
-<p>You have been added as a collaborator to the <%= link_to @resource.name, url_for(@resource) %> <%= @resource.class.name %>.</p>
+<p>You have been added as a collaborator to the <%= link_to @resource.name, polymorphic_url(@resource) %> <%= @resource.class.name %>.</p>

--- a/app/views/collaborator_mailer/added_email.text.erb
+++ b/app/views/collaborator_mailer/added_email.text.erb
@@ -1,4 +1,4 @@
 Chef Supermarket - Collaborator Notification
 _________________________________________________________
 
-You have been added as a collaborator to the <%= @resource.name %> <%= @resource.class.name %>.  Find out more details here: <%= url_for(@resource) %>
+You have been added as a collaborator to the <%= @resource.name %> <%= @resource.class.name %>.  Find out more details here: <%= polymorphic_url(@resource) %>


### PR DESCRIPTION
:fork_and_knife: `polymorphic_url` should generate the full URL for `resourceable`. Also add collaborator email mail preview.

According to the [Rails docs](https://github.com/rails/rails/blob/fa0cff484a8f0c99480b7545fc77610009723147/actionpack/lib/action_dispatch/routing/polymorphic_routes.rb#L91) `polymorphic_url` should be the equivalent to calling `cookbook_url(cookbook)` or `tool_url(tool)`.
