### PR TITLE
Add authorized_to_contribute to users show API.

### DIFF
--- a/app/views/api/v1/users/show.json.jbuilder
+++ b/app/views/api/v1/users/show.json.jbuilder
@@ -5,6 +5,7 @@ json.github Array(@github_usernames)
 json.twitter @user.twitter_username
 json.irc @user.irc_nickname
 json.jira @user.jira_username
+json.authorized_to_contribute @user.authorized_to_contribute?
 json.cookbooks do
   json.set! :owns do
     @owned_cookbooks.each do |cookbook|

--- a/spec/api/user_show_spec.rb
+++ b/spec/api/user_show_spec.rb
@@ -29,6 +29,7 @@ describe 'GET /api/v1/users/:user' do
         'irc' => 'fanny',
         'jira' => 'fanny',
         'github' => ['fanny'],
+        'authorized_to_contribute' => true,
         'cookbooks' => {
           'owns' => {
             'macand' => 'http://www.example.com/api/v1/cookbooks/macand',
@@ -69,6 +70,7 @@ describe 'GET /api/v1/users/:user' do
         cookbook: create(:cookbook, name: 'ruby'),
         user: user
       )
+      create(:icla_signature, user: user)
     end
 
     it 'returns a 200' do

--- a/spec/views/api/v1/users/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/users/show.json.jbuilder_spec.rb
@@ -43,6 +43,7 @@ describe 'api/v1/users/show' do
       cookbook: create(:cookbook, name: 'ruby'),
       user: user
     )
+    create(:icla_signature, user: user)
 
     assign(:user, user)
     assign(:owned_cookbooks, user.owned_cookbooks)
@@ -86,6 +87,11 @@ describe 'api/v1/users/show' do
   it "displays the user's jira username" do
     jira = json_body['jira']
     expect(jira).to eql(user.jira_username)
+  end
+
+  it "displays the user's authorized_to_contribute status" do
+    authorized = json_body['authorized_to_contribute']
+    expect(authorized).to eql(true)
   end
 
   it 'displays the cookbooks the user owns' do


### PR DESCRIPTION
:fork_and_knife: 

Adds the `authorized_to_contribute` boolean to the users show API.

The blob now looks like:

``` json
{
  "username": "brettchalupa",
  "name": "Brett Chalupa",
  "company": "FullStack",
  "github": [
    "brettchalupa"
  ],
  "twitter": "brettchalupa",
  "irc": "",
  "jira": "",
  "authorized_to_contribute": true,
  "cookbooks": {
    "owns": {
      "redis": "http://localhost:3000/api/v1/cookbooks/redis"
    },
    "collaborates": {},
    "follows": {
      "haskell": "http://localhost:3000/api/v1/cookbooks/haskell",
      "mysql": "http://localhost:3000/api/v1/cookbooks/mysql",
      "yum": "http://localhost:3000/api/v1/cookbooks/yum"
    }
  }
}
```
