### PR TITLE
Only display user first, last name if they exist

### DIFF
--- a/app/assets/javascripts/collaborators.js
+++ b/app/assets/javascripts/collaborators.js
@@ -20,7 +20,11 @@ $(document).on('opened', '[data-reveal]', function () {
       return collaborator.username;
     },
     formatResult: function(collaborator, container) {
-      return collaborator.first_name + ' ' + collaborator.last_name + ' (' + collaborator.username + ')';
+      if(collaborator.first_name && collaborator.last_name) {
+        return collaborator.first_name + ' ' + collaborator.last_name + ' (' + collaborator.username + ')';
+      } else {
+        return collaborator.username;
+      }
     }
   }
 


### PR DESCRIPTION
:fork_and_knife: When looking for collaborators via select2 only display the users first and last name if they have one (in Supermarket), otherwise just display their username.

From

![screen shot 2014-08-07 at 4 19 51 pm](https://cloud.githubusercontent.com/assets/316507/3848485/5c9f9978-1e70-11e4-8e13-7839f18a107e.png)

To

![screen shot 2014-08-07 at 4 20 40 pm](https://cloud.githubusercontent.com/assets/316507/3848487/5f746c82-1e70-11e4-8156-105c064c99fb.png)
