### PR TITLE
Fix ZSH syntax error when loading .env

### DIFF
--- a/.env
+++ b/.env
@@ -18,6 +18,6 @@ CURRY_SUCCESS_LABEL="Signed CLA"
 PUBSUBHUBBUB_SECRET=YOUR_PUBSUBHUBBUB_SECRET
 NEW_RELIC_APP_NAME=Supermarket
 PUBSUBHUBBUB_CALLBACK_URL=http://example.com
-FEATURES= cla,join_ccla,tools,fieri,announcement
+FEATURES=cla,join_ccla,tools,fieri,announcement
 FIERI_URL=http://example.com
 FIERI_KEY=YOUR_FIERI_KEY


### PR DESCRIPTION
Sourcing the given **.env** file would throw the following warning:

```
.env:21: command not found: cla,join_ccla,tools,fieri,announcement
```

It will also fail to set **$FEATURES** correctly.

I just removed that space, and everything works out.
