### PR TITLE
Use current version for install snippets

### DIFF
--- a/app/views/cookbooks/_installs.html.erb
+++ b/app/views/cookbooks/_installs.html.erb
@@ -30,11 +30,11 @@
   <div class="tabs-content">
     <% if current_user && current_user.install_preference.present? %>
       <div class="content <%= current_user.install_preference == 'berkshelf' ? 'active' : '' %>" id="berkshelf">
-        <pre class="install">cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</pre>
+        <pre class="install">cookbook '<%= cookbook.name %>', <% if version == cookbook.latest_cookbook_version %>'~&gt;<% else %>'=<% end %> <%= version.version %>'</pre>
       </div>
 
       <div class="content <%= current_user.install_preference == 'librarian' ? 'active' : '' %>" id="librarian">
-        <pre class="install">cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</pre>
+        <pre class="install">cookbook '<%= cookbook.name %>', <% if version == cookbook.latest_cookbook_version %>'~&gt;<% else %>'=<% end %> <%= version.version %>'</pre>
       </div>
 
       <div class="content <%= current_user.install_preference == 'knife' ? 'active' : '' %>" id="knife">
@@ -43,11 +43,11 @@
       </div>
     <% else %>
       <div class="content active" id="berkshelf">
-        <pre class="install">cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</pre>
+        <pre class="install">cookbook '<%= cookbook.name %>', <% if version == cookbook.latest_cookbook_version %>'~&gt;<% else %>'=<% end %> <%= version.version %>'</pre>
       </div>
 
       <div class="content" id="librarian">
-        <pre class="install">cookbook '<%= cookbook.name %>', '~&gt; <%= cookbook.latest_cookbook_version.version %>'</pre>
+        <pre class="install">cookbook '<%= cookbook.name %>', <% if version == cookbook.latest_cookbook_version %>'~&gt;<% else %>'=<% end %> <%= version.version %>'</pre>
       </div>
 
       <div class="content" id="knife">

--- a/app/views/cookbooks/_main.html.erb
+++ b/app/views/cookbooks/_main.html.erb
@@ -46,7 +46,7 @@
 
   <p itemprop="description"><%= cookbook.description %></p>
 
-  <%= render 'cookbooks/installs', cookbook: cookbook %>
+  <%= render 'cookbooks/installs', cookbook: cookbook, version: version %>
 
   <dl class="tabs" data-tab data-options="deep_linking:true">
     <dd class="active"><a href="#readme">README</a></dd>


### PR DESCRIPTION
:fork_and_knife: If a specific cookbook version is selected use that version number for the install snippets and set the constraint to =.

![screen shot 2014-08-28 at 1 11 24 pm](https://cloud.githubusercontent.com/assets/316507/4079548/5cfa6c7e-2ed6-11e4-8f83-2cdc48d5bf11.png)

Closes #778.
