### PR TITLE
Implement API endpoint for Tools search.

### DIFF
--- a/app/controllers/api/v1/tools_controller.rb
+++ b/app/controllers/api/v1/tools_controller.rb
@@ -14,8 +14,8 @@ class Api::V1::ToolsController < Api::V1Controller
   # recently_added.
   #
   # @example
-  #   GET /api/v1/cookbooks?start=5&items=15
-  #   GET /api/v1/cookbooks?order=recently_added
+  #   GET /api/v1/tools?start=5&items=15
+  #   GET /api/v1/tools?order=recently_added
   #
   def index
     @total = Tool.count
@@ -32,5 +32,25 @@ class Api::V1::ToolsController < Api::V1Controller
   #
   def show
     @tool = Tool.find_by!(name: params[:tool])
+  end
+
+  #
+  # GET /api/v1/tools-search?q=QUERY
+  #
+  # Return tools with a name that contains the specified query. Takes the +q+
+  # parameter for the request. It also handles the start and items parameters
+  # for specifying where to start the search and how many items to return. Start
+  # defaults to 0. Items defaults to 10. Items has an upper limit of 100.
+  #
+  # @example
+  #   GET /api/v1/tools-search?q=berkshelf
+  #   GET /api/v1/tools-search?q=berkshelf&start=3&items=5
+  #
+  def search
+    @results = Tool.search(
+      params.fetch(:q, nil)
+    ).offset(@start).limit(@items)
+
+    @total = @results.count(:all)
   end
 end

--- a/app/views/api/v1/tools/search.json.jbuilder
+++ b/app/views/api/v1/tools/search.json.jbuilder
@@ -1,0 +1,10 @@
+json.start @start
+json.total @total
+json.items @results do |tool|
+  json.tool_name tool.name
+  json.tool_type tool.type
+  json.tool_source_url tool.source_url
+  json.tool_description tool.description
+  json.tool_owner tool.maintainer
+  json.tool api_v1_tool_url(tool.slug)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Supermarket::Application.routes.draw do
 
       get 'tools/:tool' => 'tools#show', as: :tool
       get 'tools' => 'tools#index', as: :tools
+      get 'tools-search' => 'tools#search', as: :tools_search
     end
   end
 

--- a/spec/api/tools_search_spec.rb
+++ b/spec/api/tools_search_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'GET /api/v1/tools/search' do
+  let!(:berkshelf) { create(:tool, name: 'berkshelf') }
+  let!(:berkshelf_2) { create(:tool, name: 'berkshelf-2') }
+
+  it 'returns a 200' do
+    get '/api/v1/tools-search'
+
+    expect(response.status.to_i).to eql(200)
+  end
+
+  it 'returns tools that match the search query' do
+    search_response = {
+      'items' => [search_signature(berkshelf), search_signature(berkshelf_2)],
+      'total' => 2,
+      'start' => 0
+    }
+
+    get '/api/v1/tools-search?q=berkshelf'
+
+    expect(json_body).to eql(search_response)
+  end
+
+  it 'handles the start and items params' do
+    search_response = {
+      'items' => [search_signature(berkshelf_2)],
+      'total' => 1,
+      'start' => 1
+    }
+
+    get '/api/v1/tools-search?q=berkshelf&start=1&items=1'
+
+    expect(json_body).to eql(search_response)
+  end
+end
+
+def search_signature(tool)
+  {
+    'tool_name' => tool.name,
+    'tool_type' => tool.type,
+    'tool_source_url' => tool.source_url,
+    'tool_description' => tool.description,
+    'tool_owner' => tool.maintainer,
+    'tool' => "http://www.example.com/api/v1/tools/#{tool.slug}"
+  }
+end


### PR DESCRIPTION
:fork_and_knife: 

Similar to the Cookbooks search, this implements the ability to search for Tools
via the API. It is its own endpoint to not affect the Cookbooks
search endpoint.

```
GET /api/v1/tools-search?q=QUERY
```

The start and items parameters can be provided to adjust the results with
pagination.

Trello card: https://trello.com/c/l0dyeedP
