### PR TITLE
Health endpoint returns "not ok" if all is not ok.

### DIFF
--- a/app/controllers/api/v1/health_controller.rb
+++ b/app/controllers/api/v1/health_controller.rb
@@ -84,5 +84,13 @@ class Api::V1::HealthController < Api::V1Controller
       @sidekiq_health.store(:status, UNREACHABLE)
       @redis_health.store(:status, UNREACHABLE)
     end
+
+    if @sidekiq_health.fetch(:status) == REACHABLE &&
+         @postgresql_health.fetch(:status) == REACHABLE &&
+         @redis_health.fetch(:status) == REACHABLE
+      @status = 'ok'
+    else
+      @status = 'not ok'
+    end
   end
 end

--- a/app/views/api/v1/health/show.json.jbuilder
+++ b/app/views/api/v1/health/show.json.jbuilder
@@ -1,4 +1,4 @@
-json.status 'ok'
+json.status @status
 json.supermarket @supermarket_health
 json.sidekiq @sidekiq_health
 json.postgresql @postgresql_health


### PR DESCRIPTION
:fork_and_knife: 

If any aspects of the health endpoint are not "REACHABLE", set the status to
"not ok".

This is a follow up from the postmortem today about `/universe` being down.

Trello card: https://trello.com/c/Ho4fHdXy
