### PR TITLE
Create the public User show API.

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,20 @@
+class Api::V1::UsersController < Api::V1Controller
+  #
+  # GET /api/v1/users/:user
+  #
+  # Return the specified user and their associated data. If the user does not
+  # exist, return a 404.
+  #
+  # @example
+  #   GET /api/v1/users/opscode
+  #
+  def show
+    @user = Account.for(
+      'chef_oauth2'
+    ).joins(:user).with_username(params[:user]).first!.user
+    @github_usernames = @user.accounts.for('github').map(&:username).sort
+    @owned_cookbooks = @user.owned_cookbooks.order('name ASC')
+    @collaborated_cookbooks = @user.collaborated_cookbooks.order('name ASC')
+    @followed_cookbooks = @user.followed_cookbooks.order('name ASC')
+  end
+end

--- a/app/views/api/v1/users/show.json.jbuilder
+++ b/app/views/api/v1/users/show.json.jbuilder
@@ -1,0 +1,26 @@
+json.username @user.username
+json.name @user.name
+json.company @user.company
+json.github Array(@github_usernames)
+json.twitter @user.twitter_username
+json.irc @user.irc_nickname
+json.jira @user.jira_username
+json.cookbooks do
+  json.set! :owns do
+    @owned_cookbooks.each do |cookbook|
+      json.set! cookbook.name, api_v1_cookbook_url(cookbook)
+    end
+  end
+
+  json.set! :collaborates do
+    @collaborated_cookbooks.each do |cookbook|
+      json.set! cookbook.name, api_v1_cookbook_url(cookbook)
+    end
+  end
+
+  json.set! :follows do
+    @followed_cookbooks.each do |cookbook|
+      json.set! cookbook.name, api_v1_cookbook_url(cookbook)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Supermarket::Application.routes.draw do
       get 'cookbooks/:cookbook/versions/:version/download' => 'cookbook_versions#download', as: :cookbook_version_download, constraints: { version: VERSION_PATTERN }
       post 'cookbooks' => 'cookbook_uploads#create'
       delete 'cookbooks/:cookbook' => 'cookbook_uploads#destroy'
+      get 'users/:user' => 'users#show', as: :user
     end
   end
 

--- a/spec/api/user_show_spec.rb
+++ b/spec/api/user_show_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+
+describe 'GET /api/v1/users/:user' do
+  context 'when the user exists' do
+    let!(:user) do
+      create(
+        :user,
+        first_name: 'Fanny',
+        last_name: 'McNanny',
+        company: 'Fanny Pack',
+        twitter_username: 'fanny',
+        irc_nickname: 'fanny',
+        jira_username: 'fanny',
+        chef_account: create(
+          :account,
+          provider: 'chef_oauth2',
+          username: 'fanny'
+        ),
+        create_chef_account: false
+      )
+    end
+
+    let!(:user_signature) do
+      {
+        'username' => 'fanny',
+        'name' => 'Fanny McNanny',
+        'company' => 'Fanny Pack',
+        'twitter' => 'fanny',
+        'irc' => 'fanny',
+        'jira' => 'fanny',
+        'github' => ['fanny'],
+        'cookbooks' => {
+          'owns' => {
+            'macand' => 'http://www.example.com/api/v1/cookbooks/macand',
+            'redis-test' => 'http://www.example.com/api/v1/cookbooks/redis-test'
+          },
+          'collaborates' => {
+            'zeromq' => 'http://www.example.com/api/v1/cookbooks/zeromq'
+          },
+          'follows' => {
+            'ruby' => 'http://www.example.com/api/v1/cookbooks/ruby',
+            'postgres' => 'http://www.example.com/api/v1/cookbooks/postgres'
+          }
+        }
+      }
+    end
+
+    before do
+      create(
+        :account,
+        provider: 'github',
+        username: 'fanny',
+        user: user
+      )
+      create(:cookbook, name: 'redis-test', owner: user)
+      create(:cookbook, name: 'macand', owner: user)
+      create(
+        :cookbook_collaborator,
+        resourceable: create(:cookbook, name: 'zeromq'),
+        user: user
+      )
+      create(
+        :cookbook_follower,
+        cookbook: create(:cookbook, name: 'postgres'),
+        user: user
+      )
+      create(
+        :cookbook_follower,
+        cookbook: create(:cookbook, name: 'ruby'),
+        user: user
+      )
+    end
+
+    it 'returns a 200' do
+      get '/api/v1/users/fanny'
+
+      expect(response.status.to_i).to eql(200)
+    end
+
+    it 'returns the user' do
+      get '/api/v1/users/fanny'
+
+      expect(signature(json_body)).to include(user_signature)
+    end
+  end
+
+  context 'when the user does not exist' do
+    it 'returns a 404' do
+      get '/api/v1/users/notauser'
+
+      expect(response.status.to_i).to eql(404)
+    end
+
+    it 'returns a 404 message' do
+      get '/api/v1/users/notauser'
+
+      expect(json_body).to eql(error_404)
+    end
+  end
+end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+
+describe Api::V1::UsersController do
+  let!(:user) { create(:user) }
+
+  let!(:redis_test) do
+    create(:cookbook, name: 'redis_test', owner: user)
+  end
+
+  let!(:macand) do
+    create(:cookbook, name: 'macand', owner: user)
+  end
+
+  let!(:zeromq) { create(:cookbook, name: 'zeromq') }
+  let!(:apples) { create(:cookbook, name: 'apples') }
+  let!(:postgres) { create(:cookbook, name: 'postgres') }
+  let!(:ruby) { create(:cookbook, name: 'ruby') }
+
+  describe '#show' do
+    context 'when a user exists' do
+      before do
+        create(
+          :account,
+          provider: 'chef_oauth2',
+          user: user,
+          username: 'clive'
+        )
+        create(
+          :account,
+          provider: 'github',
+          user: user,
+          username: 'clive'
+        )
+        create(
+          :account,
+          provider: 'github',
+          user: user,
+          username: 'xanadu'
+        )
+        create(
+          :cookbook_collaborator,
+          resourceable: zeromq,
+          user: user
+        )
+        create(
+          :cookbook_collaborator,
+          resourceable: apples,
+          user: user
+        )
+        create(
+          :cookbook_follower,
+          cookbook: postgres,
+          user: user
+        )
+        create(
+          :cookbook_follower,
+          cookbook: ruby,
+          user: user
+        )
+      end
+
+      it 'responds with a 200' do
+        get :show, user: 'clive', format: :json
+
+        expect(response.status.to_i).to eql(200)
+      end
+
+      it 'sends the user to the view' do
+        get :show, user: 'clive', format: :json
+
+        expect(assigns[:user]).to eql(user)
+      end
+
+      it "sends the user's github accounts to the view" do
+        get :show, user: 'clive', format: :json
+
+        expect(assigns[:github_usernames]).to include('clive')
+        expect(assigns[:github_usernames]).to include('xanadu')
+      end
+
+      it 'sorts the github accounts by username' do
+        get :show, user: 'clive', format: :json
+
+        expect(assigns[:github_usernames]).to eql(%w(clive xanadu))
+      end
+
+      it 'sends the owned cookbooks to the view' do
+        get :show, user: 'clive', format: :json
+
+        expect(assigns[:owned_cookbooks]).to include(macand)
+        expect(assigns[:owned_cookbooks]).to include(redis_test)
+      end
+
+      it 'sorts the owned cookbooks by name' do
+        get :show, user: 'clive', format: :json
+
+        expect(assigns[:owned_cookbooks].to_a).to eql([macand, redis_test])
+      end
+
+      it 'sends the collaborated cookbooks to the view' do
+        get :show, user: 'clive', format: :json
+
+        expect(assigns[:collaborated_cookbooks]).to include(apples)
+        expect(assigns[:collaborated_cookbooks]).to include(zeromq)
+      end
+
+      it 'sorts the collaborated cookbooks by name' do
+        get :show, user: 'clive', format: :json
+
+        expect(assigns[:collaborated_cookbooks].to_a).to eql([apples, zeromq])
+      end
+
+      it 'sends the followed cookbooks to the view' do
+        get :show, user: 'clive', format: :json
+
+        expect(assigns[:followed_cookbooks]).to include(ruby)
+        expect(assigns[:followed_cookbooks]).to include(postgres)
+      end
+
+      it 'sorts the followed cookbooks by name' do
+        get :show, user: 'clive', format: :json
+
+        expect(assigns[:followed_cookbooks].to_a).to eql([postgres, ruby])
+      end
+
+    end
+
+    context 'when a user does not exist' do
+      it 'responds with a 404' do
+        get :show, user: 'sushiqueen', format: :json
+
+        expect(response.status.to_i).to eql(404)
+      end
+    end
+  end
+end

--- a/spec/views/api/v1/users/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/users/show.json.jbuilder_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+describe 'api/v1/users/show' do
+  let!(:user) do
+    create(
+      :user,
+      first_name: 'Fanny',
+      last_name: 'McNanny',
+      company: 'FannyInternational',
+      twitter_username: 'fannyfannyfanny',
+      irc_nickname: 'fannyfunnyfanny',
+      jira_username: 'funnyfannyfunny'
+    )
+  end
+
+  before do
+    create(
+      :account,
+      provider: 'chef_oauth2',
+      username: 'fanny',
+      user: user
+    )
+    create(
+      :account,
+      provider: 'github',
+      username: 'fanny',
+      user: user
+    )
+    create(:cookbook, name: 'redis-test', owner: user)
+    create(:cookbook, name: 'macand', owner: user)
+    create(
+      :cookbook_collaborator,
+      resourceable: create(:cookbook, name: 'zeromq'),
+      user: user
+    )
+    create(
+      :cookbook_follower,
+      cookbook: create(:cookbook, name: 'postgres'),
+      user: user
+    )
+    create(
+      :cookbook_follower,
+      cookbook: create(:cookbook, name: 'ruby'),
+      user: user
+    )
+
+    assign(:user, user)
+    assign(:owned_cookbooks, user.owned_cookbooks)
+    assign(:collaborated_cookbooks, user.collaborated_cookbooks)
+    assign(:followed_cookbooks, user.followed_cookbooks)
+    assign(:github_usernames, user.accounts.for('github').map(&:username))
+
+    render
+  end
+
+  it "displays the user's chef username" do
+    username = json_body['username']
+    expect(username).to eql(user.username)
+  end
+
+  it "displays the user's name" do
+    name = json_body['name']
+    expect(name).to eql(user.name)
+  end
+
+  it "displays the user's company" do
+    company = json_body['company']
+    expect(company).to eql(user.company)
+  end
+
+  it "displays the user's github accounts" do
+    github = json_body['github']
+    expect(github).to eql(['fanny'])
+  end
+
+  it "displays the user's twitter handle" do
+    twitter = json_body['twitter']
+    expect(twitter).to eql(user.twitter_username)
+  end
+
+  it "displays the user's irc handle" do
+    irc = json_body['irc']
+    expect(irc).to eql(user.irc_nickname)
+  end
+
+  it "displays the user's jira username" do
+    jira = json_body['jira']
+    expect(jira).to eql(user.jira_username)
+  end
+
+  it 'displays the cookbooks the user owns' do
+    owned_cookbooks = json_body['cookbooks']['owns']
+    expect(owned_cookbooks).to eql(
+      'macand' => 'http://test.host/api/v1/cookbooks/macand',
+      'redis-test' => 'http://test.host/api/v1/cookbooks/redis-test'
+    )
+  end
+
+  it 'displays the cookbooks the user collaborates on' do
+    collaborates_cookbooks = json_body['cookbooks']['collaborates']
+    expect(collaborates_cookbooks).to eql(
+      'zeromq' => 'http://test.host/api/v1/cookbooks/zeromq'
+    )
+  end
+
+  it 'displays the cookbooks the user follows' do
+    collaborates_cookbooks = json_body['cookbooks']['follows']
+    expect(collaborates_cookbooks).to eql(
+      'postgres' => 'http://test.host/api/v1/cookbooks/postgres',
+      'ruby' => 'http://test.host/api/v1/cookbooks/ruby'
+    )
+  end
+end


### PR DESCRIPTION
:fork_and_knife: 

A user and their related cookbooks can be viewed via the API by issuing a GET
request to /api/v1/users/:username.

Example:

```
GET /api/v1/users/opscode
```

This returns the user, quite a bit of their data on their record and the
cookbooks they are associated with (owns, collaborates, follows). This does not
include Tools because there is no API available for them at this time.

Note: the GitHub accounts are an array because a user may have more than one
connected GitHub account.

What the blob looks like:

``` json
{
  "username": "brettchalupa",
  "name": "Brett Chalupa",
  "company": "FullStack",
  "github": [
    "brettchalupa"
  ],
  "twitter": "brettchalupa",
  "irc": "",
  "jira": "",
  "cookbooks": {
    "owns": {
      "redis": "http://localhost:3000/api/v1/cookbooks/redis"
    },
    "collaborates": {},
    "follows": {
      "haskell": "http://localhost:3000/api/v1/cookbooks/haskell",
      "mysql": "http://localhost:3000/api/v1/cookbooks/mysql",
      "yum": "http://localhost:3000/api/v1/cookbooks/yum"
    }
  }
}
```

Closes #545 
