### PR TITLE
Create the Tools show API endpoint

### DIFF
--- a/app/controllers/api/v1/tools_controller.rb
+++ b/app/controllers/api/v1/tools_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::ToolsController < Api::V1Controller
+  #
+  # GET /api/v1/tools/:tool
+  #
+  # Return the specified tool. If it does not exist, return a 404.
+  #
+  # @example
+  #   GET /api/v1/tools/berkshelf
+  #
+  def show
+    @tool = Tool.find_by!(name: params[:tool])
+  end
+end

--- a/app/views/api/v1/tools/show.json.jbuilder
+++ b/app/views/api/v1/tools/show.json.jbuilder
@@ -1,0 +1,7 @@
+json.name @tool.name
+json.slug @tool.slug
+json.type @tool.type
+json.source_url @tool.source_url
+json.description @tool.description
+json.instructions @tool.instructions
+json.owner @tool.maintainer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Supermarket::Application.routes.draw do
       delete 'cookbooks/:cookbook' => 'cookbook_uploads#destroy'
       get 'users/:user' => 'users#show', as: :user
       post '/cookbook-verisons/evaluation' => 'cookbook_versions#evaluation', as: :cookbook_versions_evaluation, constraints: proc { ROLLOUT.active?(:fieri) }
+
+      get 'tools/:tool' => 'tools#show', as: :tool
     end
   end
 

--- a/spec/api/tool_show_spec.rb
+++ b/spec/api/tool_show_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'GET /api/v1/tools/:tool' do
+  context 'when the tool exists' do
+    let(:tool) { create(:tool) }
+
+    let(:tool_signature) do
+      {
+        'name' => tool.name,
+        'slug' => tool.slug,
+        'type' => tool.type,
+        'source_url' => tool.source_url,
+        'description' => tool.description,
+        'instructions' => tool.instructions,
+        'owner' => tool.maintainer
+      }
+    end
+
+    it 'returns a 200' do
+      get "/api/v1/tools/#{tool.name}"
+
+      expect(response.status.to_i).to eql(200)
+    end
+
+    it 'returns the tool' do
+      get "/api/v1/tools/#{tool.name}"
+
+      expect(signature(json_body)).to include(tool_signature)
+    end
+  end
+
+  context 'when the tool does not exist' do
+    it 'returns a 404' do
+      get '/api/v1/tools/trololol'
+
+      expect(response.status.to_i).to eql(404)
+    end
+
+    it 'returns a 404 message' do
+      get '/api/v1/tools/trololol'
+
+      expect(json_body).to eql(error_404)
+    end
+  end
+end

--- a/spec/controllers/api/v1/tools_controller_spec.rb
+++ b/spec/controllers/api/v1/tools_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe Api::V1::ToolsController do
+  describe '#show' do
+    context 'when a tool exists' do
+      let!(:berkshelf_tool) { create(:tool, name: 'berkshelf') }
+
+      it 'responds with a 200' do
+        get :show, tool: berkshelf_tool.name, format: :json
+
+        expect(response.status.to_i).to eql(200)
+      end
+
+      it 'sends the tool to the view' do
+        get :show, tool: berkshelf_tool.name, format: :json
+
+        expect(assigns[:tool]).to eql(berkshelf_tool)
+      end
+    end
+
+    context 'when a tool does not exist' do
+      it 'responds with a 404' do
+        get :show, tool: 'trololol', format: :json
+
+        expect(response.status.to_i).to eql(404)
+      end
+    end
+  end
+end


### PR DESCRIPTION
:fork_and_knife: :meat_on_bone: :curry:

This allows access to the information for a specific Tool via the API.

An example request:

```
 GET /api/v1/tools/berkshelf
```

This will return the information for the berkshelf tool on Supermarket.

Unlike the rest of the API, this commit commit does not add view level specs. I
feel that the API spec properly tests the signature of what is output via the
API, which, to me, feels like the same expectations as the view specs.
