### PR TITLE
Display changelog in follower email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'redis-rails'
 gem 'yajl-ruby'
 gem 'utf8-cleaner'
 gem 'rinku', require: 'rails_rinku'
+gem 'html_truncator'
 
 gem 'sentry-raven', '~> 0.8.0', require: false
 gem 'analytics-ruby', '~> 1.0.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,8 @@ GEM
     hashie (2.1.2)
     highline (1.6.21)
     hike (1.2.3)
+    html_truncator (0.4.0)
+      nokogiri (~> 1.5)
     htmlentities (4.3.2)
     httparty (0.13.1)
       json (~> 1.8)
@@ -452,6 +454,7 @@ DEPENDENCIES
   factory_girl
   faker
   foreman
+  html_truncator
   jbuilder
   kaminari
   launchy

--- a/app/assets/stylesheets/mailers.css.scss
+++ b/app/assets/stylesheets/mailers.css.scss
@@ -183,3 +183,15 @@ a { color: #404248; }
   background-color: #f04124;
   padding: 0 50px;
 }
+
+.changelog {
+  .title {
+    border-bottom: solid 1px #e7e7e7;
+    padding-bottom: 10px;
+    margin-top: 30px;
+  }
+
+  .button {
+    margin-top: 20px;
+  }
+}

--- a/app/mailers/cookbook_mailer.rb
+++ b/app/mailers/cookbook_mailer.rb
@@ -1,5 +1,6 @@
 class CookbookMailer < ActionMailer::Base
   layout 'mailer'
+  add_template_helper(CookbookVersionsHelper)
 
   #
   # Creates notification email to a cookbook follower

--- a/app/views/cookbook_mailer/follower_notification_email.html.erb
+++ b/app/views/cookbook_mailer/follower_notification_email.html.erb
@@ -1,3 +1,12 @@
 <h1>New version of <%= @cookbook.name %> released.</h1>
 <p>A new version of <%= @cookbook.name %> has been relased [<%= @cookbook.latest_cookbook_version.version %>].</p>
 <%= link_to 'View Version', cookbook_version_url(@cookbook, @cookbook.latest_cookbook_version), class: 'button accept' %>
+
+<div class="changelog">
+  <% if @cookbook.latest_cookbook_version.changelog.present? %>
+    <h2 class="title">Changelog</h2>
+    <%= HTML_Truncator.truncate(render_document(@cookbook.latest_cookbook_version.changelog, @cookbook.latest_cookbook_version.changelog_extension), 30, ellipsis: '').html_safe %>
+
+    <%= link_to 'View Full Changelog', cookbook_version_url(@cookbook, @cookbook.latest_cookbook_version, anchor: 'changelog'), class: 'button accept' %>
+  <% end %>
+</div>

--- a/app/views/cookbook_mailer/follower_notification_email.text.erb
+++ b/app/views/cookbook_mailer/follower_notification_email.text.erb
@@ -7,3 +7,12 @@ New version of <%= @cookbook.name %> released.
 A new version of <%= @cookbook.name %> has been relased [<%= @cookbook.latest_cookbook_version.version %>].
 
 <%= cookbook_version_url(@cookbook, @cookbook.latest_cookbook_version) %>
+
+<% if @cookbook.latest_cookbook_version.changelog.present? %>
+Changelog
+_________________________________________________________
+
+<%= truncate @cookbook.latest_cookbook_version.changelog, length: 100 %>
+
+<%= cookbook_version_url(@cookbook, @cookbook.latest_cookbook_version, anchor: 'changelog') %>
+<% end %>


### PR DESCRIPTION
:fork_and_knife: Display truncated changelog and link to full changelog in follower notification email.

![screen shot 2014-08-07 at 3 00 42 pm](https://cloud.githubusercontent.com/assets/316507/3847455/ff1cbc5e-1e65-11e4-8fa9-35d7edbf71c6.png)

Closes #664.
