### PR TITLE
Added override to github shortcut to use https instead of git protocol

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,13 @@
 source 'https://rubygems.org'
 ruby '2.0.0'
 
+# Override the Bundler :github shortcut to use HTTPS instead of the git protocol
+# Note: Version 2.x of Bundler should do this by default
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
 gem 'rails', '~> 4.1.5'
 
 gem 'omniauth'


### PR DESCRIPTION
The Gemfile currently uses the 'github' shortcut to specify dependencies.

Per the Bundler docs (http://bundler.io/git.html) the 'gitbub' shortcut defaults to using the git protocol. The git protocol is pretty darn insecure and sits on an odd port.

This makes life difficult for those behind big ugly firewalls that allow only HTTP(s) egress. Though, in this case, reaching out to the wild wild web using a protocol like git seems like a reasonable thing to prohibit.

There are 2 options:
1. Prohibit the use of the github shortcut in favor of the git shortcut using https
2. Override the github shortcut in the Gemfile to use https (as suggested in the Bunder docs)

This pull request implements option number 2. It sounds from the Bundler docs that the github shortcut will be changed to use https when Bundler 2.x comes out, so this is a temporary workaround until then.
