### PR TITLE
Set cookbook source & issues url from metadata

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -253,6 +253,8 @@ class Cookbook < ActiveRecord::Base
       )
 
       self.updated_at = Time.now
+      self.source_url = metadata.source_url
+      self.issues_url = metadata.issues_url
       save!
 
       metadata.platforms.each do |name, version_constraint|

--- a/app/models/cookbook_upload/metadata.rb
+++ b/app/models/cookbook_upload/metadata.rb
@@ -43,12 +43,23 @@ class CookbookUpload
     #   @example
     #     metadata.platforms == { 'ubuntu' => '>= 0.0.0' }
     #
+
     #
     # @!attribute [r] dependencies
     #   @return [Hash<String,String>] The cookbook dependencies
     #
     #   @example
     #     metadata.dependencies == { 'apt' => '~> 0.0.2' }
+    #
+
+    #
+    # @!attribute [r] source_url
+    #   @return [String] The cookbook source url
+    #
+
+    #
+    # @!attribute [r] issues_url
+    #   @return [String] The cookbook issues url
     #
 
     values do
@@ -58,6 +69,8 @@ class CookbookUpload
       attribute :license, String, default: ''
       attribute :platforms, Hash[String => String]
       attribute :dependencies, Hash[String => String]
+      attribute :source_url, String, default: ''
+      attribute :issues_url, String, default: ''
     end
   end
 end

--- a/spec/api/cookbook_destroy_spec.rb
+++ b/spec/api/cookbook_destroy_spec.rb
@@ -8,7 +8,7 @@ describe 'DELETE /api/v1/cookbooks/:cookbook' do
       {
         'name' => 'redis-test',
         'maintainer' => user.username,
-        'external_url' => nil,
+        'external_url' => '',
         'description' => 'Installs/Configures redis-test',
         'average_rating' => nil,
         'category' => 'Other',

--- a/spec/api/cookbook_show_spec.rb
+++ b/spec/api/cookbook_show_spec.rb
@@ -10,7 +10,7 @@ describe 'GET /api/v1/cookbooks/:cookbook' do
         'category' => 'Other',
         'maintainer' => user.username,
         'latest_version' => 'http://www.example.com/api/v1/cookbooks/redis-test/versions/0.2.0',
-        'external_url' => nil,
+        'external_url' => '',
         'versions' =>
           [
             'http://www.example.com/api/v1/cookbooks/redis-test/versions/0.2.0',

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -362,7 +362,9 @@ describe Cookbook do
             dependencies: {
               'apt' => '= 1.2.3',
               'yum' => '~> 2.1.3'
-            }
+            },
+            source_url: 'http://example.com',
+            issues_url: 'http://example.com/issues'
           )
         end
       end
@@ -394,6 +396,18 @@ describe Cookbook do
       cookbook.publish_version!(params)
 
       expect(cookbook.updated_at).to be > original_date
+    end
+
+    it 'sets the source_url attribute on the cookbook' do
+      cookbook.publish_version!(params)
+
+      expect(cookbook.source_url).to eql('http://example.com')
+    end
+
+    it 'sets the issues_url attribute on the cookbook' do
+      cookbook.publish_version!(params)
+
+      expect(cookbook.issues_url).to eql('http://example.com/issues')
     end
 
     it 'saves the README' do


### PR DESCRIPTION
:fork_and_knife: 

With the inevitability of chef supporting source_url and issues_url in the
metadata.rb, Supermarket should set the attributes on cookbook from the latest
version that gets uploaded.

The reason this does not add a source and issue url to CookbookVersion is - if
the URL changes, we would always want the URL to be the most recent one incase
they change. :smile:

Related to: 
- https://github.com/opscode/chef/pull/1914
- https://github.com/opscode/supermarket/issues/724
- https://trello.com/c/TKCg00fR
