### PR TITLE
fix rss link hit area

### DIFF
--- a/app/assets/stylesheets/structure.scss
+++ b/app/assets/stylesheets/structure.scss
@@ -345,7 +345,8 @@ pre {
 }
 
 .rss_feed_link {
-  display: block;
+  display: inline-block;
+  padding: 3px 15px 3px 0;
   color: darken($primary_gray, 10%);
   font: {
     size: rem-calc(12);


### PR DESCRIPTION
The rss link is currently a block element and spans the entire page. It's easy to click when you don't mean to. This fixes that by changing to inline-block and adding a little padding for fat fingers.
