### PR TITLE
Display foodcritic_failure on cookbook show API.

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -81,6 +81,7 @@ class Cookbook < ActiveRecord::Base
   # Delegations
   # --------------------
   delegate :description, to: :latest_cookbook_version
+  delegate :foodcritic_failure, to: :latest_cookbook_version
 
   # Validations
   # --------------------

--- a/app/views/api/v1/cookbooks/show.json.jbuilder
+++ b/app/views/api/v1/cookbooks/show.json.jbuilder
@@ -1,5 +1,6 @@
 json.partial! 'cookbook'
 json.deprecated @cookbook.deprecated
+json.foodcritic_failure @cookbook.foodcritic_failure
 if @cookbook.deprecated? && @cookbook.replacement.present?
   json.replacement api_v1_cookbook_url(@cookbook.replacement)
 end

--- a/spec/factories/cookbook_version.rb
+++ b/spec/factories/cookbook_version.rb
@@ -6,5 +6,6 @@ FactoryGirl.define do
     tarball { File.open('spec/support/cookbook_fixtures/redis-test-v1.tgz') }
     readme '# redis cookbook'
     readme_extension 'md'
+    foodcritic_failure false
   end
 end

--- a/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
+++ b/spec/views/api/v1/cookbooks/show.json.jbuilder_spec.rb
@@ -21,7 +21,8 @@ describe 'api/v1/cookbooks/show' do
       description: 'great cookbook',
       version: '2.0.0',
       web_download_count: 1,
-      api_download_count: 19
+      api_download_count: 19,
+      foodcritic_failure: true
     )
   end
 
@@ -32,7 +33,8 @@ describe 'api/v1/cookbooks/show' do
       description: 'great cookbook',
       version: '2.1.0',
       web_download_count: 1,
-      api_download_count: 13
+      api_download_count: 13,
+      foodcritic_failure: true
     )
   end
 
@@ -94,6 +96,11 @@ describe 'api/v1/cookbooks/show' do
   it "displays the cookbook's deprecation status" do
     deprecated = json_body['deprecated']
     expect(deprecated).to eql(true)
+  end
+
+  it "displays the cookbook's foodcritic failure status" do
+    failure = json_body['foodcritic_failure']
+    expect(failure).to eql(true)
   end
 
   it "displays the cookbook's replacement cookbook" do


### PR DESCRIPTION
:fork_and_knife: 

It delegates to the latest version to get the attribute.
