### PR TITLE
Display Foodcritic results and feedback on cookbooks

### DIFF
--- a/app/assets/stylesheets/cookbooks/show.scss
+++ b/app/assets/stylesheets/cookbooks/show.scss
@@ -20,6 +20,20 @@
     }
   }
 
+  .tabs {
+    .fa {
+      margin-left: rem-calc(5);
+    }
+
+    .fa-times {
+      color: $primary_red;
+    }
+
+    .fa-check {
+      color: $secondary_green;
+    }
+  }
+
   .installs {
     margin-bottom: rem-calc(50);
 

--- a/app/views/cookbooks/_main.html.erb
+++ b/app/views/cookbooks/_main.html.erb
@@ -54,6 +54,15 @@
     <% if version.changelog %>
       <dd><a href="#changelog" rel="changelog">Changelog</a></dd>
     <% end %>
+    <% if ROLLOUT.active?(:fieri) %>
+      <% unless version.foodcritic_failure.nil? %>
+        <dd>
+          <a href="#foodcritic" rel="foodcritic">Foodcritic
+            <i class="fa <%= version.foodcritic_failure ? 'fa-times' : 'fa-check' %>" title="Foodcritic is <%= version.foodcritic_failure ? 'failing' : 'passing' %>" data-tooltip></i>
+          </a>
+        </dd>
+      <% end %>
+    <% end %>
   </dl>
   <div class="tabs-content">
     <div class="content active" id="readme">
@@ -70,6 +79,17 @@
       <div class="content" id="changelog">
         <%= render_document(version.changelog, version.changelog_extension) %>
       </div>
+    <% end %>
+    <% if ROLLOUT.active?(:fieri) %>
+      <% unless version.foodcritic_failure.nil? %>
+        <div class="content" id="foodcritic">
+          <% if version.foodcritic_feedback.present? %>
+            <pre><%= version.foodcritic_feedback.gsub(/\n/, '<br />').html_safe %></pre>
+          <% else %>
+            <p><%= version.version %> passed <%= link_to 'Foodcritic', 'http://acrmp.github.io/foodcritic', target: '_blank' %>.
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
:fork_and_knife: If Foodcritic has been run display the result of the run (pass/fail) and the feedback as a tab on the cookbook show view.

![screen shot 2014-08-19 at 3 19 18 pm](https://cloud.githubusercontent.com/assets/316507/3971710/69522f7c-27d6-11e4-9bef-906989e8bc2e.png)

![screen shot 2014-08-19 at 3 19 35 pm](https://cloud.githubusercontent.com/assets/316507/3971712/6c31dbc0-27d6-11e4-9afb-f22a58b8b08b.png)
