### PR TITLE
Create Supermarket::StatsD wrapper

### DIFF
--- a/app/controllers/api/v1/cookbook_versions_controller.rb
+++ b/app/controllers/api/v1/cookbook_versions_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::CookbookVersionsController < Api::V1Controller
 
     CookbookVersion.increment_counter(:api_download_count, @cookbook_version.id)
     Cookbook.increment_counter(:api_download_count, @cookbook.id)
-    STATSD.increment 'api_downloads' if defined? STATSD
+    Supermarket::StatsD.increment('api_downloads')
 
     redirect_to @cookbook_version.tarball.url
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   include Supermarket::Authorization
   include Supermarket::Authentication
   include Supermarket::LocationStorage
+  include Supermarket::StatsD
 
   rescue_from(
     NotAuthorizedError,

--- a/app/controllers/cookbook_versions_controller.rb
+++ b/app/controllers/cookbook_versions_controller.rb
@@ -9,7 +9,7 @@ class CookbookVersionsController < ApplicationController
   def download
     CookbookVersion.increment_counter(:web_download_count, @version.id)
     Cookbook.increment_counter(:web_download_count, @cookbook.id)
-    STATSD.increment 'web_downloads' if defined? STATSD
+    Supermarket::StatsD.increment('web_downloads')
 
     redirect_to @version.tarball.url
   end

--- a/lib/supermarket/stats_d.rb
+++ b/lib/supermarket/stats_d.rb
@@ -1,0 +1,10 @@
+module Supermarket
+  module StatsD
+    #
+    # Increment the stat passed in if STATSD is defined.
+    #
+    def self.increment(stat)
+      STATSD.increment(stat) if defined? STATSD
+    end
+  end
+end


### PR DESCRIPTION
:fork_and_knife: :curry: 

The Supermarket::StatsD wrapper creates a convenient place for calling the
STATSD constant while checking if it is defined.

Related to #787.
