### PR TITLE
Implement the Tools index API endpoint.

### DIFF
--- a/app/controllers/api/v1/cookbooks_controller.rb
+++ b/app/controllers/api/v1/cookbooks_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::CookbooksController < Api::V1Controller
-  before_filter :init_params
+  before_filter :init_params, except: [:show]
 
   #
   # GET /api/v1/cookbooks
@@ -67,27 +67,5 @@ class Api::V1::CookbooksController < Api::V1Controller
     ).offset(@start).limit(@items)
 
     @total = @results.count(:all)
-  end
-
-  private
-
-  #
-  # This creates instance variables for +start+ and +items+, which are shared
-  # between the index and search methods. Also +order+ which is for ordering.
-  #
-  def init_params
-    @start = params.fetch(:start, 0).to_i
-    @items = [params.fetch(:items, 10).to_i, 100].min
-
-    if @start < 0 || @items < 0
-      return error(
-        error_code: t('api.error_codes.invalid_data'),
-        error_messages: [t('api.error_messages.negative_parameter',
-                           start: params.fetch(:start, 'not provided'),
-                           items: params.fetch(:items, 'not provided'))]
-      )
-    end
-
-    @order = params.fetch(:order, 'name ASC').to_s
   end
 end

--- a/app/controllers/api/v1/tools_controller.rb
+++ b/app/controllers/api/v1/tools_controller.rb
@@ -1,4 +1,27 @@
 class Api::V1::ToolsController < Api::V1Controller
+  before_filter :init_params, except: [:show]
+
+  #
+  # GET /api/v1/tools
+  #
+  # Return all Tools. Defaults to 10 at a time, starting at the first
+  # Tool when sorted alphabetically. The max number of Tools that can be
+  # returned is 100.
+  #
+  # Pass in the start and items params to specify the index at which to start
+  # and how many to return. You can pass in an order param to specify how
+  # you'd like the the collection ordered. Possible values are
+  # recently_added.
+  #
+  # @example
+  #   GET /api/v1/cookbooks?start=5&items=15
+  #   GET /api/v1/cookbooks?order=recently_added
+  #
+  def index
+    @total = Tool.count
+    @tools = Tool.index(order: @order, limit: @items, start: @start)
+  end
+
   #
   # GET /api/v1/tools/:tool
   #

--- a/app/controllers/api/v1_controller.rb
+++ b/app/controllers/api/v1_controller.rb
@@ -39,4 +39,24 @@ class Api::V1Controller < ApplicationController
   def error(body, status = 400)
     render json: body, status: status
   end
+
+  #
+  # This creates instance variables for +start+ and +items+, which are shared
+  # between the index and search methods. Also +order+ which is for ordering.
+  #
+  def init_params
+    @start = params.fetch(:start, 0).to_i
+    @items = [params.fetch(:items, 10).to_i, 100].min
+
+    if @start < 0 || @items < 0
+      return error(
+        error_code: t('api.error_codes.invalid_data'),
+        error_messages: [t('api.error_messages.negative_parameter',
+                           start: params.fetch(:start, 'not provided'),
+                           items: params.fetch(:items, 'not provided'))]
+      )
+    end
+
+    @order = params.fetch(:order, 'name ASC').to_s
+  end
 end

--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -67,6 +67,19 @@ class Tool < ActiveRecord::Base
     where(lowercase_name: lowercase_names)
   }
 
+  scope :ordered_by, lambda { |ordering|
+    reorder({
+      'recently_added' => 'id DESC'
+    }.fetch(ordering, 'name ASC'))
+  }
+
+  scope :index, lambda { |opts = {}|
+    includes(owner: :chef_account)
+    .ordered_by(opts.fetch(:order, 'name ASC'))
+    .limit(opts.fetch(:limit, 10))
+    .offset(opts.fetch(:start, 0))
+  }
+
   #
   # The username of this tools's owner
   #

--- a/app/views/api/v1/tools/index.json.jbuilder
+++ b/app/views/api/v1/tools/index.json.jbuilder
@@ -1,0 +1,10 @@
+json.start @start
+json.total @total
+json.items @tools do |tool|
+  json.tool_name tool.name
+  json.tool_type tool.type
+  json.tool_source_url tool.source_url
+  json.tool_description tool.description
+  json.tool_owner tool.maintainer
+  json.tool api_v1_tool_url(tool)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Supermarket::Application.routes.draw do
       post '/cookbook-verisons/evaluation' => 'cookbook_versions#evaluation', as: :cookbook_versions_evaluation, constraints: proc { ROLLOUT.active?(:fieri) }
 
       get 'tools/:tool' => 'tools#show', as: :tool
+      get 'tools' => 'tools#index', as: :tools
     end
   end
 

--- a/spec/api/tools_index_spec.rb
+++ b/spec/api/tools_index_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'GET /api/v1/tools' do
+  it 'returns a 200' do
+    get '/api/v1/tools'
+
+    expect(response.status.to_i).to eql(200)
+  end
+
+  context 'when there are no tools' do
+    it 'returns an empty JSON template' do
+      get '/api/v1/tools'
+
+      expect(json_body['start']).to eql(0)
+      expect(json_body['total']).to eql(0)
+      expect(json_body['items']).to match_array([])
+    end
+  end
+
+  context 'when there are tools' do
+    let!(:berkshelf) { create(:tool, name: 'berkshelf') }
+    let!(:knife_supermarket) { create(:tool, name: 'knife_supermarket') }
+
+    it 'returns a JSON template with the tools' do
+      get '/api/v1/tools'
+
+      expect(json_body['start']).to eql(0)
+      expect(json_body['total']).to eql(2)
+      expect(json_body['items']).to match_array(
+        [index_signature(berkshelf), index_signature(knife_supermarket)]
+      )
+    end
+  end
+end
+
+def index_signature(tool)
+  {
+    'tool_name' => tool.name,
+    'tool_type' => tool.type,
+    'tool_source_url' => tool.source_url,
+    'tool_description' => tool.description,
+    'tool_owner' => tool.maintainer,
+    'tool' => "http://www.example.com/api/v1/tools/#{tool.slug}"
+  }
+end

--- a/spec/controllers/api/v1/tools_controller_spec.rb
+++ b/spec/controllers/api/v1/tools_controller_spec.rb
@@ -1,6 +1,121 @@
 require 'spec_helper'
 
 describe Api::V1::ToolsController do
+  describe '#index' do
+    let!(:metal) do
+      create(:tool, name: 'metal')
+    end
+
+    let!(:berkshelf) do
+      create(:tool, name: 'berkshelf')
+    end
+
+    it 'responds with a 200' do
+      get :index, format: :json
+
+      expect(response.status.to_i).to eql(200)
+    end
+
+    it 'sends the tools to view' do
+      get :index, format: :json
+
+      expect(assigns[:tools]).to be_present
+    end
+
+    it 'sends the total tools count to view' do
+      get :index, format: :json
+
+      expect(assigns[:total]).to be_present
+    end
+
+    it 'sends start to view' do
+      get :index, start: 4, format: :json
+
+      expect(assigns[:start]).to eql(4)
+    end
+
+    it 'sends items to view' do
+      get :index, format: :json
+
+      expect(assigns[:items]).to be_present
+    end
+
+    it 'sends order to view' do
+      get :index, format: :json
+
+      expect(assigns[:order]).to be_present
+    end
+
+    it 'orders the tools by their name by default' do
+      get :index, format: :json
+
+      tool_names = assigns[:tools].map(&:name)
+
+      expect(tool_names).to eql(%W(berkshelf metal))
+    end
+
+    it 'allows ordering by recently added' do
+      get :index, order: :recently_added, format: :json
+      tools = assigns[:tools]
+      expect(tools.first).to eql(berkshelf)
+      expect(tools.last).to eql(metal)
+    end
+
+    it 'uses the start param to offset the tools sent to the view' do
+      get :index, start: 1, format: :json
+
+      tool_names = assigns[:tools].map(&:name)
+
+      expect(tool_names).to eql(['metal'])
+    end
+
+    it 'uses the items param to limit the tools sent to the view' do
+      get :index, items: 1, format: :json
+
+      tool_names = assigns[:tools].map(&:name)
+
+      expect(tool_names).to eql(['berkshelf'])
+    end
+
+    it 'handles the start and items param' do
+      get :index, items: 1, start: 1, format: :json
+
+      tools_names = assigns[:tools].map(&:name)
+
+      expect(tools_names).to eql(['metal'])
+    end
+
+    it 'defaults the items param to 10' do
+      get :index, format: :json
+
+      expect(assigns[:items]).to eql(10)
+    end
+
+    it 'defaults the start param to 0' do
+      get :index, format: :json
+
+      expect(assigns[:start]).to eql(0)
+    end
+
+    it 'limits the number of items to 100' do
+      get :index, items: 101, format: :json
+
+      expect(assigns[:items]).to eql(100)
+    end
+
+    it 'returns a 400 if start is negative' do
+      get :index, start: -1, format: :json
+
+      expect(response.status).to eql(400)
+    end
+
+    it 'returns a 400 if items is negative' do
+      get :index, items: -1, format: :json
+
+      expect(response.status).to eql(400)
+    end
+  end
+
   describe '#show' do
     context 'when a tool exists' do
       let!(:berkshelf_tool) { create(:tool, name: 'berkshelf') }


### PR DESCRIPTION
:fork_and_knife: 

Similar to the Cookbooks index endpoint, this implements a list of all of the
tools. Pagination is handled the same way as the Cookbook index API.

```
GET /api/v1/tools
```
