### PR TITLE
Include a partial changelog in the cookbook atom feed

### DIFF
--- a/app/views/cookbooks/show.atom.builder
+++ b/app/views/cookbooks/show.atom.builder
@@ -4,9 +4,18 @@ atom_feed language: 'en-US' do |feed|
 
   @cookbook_versions.each do |v|
     feed.entry(v, url: cookbook_version_url(@cookbook, v)) do |entry|
-      entry.title "#{v.cookbook.name} - v#{v.version}"
-      entry.content v.description
+      content = if v.changelog.present?
+                  <<-EOS
+                    <p>#{v.description}</p>
+                    #{HTML_Truncator.truncate(render_document(v.changelog, v.changelog_extension), 30, ellipsis: '')}
+                    <p>#{link_to 'View Full Changelog', cookbook_version_url(@cookbook, v, anchor: 'changelog')}</p>
+                  EOS
+                else
+                  v.description
+                end
 
+      entry.title "#{v.cookbook.name} - v#{v.version}"
+      entry.content content, type: 'html'
       entry.author do |author|
         author.name v.cookbook.maintainer
         author.uri user_url(v.cookbook.owner)

--- a/spec/views/cookbooks/show.atom.builder_spec.rb
+++ b/spec/views/cookbooks/show.atom.builder_spec.rb
@@ -13,7 +13,9 @@ describe 'cookbooks/show.atom.builder' do
     create(
       :cookbook_version,
       version: '0.2.0',
-      license: 'MIT'
+      license: 'MIT',
+      changelog: 'we added so much stuff!',
+      changelog_extension: 'md'
     )
   end
 
@@ -29,33 +31,27 @@ describe 'cookbooks/show.atom.builder' do
   before do
     assign(:cookbook_versions, kiwi.cookbook_versions)
     assign(:cookbook, kiwi)
+    render
   end
 
   it 'displays the feed title' do
-    render
-
     expect(xml_body['feed']['title']).to eql('Kiwi versions')
   end
 
   it 'displays when the feed was updated' do
-    render
-
     expect(Date.parse(xml_body['feed']['updated'])).to_not be_nil
   end
 
   it 'displays cookbook version entries' do
-    render
-
     expect(xml_body['feed']['entry'].count).to eql(2)
   end
 
   it 'displays information about a cookbook' do
-    render
-
     cookbook = xml_body['feed']['entry'].first
 
     expect(cookbook['title']).to eql('Kiwi - v0.2.0')
-    expect(cookbook['content']).to eql(kiwi_0_2_0.description)
+    expect(cookbook['content']).to match(Regexp.new(kiwi_0_2_0.description))
+    expect(cookbook['content']).to match(/we added so much stuff!/)
     expect(cookbook['author']['name']).to eql(kiwi.owner.username)
     expect(cookbook['author']['uri']).to eql(user_url(kiwi.owner))
   end


### PR DESCRIPTION
:convenience_store: 

Now there's a partial changelog in the cookbook ATOM feed, with a link to see the full thing.

Closes https://github.com/opscode/supermarket/issues/813
