### PR TITLE
Create the Other category by default

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -118,6 +118,11 @@ if ENV['SEED_CLA_DATA']
   end
 end
 
+#
+# Default category
+#
+category = Category.where(name: 'Other').first_or_create!
+
 if Rails.env.development?
 
   #
@@ -199,11 +204,6 @@ if Rails.env.development?
     email: 'johndoe@example.com',
     organization: organization
   ).first_or_create!
-
-  #
-  # Default category for use in development.
-  #
-  category = Category.where(name: 'Other').first_or_create!
 
   #
   # Default cookbooks for use in development.


### PR DESCRIPTION
:convenience_store: 

When standing up a Supermarket instance internally, it can be confusing that there's no default category created, and some people may not know how to hook this up themselves.  This ensues that the "Other" category always exists, instead of just in `development` mode.
