### PR TITLE
Obvious fix: berkshelf tab typo

### DIFF
--- a/app/views/cookbooks/_main.html.erb
+++ b/app/views/cookbooks/_main.html.erb
@@ -48,7 +48,7 @@
 
   <div class="installs">
     <dl data-tab data-options="deep_linking:true; scroll_to_content: false;">
-      <dd class="active"><a href="#berkshelf" class="button tiny secondary">Bershelf</a></dd>
+      <dd class="active"><a href="#berkshelf" class="button tiny secondary">Berkshelf</a></dd>
       <dd><a href="#librarian" class="button tiny secondary">Librarian</a></dd>
       <dd><a href="#knife" class="button tiny secondary">Knife</a></dd>
     </dl>


### PR DESCRIPTION
![fixes-bershelf-tab](https://cloud.githubusercontent.com/assets/12483/3849966/68870618-1e7f-11e4-9d18-1cc2561c8af9.png)
