### PR TITLE
Allow the user to click on details and gear

### DIFF
--- a/app/assets/stylesheets/cookbooks/show.scss
+++ b/app/assets/stylesheets/cookbooks/show.scss
@@ -179,9 +179,13 @@
   }
 
   .show-cookbook-urls-manage {
-    font-size: rem-calc(18);
+    cursor: pointer;
 
-    &.active .fa {
+    .fa {
+      font-size: rem-calc(18);
+    }
+
+    &.active, &.active .fa {
       color: $secondary_blue;
     }
   }

--- a/app/views/cookbooks/_sidebar.html.erb
+++ b/app/views/cookbooks/_sidebar.html.erb
@@ -6,9 +6,9 @@
     <%= render "cookbooks/manage_cookbook", cookbook: cookbook %>
   <% end %>
 
-  <h3>
+  <h3 class="<%= 'show-cookbook-urls-manage' if policy(cookbook).manage_cookbook_urls? %>" rel="edit-cookbook-urls">
     <% if policy(cookbook).manage_cookbook_urls? %>
-      <%= link_to '#', class: 'show-cookbook-urls-manage', rel: 'edit-cookbook-urls' do %>
+      <%= link_to '#' do %>
          <i class="fa fa-gear"></i>
       <% end %>
     <% end %>


### PR DESCRIPTION
:fork_and_knife: To make the manage cookbook UI a bit easier to use allow the user to click on the details heading or the gear.

![toggle](https://cloud.githubusercontent.com/assets/316507/3891189/aed44b16-2227-11e4-8eeb-a7276f969ff4.gif)

Closes #724.
