### PR TITLE
fix cookbook sorting to include version numbers

### DIFF
--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -271,7 +271,12 @@ class Cookbook < ActiveRecord::Base
   def contingents
     CookbookDependency.includes(cookbook_version: :cookbook)
       .where(cookbook_id: id)
-      .sort_by { |cd| cd.cookbook_version.cookbook.name }
+      .sort_by do |cd|
+        [
+          cd.cookbook_version.cookbook.name,
+          Semverse::Version.new(cd.cookbook_version.version)
+        ]
+      end
   end
 
   #


### PR DESCRIPTION
:fork_and_knife: 

Previously, this sorting was only done on cookbook name and the versions were all out of order.  Now it's sorted by name first, and version in semver order after that.

Screenshot:
![](https://dl.dropboxusercontent.com/s/7019q8k4fluqr7t/2014-08-28%20at%204.22%20PM%202x.png?dl=0)
