### PR TITLE
Add cookbooks foodcritic endpoint

### DIFF
--- a/app/controllers/api/v1/cookbooks_controller.rb
+++ b/app/controllers/api/v1/cookbooks_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::CookbooksController < Api::V1Controller
   before_filter :init_params, except: [:show]
+  before_filter :assign_cookbook, only: [:show, :foodcritic]
 
   #
   # GET /api/v1/cookbooks
@@ -38,8 +39,6 @@ class Api::V1::CookbooksController < Api::V1Controller
   #   GET /api/v1/cookbooks/redis
   #
   def show
-    @cookbook = Cookbook.with_name(params[:cookbook]).
-      includes(:cookbook_versions).first!
     @latest_cookbook_version_url = api_v1_cookbook_version_url(
       @cookbook, @cookbook.latest_cookbook_version
     )
@@ -47,6 +46,17 @@ class Api::V1::CookbooksController < Api::V1Controller
     @cookbook_versions_urls = @cookbook.sorted_cookbook_versions.map do |version|
       api_v1_cookbook_version_url(@cookbook, version)
     end
+  end
+
+  #
+  # GET /api/v1/cookbooks/:foodcritic
+  #
+  # Return the failure status and feedback from the cookbook's Foodcritic run.
+  #
+  # @example
+  #   GET /api/v1/cookbooks/redis/foodcritic
+  #
+  def foodcritic
   end
 
   #
@@ -67,5 +77,12 @@ class Api::V1::CookbooksController < Api::V1Controller
     ).offset(@start).limit(@items)
 
     @total = @results.count(:all)
+  end
+
+  private
+
+  def assign_cookbook
+    @cookbook = Cookbook.with_name(params[:cookbook]).
+      includes(:cookbook_versions).first!
   end
 end

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -82,6 +82,7 @@ class Cookbook < ActiveRecord::Base
   # --------------------
   delegate :description, to: :latest_cookbook_version
   delegate :foodcritic_failure, to: :latest_cookbook_version
+  delegate :foodcritic_feedback, to: :latest_cookbook_version
 
   # Validations
   # --------------------

--- a/app/views/api/v1/cookbooks/foodcritic.json.jbuilder
+++ b/app/views/api/v1/cookbooks/foodcritic.json.jbuilder
@@ -1,0 +1,2 @@
+json.failed @cookbook.foodcritic_failure
+json.feedback @cookbook.foodcritic_feedback

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Supermarket::Application.routes.draw do
       get 'cookbooks' => 'cookbooks#index'
       get 'search' => 'cookbooks#search'
       get 'cookbooks/:cookbook' => 'cookbooks#show', as: :cookbook
+      get 'cookbooks/:cookbook/foodcritic' => 'cookbooks#foodcritic', constraints: proc { ROLLOUT.active?(:fieri) }
       get 'cookbooks/:cookbook/versions/:version' => 'cookbook_versions#show', as: :cookbook_version, constraints: { version: VERSION_PATTERN }
       get 'cookbooks/:cookbook/versions/:version/download' => 'cookbook_versions#download', as: :cookbook_version_download, constraints: { version: VERSION_PATTERN }
       post 'cookbooks' => 'cookbook_uploads#create'

--- a/spec/api/cookbook_foodcritic_spec.rb
+++ b/spec/api/cookbook_foodcritic_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'GET /api/v1/cookbooks/:cookbook/foodcritic' do
+  let(:cookbook) do
+    create(:cookbook, cookbook_versions: [
+      create(
+        :cookbook_version,
+        foodcritic_failure: true,
+        foodcritic_feedback: 'FC015: Consider converting definition to a LWRP: ./definitions/apache_conf.rb:1'
+      )
+    ])
+  end
+
+  let(:cookbook_foodcritic_signature) do
+    {
+      'failed' => cookbook.foodcritic_failure,
+      'feedback' => cookbook.foodcritic_feedback
+    }
+  end
+
+  it 'returns a 200' do
+    get "/api/v1/cookbooks/#{cookbook.name}/foodcritic"
+
+    expect(response.status.to_i).to eql(200)
+  end
+
+  it 'returns the foodcritic results' do
+    get "/api/v1/cookbooks/#{cookbook.name}/foodcritic"
+
+    expect(signature(json_body)).to include(cookbook_foodcritic_signature)
+  end
+end

--- a/spec/controllers/api/v1/cookbooks_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbooks_controller_spec.rb
@@ -180,6 +180,39 @@ describe Api::V1::CookbooksController do
     end
   end
 
+  describe '#foodcritic' do
+    context 'when a cookbook exists' do
+      before do
+        create(
+          :cookbook_version,
+          cookbook: sashimi,
+          version: '1.1.0',
+          license: 'MIT'
+        )
+      end
+
+      it 'responds with a 200' do
+        get :foodcritic, cookbook: 'sashimi', format: :json
+
+        expect(response.status.to_i).to eql(200)
+      end
+
+      it 'sends the cookbook to the view' do
+        get :foodcritic, cookbook: 'sashimi', format: :json
+
+        expect(assigns[:cookbook]).to eql(sashimi)
+      end
+    end
+
+    context 'when a cookbook does not exist' do
+      it 'responds with a 404' do
+        get :foodcritic, cookbook: 'mamimi', format: :json
+
+        expect(response.status.to_i).to eql(404)
+      end
+    end
+  end
+
   describe '#search' do
     let!(:redis) { create(:cookbook, name: 'redis') }
     let!(:redis_2) { create(:cookbook, name: 'redis-2') }


### PR DESCRIPTION
:fork_and_knife: Add an endpoint to view the foodcritic failure status and feedback for a given cookbook.
