### PR TITLE
Hide contributor status if CLAs are disabled.

### DIFF
--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -3,8 +3,10 @@
   <h3><%= @user.name %></h3>
   <h4><%= image_tag "chef-icon.png" %> <%= @user.username %></h4>
 
-  <% if @user.authorized_to_contribute? %>
-    <h4><i class="fa fa-check"></i> Authorized to Contribute</h4>
+  <% if ROLLOUT.active?(:cla) %>
+    <% if @user.authorized_to_contribute? %>
+      <h4><i class="fa fa-check"></i> Authorized to Contribute</h4>
+    <% end %>
   <% end %>
 
   <ul>


### PR DESCRIPTION
:fork_and_knife: Noticed while QAing that we should hide "Authorized To Contribute" on user profiles if CLAs are disabled.
