### PR TITLE
Add Kitchen Driver to supported Tool types.

### DIFF
--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -1,7 +1,7 @@
 class Tool < ActiveRecord::Base
   include PgSearch
 
-  ALLOWED_TYPES = %w(knife_plugin ohai_plugin chef_tool handler metal_driver)
+  ALLOWED_TYPES = %w(knife_plugin ohai_plugin chef_tool handler metal_driver kitchen_driver)
 
   self.inheritance_column = nil
 


### PR DESCRIPTION
:fork_and_knife: 

Closes #746.
