### PR TITLE
Always display some kind of name, even if first/last doesn't exist

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,7 +140,11 @@ class User < ActiveRecord::Base
   # @return [String]
   #
   def name
-    [first_name, last_name].join(' ')
+    if first_name || last_name
+      [first_name, last_name].join(' ').strip
+    else
+      username
+    end
   end
 
   #

--- a/app/views/organizations/requests_to_join.html.erb
+++ b/app/views/organizations/requests_to_join.html.erb
@@ -12,7 +12,7 @@
       <table class="pending-requests">
         <% @pending_requests.each do |request| %>
           <tr class="pending-request">
-            <td><%= link_to request.user.name, request.user %> requested to join on <%= request.created_at.to_s(:longish) %></td>
+            <td><%= link_to request.user.name, user_path(request.user) %> requested to join on <%= request.created_at.to_s(:longish) %></td>
             <td class="right">
               <ul class="button-group radius right">
                 <li><%= link_to 'Accept Request', accept_ccla_signature_contributor_request_path(request.ccla_signature, request), class: 'button secondary tiny' %></li>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -494,6 +494,34 @@ describe User do
     end
   end
 
+  describe '#name' do
+    it 'joins the first and last name with a space' do
+      user = create(:user, first_name: 'Jimmy', last_name: 'Smith')
+      expect(user.name).to eql('Jimmy Smith')
+    end
+
+    it 'displays the name correctly even if there is only a first name' do
+      user = create(:user, first_name: 'Jimmy', last_name: nil)
+      expect(user.name).to eql('Jimmy')
+    end
+
+    it 'displays the name correctly even if there is only a last name' do
+      user = create(:user, first_name: nil, last_name: 'Smith')
+      expect(user.name).to eql('Smith')
+    end
+
+    it 'displays the name correctly if there are multiple names for first or last name' do
+      user = create(:user, first_name: 'Jimmy Joe', last_name: 'Billy Bob')
+      expect(user.name).to eql('Jimmy Joe Billy Bob')
+    end
+
+    it 'displays the username if there are no names at all' do
+      user = create(:user, first_name: nil, last_name: nil, create_chef_account: false)
+      account = create(:account, username: 'superman', user: user, provider: 'chef_oauth2')
+      expect(user.name).to eql('superman')
+    end
+  end
+
   describe '#update_install_preference' do
     it 'returns true if the user is saved' do
       user = build(:user)

--- a/spec/views/contributor_request_mailer/incoming_request_email.html_spec.rb
+++ b/spec/views/contributor_request_mailer/incoming_request_email.html_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'contributor_request_mailer/incoming_request_email.html.erb' do
   before do
-    user = create(:user)
+    user = create(:user, create_chef_account: false)
     account = create(:account, username: 'jimmeh', provider: 'chef_oauth2', user: user)
     assign(:username, 'jimmy')
     assign(:user, user)

--- a/spec/views/organizations/requests_to_join.html.erb_spec.rb
+++ b/spec/views/organizations/requests_to_join.html.erb_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'organizations/requests_to_join.html.erb' do
+  before do
+    policy = double(
+      'policy',
+      :view_cclas? => true,
+      :manage_contributors? => true,
+      :manage_requests_to_join? => true,
+      :manage_organization? => true
+    )
+    allow(view).to receive(:policy).and_return(policy)
+    user = create(:user, create_chef_account: false, first_name: nil, last_name: nil)
+    account = create(:account, username: 'jimmeh', provider: 'chef_oauth2', user: user)
+    org = create(:organization)
+    pending_request = create(:contributor_request, user: user, organization: org)
+    assign(:organization, org)
+    assign(:pending_requests, [pending_request])
+    render
+  end
+
+  it 'shows the username as a link that is never blank' do
+    expect(rendered).to match(%r{<a href="/users/jimmeh">jimmeh</a> requested to join on})
+  end
+end


### PR DESCRIPTION
:fork_and_knife: 

Previously, if the user didn't have a first/last name, then there was no way to see who was requesting to join the organization.  Now, if there's no first/last name, we show the username.

Closes https://github.com/opscode/supermarket/issues/806
