### PR TITLE
Make emails configurable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,5 @@ EachWithObject:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Style/NumericLiterals:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'analytics-ruby', '~> 1.0.0', require: false
 gem 'sass-rails',   '~> 4.0.1'
 gem 'compass-rails'
 gem 'uglifier',     '~> 2.2'
+gem 'bitmask_attributes'
 
 group :doc do
   gem 'yard', require: false
@@ -75,6 +76,7 @@ group :test do
   gem 'capybara'
   gem 'factory_girl'
   gem 'poltergeist'
+  gem 'timecop'
 
   # To prevent the validates_uniqueness matcher from raising a chef version
   # constraint error this pins shoulda-matchers at a commit where setting

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    bitmask_attributes (1.0.0)
+      activerecord (>= 3.1)
     builder (3.2.2)
     byebug (3.4.0)
       columnize (~> 0.8)
@@ -401,6 +403,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.4)
     tilt (1.4.1)
+    timecop (0.7.1)
     timers (1.1.0)
     tins (1.3.2)
     treetop (1.4.15)
@@ -447,6 +450,7 @@ DEPENDENCIES
   and_feathers (>= 1.0.0.pre)
   and_feathers-gzipped_tarball (>= 1.0.0.pre)
   aws-sdk
+  bitmask_attributes
   byebug
   capybara
   chef (~> 11.10.4)
@@ -494,6 +498,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   statsd-ruby
+  timecop
   uglifier (~> 2.2)
   unicorn
   unicorn-rails

--- a/app/controllers/email_preferences_controller.rb
+++ b/app/controllers/email_preferences_controller.rb
@@ -1,0 +1,11 @@
+class EmailPreferencesController < ApplicationController
+  #
+  # GET /unsubscribe/:token
+  #
+  # This will unsubscribe a user from a specific email.
+  #
+  def unsubscribe
+    @unsubscribe_request = UnsubscribeRequest.find_by!(token: params[:token])
+    @unsubscribe_request.make_it_so
+  end
+end

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -53,7 +53,7 @@ class ProfileController < ApplicationController
       :twitter_username,
       :irc_nickname,
       :jira_username,
-      :email_notifications
+      email_preferences: []
     )
   end
 

--- a/app/helpers/email_preferences_helper.rb
+++ b/app/helpers/email_preferences_helper.rb
@@ -1,0 +1,17 @@
+module EmailPreferencesHelper
+  #
+  # This translates a symbol or string representing the name of an email
+  # preference into a descriptive name for displaying in the view.
+  #
+  # @param name [String, Symbol] the short name of the email preference
+  #
+  # @return [String] the descriptive name
+  #
+  def pretty_email_name(name)
+    case name.to_sym
+    when :new_version then 'New cookbook version'
+    when :deleted then 'Cookbook deleted'
+    when :deprecated then 'Cookbook deprecated'
+    end
+  end
+end

--- a/app/helpers/profile_helper.rb
+++ b/app/helpers/profile_helper.rb
@@ -1,0 +1,30 @@
+module ProfileHelper
+  include EmailPreferencesHelper
+
+  #
+  # Constructs a checkbox and associated label inside a <div> for use on the
+  # profile edit screen, as part of the email preferences.
+  #
+  # @param name [String] the name of the checkbox
+  # @param value [Symbol] the value the checkbox should have
+  #
+  # @return [String] the HTML to show
+  #
+  def email_preference(name, value)
+    id_value = "user_#{name}_#{value}"
+    meth = "#{name}?".to_sym
+
+    content_tag(:div) do
+      [
+        check_box_tag(
+          "user[#{name}][]",
+          value.to_s,
+          current_user.send(meth, value),
+          id: id_value
+        ),
+
+        label_tag(id_value, pretty_email_name(value))
+      ].join.html_safe
+    end
+  end
+end

--- a/app/mailers/cookbook_mailer.rb
+++ b/app/mailers/cookbook_mailer.rb
@@ -11,6 +11,10 @@ class CookbookMailer < ActionMailer::Base
   def follower_notification_email(cookbook_follower)
     @cookbook = cookbook_follower.cookbook
     @to = cookbook_follower.user.email
+    @unsubscribe_request = UnsubscribeRequest.create(
+      user: cookbook_follower.user,
+      email_preference_name: 'new_version'
+    )
 
     mail(to: @to, subject: "A new version of the #{@cookbook.name} cookbook has been released")
   end
@@ -20,11 +24,15 @@ class CookbookMailer < ActionMailer::Base
   # explaining that the cookbook has been deleted
   #
   # @param name [String] the name of the cookbook
-  # @param email [String] the user to notify
+  # @param user [User] the user to notify
   #
-  def cookbook_deleted_email(name, email)
+  def cookbook_deleted_email(name, user)
     @name = name
-    @to = email
+    @to = user.email
+    @unsubscribe_request = UnsubscribeRequest.create(
+      user: user,
+      email_preference_name: 'deleted'
+    )
 
     mail(to: @to, subject: "The #{name} cookbook has been deleted")
   end
@@ -36,12 +44,16 @@ class CookbookMailer < ActionMailer::Base
   #
   # @param cookbook [Cookbook] the cookbook
   # @param replacement_cookbook [Cookbook] the replacement cookbook
-  # @param email [String] the user to notify
+  # @param user [User] the user to notify
   #
-  def cookbook_deprecated_email(cookbook, replacement_cookbook, email)
+  def cookbook_deprecated_email(cookbook, replacement_cookbook, user)
     @cookbook = cookbook
     @replacement_cookbook = replacement_cookbook
-    @to = email
+    @to = user.email
+    @unsubscribe_request = UnsubscribeRequest.create(
+      user: user,
+      email_preference_name: 'deprecated'
+    )
 
     subject = %(
       The #{@cookbook.name} cookbook has been deprecated in favor

--- a/app/models/unsubscribe_request.rb
+++ b/app/models/unsubscribe_request.rb
@@ -1,0 +1,43 @@
+class UnsubscribeRequest < ActiveRecord::Base
+  # Associations
+  # --------------------
+  belongs_to :user
+
+  # Validations
+  # --------------------
+  validates :user, presence: true
+  validates :token, presence: true
+  validates :email_preference_name, presence: true
+
+  # Callbacks
+  # --------------------
+  before_validation :ensure_token
+
+  #
+  # This method does the main work of this class, namely finding the
+  # appropriate user, removing the appropriate preference from their
+  # email_preferences list, and then deleting itself and any other
+  # UnsubscribeRequests for the same email, and the same user.
+  #
+  def make_it_so
+    user.email_preferences.delete(email_preference_name.to_sym)
+    user.save
+    self.class.where(
+      email_preference_name: email_preference_name,
+      user_id: user_id
+    ).delete_all
+  end
+
+  def to_param
+    token
+  end
+
+  private
+
+  #
+  # This ensures there's a token present when a request is created.
+  #
+  def ensure_token
+    self.token = SecureRandom.hex if token.blank?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,10 @@ class User < ActiveRecord::Base
   scope :with_email, ->(email) { where(email: email) }
   scope :with_username, ->(username) { joins(:chef_account).where('accounts.username' => username) }
 
+  # Callbacks
+  # --------------------
+  before_create :default_email_preferences
+
   # Search
   # --------------------
   pg_search_scope(
@@ -46,6 +50,10 @@ class User < ActiveRecord::Base
       trigram: { threshold: 0.2 }
     }
   )
+
+  bitmask :email_preferences,
+          as: [:new_version, :deleted, :deprecated],
+          zero_value: :none
 
   #
   # Returns all +CookbookVersion+ instances that +User+ follows.
@@ -351,5 +359,14 @@ class User < ActiveRecord::Base
     else
       false
     end
+  end
+
+  private
+
+  #
+  # This sets up a default preference of all emails for new users.
+  #
+  def default_email_preferences
+    self.email_preferences = [:new_version, :deleted, :deprecated] if email_preferences.blank?
   end
 end

--- a/app/views/cookbook_mailer/cookbook_deleted_email.html.erb
+++ b/app/views/cookbook_mailer/cookbook_deleted_email.html.erb
@@ -1,1 +1,3 @@
 <p>The <%= @name %> cookbook, which you follow or are a collaborator on, has been deleted.</p>
+
+<%= link_to 'Unsubscribe', unsubscribe_url(@unsubscribe_request) %>

--- a/app/views/cookbook_mailer/cookbook_deleted_email.text.erb
+++ b/app/views/cookbook_mailer/cookbook_deleted_email.text.erb
@@ -1,1 +1,3 @@
 The <%= @name %> cookbook, which you follow or are a collaborator on, has been deleted.
+
+Unsubscribe from this email: <%= unsubscribe_url(@unsubscribe_request) %>

--- a/app/views/cookbook_mailer/cookbook_deprecated_email.html.erb
+++ b/app/views/cookbook_mailer/cookbook_deprecated_email.html.erb
@@ -1,1 +1,3 @@
 <p>The <%= link_to @cookbook.name, cookbook_url(@cookbook) %> cookbook has been deprecated in favor of the <%= link_to @replacement_cookbook.name, cookbook_url(@replacement_cookbook) %> cookbook.</p>
+
+<%= link_to 'Unsubscribe', unsubscribe_url(@unsubscribe_request) %>

--- a/app/views/cookbook_mailer/cookbook_deprecated_email.text.erb
+++ b/app/views/cookbook_mailer/cookbook_deprecated_email.text.erb
@@ -1,1 +1,3 @@
 The <%= @cookbook.name %> cookbook [<%= cookbook_url(@cookbook) %>] has been deprecated in favor of the <%= @replacement_cookbook.name %> cookbook [<%= cookbook_url(@replacement_cookbook) %>].
+
+Unsubscribe from this email: <%= unsubscribe_url(@unsubscribe_request) %>

--- a/app/views/cookbook_mailer/follower_notification_email.html.erb
+++ b/app/views/cookbook_mailer/follower_notification_email.html.erb
@@ -10,3 +10,5 @@
     <%= link_to 'View Full Changelog', cookbook_version_url(@cookbook, @cookbook.latest_cookbook_version, anchor: 'changelog'), class: 'button accept' %>
   <% end %>
 </div>
+
+<%= link_to 'Unsubscribe', unsubscribe_url(@unsubscribe_request) %>

--- a/app/views/cookbook_mailer/follower_notification_email.text.erb
+++ b/app/views/cookbook_mailer/follower_notification_email.text.erb
@@ -16,3 +16,5 @@ _________________________________________________________
 
 <%= cookbook_version_url(@cookbook, @cookbook.latest_cookbook_version, anchor: 'changelog') %>
 <% end %>
+
+Unsubscribe from this email: <%= unsubscribe_url(@unsubscribe_request) %>

--- a/app/views/email_preferences/unsubscribe.html.erb
+++ b/app/views/email_preferences/unsubscribe.html.erb
@@ -1,0 +1,5 @@
+<div class="page">
+  <h1 class="text-center">
+    You have been successfully unsubscribed from <%= pretty_email_name(@unsubscribe_request.email_preference_name) %> emails.
+  </h1>
+</div>

--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -35,10 +35,14 @@
             <div class="jirausername-field">
               <%= f.text_field :jira_username, placeholder: 'JIRA Username', title: 'jira username' %>
             </div>
-            <div class="emailnotification-field">
-              <%= f.check_box :email_notifications %>
-              <%= label_tag :user_email_notifications, "Receive email notifications." %>
-            </div>
+          </fieldset>
+
+          <fieldset>
+            Email Preferences<br><br>
+            <%= email_preference(:email_preferences, :new_version) %>
+            <%= email_preference(:email_preferences, :deleted) %>
+            <%= email_preference(:email_preferences, :deprecated) %>
+            <%= hidden_field_tag 'user[email_preferences][]', 'none' %>
           </fieldset>
           <%= f.submit 'Update Profile', class: 'button primary radius' %>
         <% end %>

--- a/app/workers/cookbook_deletion_worker.rb
+++ b/app/workers/cookbook_deletion_worker.rb
@@ -13,10 +13,10 @@ class CookbookDeletionWorker
     followers_or_collaborators = CookbookFollower.where(cookbook_id: id).includes(:user) +
       Collaborator.where(resourceable_id: id, resourceable_type: 'Cookbook').includes(:user)
 
-    users = followers_or_collaborators.map(&:user).uniq.select(&:email_notifications)
+    users = followers_or_collaborators.map(&:user).uniq.select { |u| u.email_preferences?(:deleted) }
 
     users.each do |user|
-      CookbookMailer.delay.cookbook_deleted_email(cookbook['name'], user.email)
+      CookbookMailer.cookbook_deleted_email(cookbook['name'], user).deliver
     end
 
     followers_or_collaborators.each(&:destroy)

--- a/app/workers/cookbook_deprecated_notifier.rb
+++ b/app/workers/cookbook_deprecated_notifier.rb
@@ -15,11 +15,11 @@ class CookbookDeprecatedNotifier
     replacement_cookbook = cookbook.replacement
 
     users_to_email(cookbook).each do |user|
-      CookbookMailer.delay.cookbook_deprecated_email(
+      CookbookMailer.cookbook_deprecated_email(
         cookbook,
         replacement_cookbook,
-        user.email
-      )
+        user
+      ).deliver
     end
   end
 
@@ -31,6 +31,6 @@ class CookbookDeprecatedNotifier
     users_to_email << cookbook.collaborator_users
     users_to_email << cookbook.followers
 
-    users_to_email.flatten.uniq.select(&:email_notifications?)
+    users_to_email.flatten.uniq.select { |u| u.email_preferences?(:deprecated) }
   end
 end

--- a/app/workers/cookbook_notify_worker.rb
+++ b/app/workers/cookbook_notify_worker.rb
@@ -14,14 +14,15 @@ class CookbookNotifyWorker
 
     active_user_ids = User.joins(:accounts).
       where('provider = ? AND oauth_token != ?', 'chef_oauth2', 'imported').
+      with_email_preferences(:new_version).
       pluck(:id)
 
     emailable_cookbook_followers = cookbook.cookbook_followers.
       joins(:user).
-      where(users: { email_notifications: true, id: active_user_ids })
+      where(users: { id: active_user_ids })
 
     emailable_cookbook_followers.each do |cookbook_follower|
-      CookbookMailer.delay.follower_notification_email(cookbook_follower)
+      CookbookMailer.follower_notification_email(cookbook_follower).deliver
     end
   end
 end

--- a/app/workers/unsubscribe_request_cleanup_worker.rb
+++ b/app/workers/unsubscribe_request_cleanup_worker.rb
@@ -1,0 +1,14 @@
+class UnsubscribeRequestCleanupWorker
+  include Sidekiq::Worker
+  include Sidetiq::Schedulable
+
+  recurrence { daily }
+
+  #
+  # Find any UnsubscribeRequests older than 6 months and delete them, to
+  # prevent unbounded growth of the unsubscribe_requests table.
+  #
+  def perform
+    UnsubscribeRequest.where('created_at < ?', 6.months.ago).delete_all
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Supermarket::Application.routes.draw do
   get 'cookbooks-directory' => 'cookbooks#directory'
   get 'universe' => 'api/v1/universe#index', defaults: { format: :json }
   get 'status' => 'api/v1/health#show', defaults: { format: :json }
+  get 'unsubscribe/:token' => 'email_preferences#unsubscribe', as: :unsubscribe
 
   resources :cookbooks, only: [:index, :show, :update] do
     member do

--- a/db/migrate/20140929223955_add_email_preferences_to_user.rb
+++ b/db/migrate/20140929223955_add_email_preferences_to_user.rb
@@ -1,0 +1,5 @@
+class AddEmailPreferencesToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :email_preferences, :integer
+  end
+end

--- a/db/migrate/20140930215139_create_unsubscribe_requests.rb
+++ b/db/migrate/20140930215139_create_unsubscribe_requests.rb
@@ -1,0 +1,12 @@
+class CreateUnsubscribeRequests < ActiveRecord::Migration
+  def change
+    create_table :unsubscribe_requests do |t|
+      t.references :user, null: false
+      t.string :token, null: false
+      t.string :email_preference_name, null: false
+      t.timestamps
+    end
+
+    add_index :unsubscribe_requests, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140902191042) do
+ActiveRecord::Schema.define(version: 20140930215139) do
 
   create_table "accounts", force: true do |t|
     t.integer  "user_id"
@@ -339,6 +339,16 @@ ActiveRecord::Schema.define(version: 20140902191042) do
   add_index "tools", ["slug"], name: "index_tools_on_slug", unique: true, using: :btree
   add_index "tools", ["user_id"], name: "index_tools_on_user_id", using: :btree
 
+  create_table "unsubscribe_requests", force: true do |t|
+    t.integer  "user_id",               null: false
+    t.string   "token",                 null: false
+    t.string   "email_preference_name", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "unsubscribe_requests", ["token"], name: "index_unsubscribe_requests_on_token", unique: true, using: :btree
+
   create_table "users", force: true do |t|
     t.string   "first_name"
     t.string   "last_name"
@@ -353,6 +363,7 @@ ActiveRecord::Schema.define(version: 20140902191042) do
     t.text     "public_key"
     t.boolean  "email_notifications", default: true
     t.string   "install_preference"
+    t.integer  "email_preferences"
   end
 
 end

--- a/lib/tasks/email_preferences.rake
+++ b/lib/tasks/email_preferences.rake
@@ -1,0 +1,8 @@
+namespace :email_preferences do
+  task migrate: :environment do
+    User.where(email_notifications: true).find_each do |user|
+      user.email_preferences << :new_version
+      user.save
+    end
+  end
+end

--- a/spec/api/universe_spec.rb
+++ b/spec/api/universe_spec.rb
@@ -94,8 +94,8 @@ describe 'GET /universe' do
   end
 
   it 'should use supermarket location_type in the future' do
-    unless Time.now < Time.at(1_412_035_199.0)
-      raise 'We should implement the universe using the supermarket location_type and location_path by 2014-09-30'
+    unless Time.now < Time.at(1420012800)
+      raise 'We should implement the universe using the supermarket location_type and location_path by 2014-12-31'
     end
   end
 end

--- a/spec/controllers/email_preferences_controller_spec.rb
+++ b/spec/controllers/email_preferences_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe EmailPreferencesController do
+  let(:unsubscribe_request) { create(:unsubscribe_request) }
+
+  describe 'GET /unsubscribe' do
+    it 'should succeed' do
+      get :unsubscribe, token: unsubscribe_request.token
+      expect(response).to be_success
+    end
+
+    it 'should 404 if the token does not exist' do
+      get :unsubscribe, token: 'haha'
+      expect(response).to render_template('exceptions/404.html.erb')
+    end
+
+    it 'should unsubscribe the person from the email' do
+      allow(UnsubscribeRequest).to receive(:find_by!) { unsubscribe_request }
+      expect(unsubscribe_request).to receive(:make_it_so)
+      get :unsubscribe, token: unsubscribe_request.token
+    end
+  end
+end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -25,8 +25,7 @@ describe ProfileController do
 
       it 'uses strong parameters' do
         fake_user = double(User)
-
-        expect(fake_user).to receive(:update_attributes).with(
+        attrs = {
           'email' => 'bob@example.com',
           'first_name' => 'Bob',
           'last_name' => 'Smith',
@@ -34,22 +33,14 @@ describe ProfileController do
           'twitter_username' => 'bobbo',
           'irc_nickname' => 'bobbo',
           'jira_username' => 'bobbo',
-          'email_notifications' => true
-        )
+          'email_preferences' => ['new_version']
+        }
+
+        expect(fake_user).to receive(:update_attributes).with(attrs)
 
         allow(controller).to receive(:current_user) { fake_user }
 
-        patch :update, user: attributes_for(
-          :user,
-          'email' => 'bob@example.com',
-          'first_name' => 'Bob',
-          'last_name' => 'Smith',
-          'company' => 'Acme',
-          'twitter_username' => 'bobbo',
-          'irc_nickname' => 'bobbo',
-          'jira_username' => 'bobbo',
-          'email_notifications' => true
-        )
+        patch :update, user: attributes_for(:user, attrs)
       end
     end
 

--- a/spec/factories/unsubscribe_request.rb
+++ b/spec/factories/unsubscribe_request.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :unsubscribe_request do
+    email_preference_name 'new_version'
+    association :user
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     first_name 'John'
     last_name 'Doe'
     public_key { File.read('spec/support/key_fixtures/valid_public_key.pub') }
+    email_preferences [:new_version, :deleted, :deprecated]
 
     sequence(:email) { |n| "johndoe#{n}@example.com" }
 

--- a/spec/helpers/email_preferences_helper_spec.rb
+++ b/spec/helpers/email_preferences_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe EmailPreferencesHelper do
+  it 'should output pretty names when given a short name' do
+    expect(helper.pretty_email_name(:new_version)).to eql('New cookbook version')
+    expect(helper.pretty_email_name(:deleted)).to eql('Cookbook deleted')
+    expect(helper.pretty_email_name(:deprecated)).to eql('Cookbook deprecated')
+  end
+
+  it 'should do the right thing when given strings instead of symbols' do
+    expect(helper.pretty_email_name('new_version')).to eql('New cookbook version')
+    expect(helper.pretty_email_name('deleted')).to eql('Cookbook deleted')
+    expect(helper.pretty_email_name('deprecated')).to eql('Cookbook deprecated')
+  end
+end

--- a/spec/helpers/profile_helper_spec.rb
+++ b/spec/helpers/profile_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe ProfileHelper do
+  context '#email_preference' do
+    it 'should output an unchecked checkbox if the user does not have the preference' do
+      user = create(:user)
+      user.email_preferences.delete(:new_version)
+      user.save
+      allow(helper).to receive(:current_user) { user }
+      div = '<div><input id="user_email_preferences_new_version" name="user[email_preferences][]" type="checkbox" value="new_version" /><label for="user_email_preferences_new_version">New cookbook version</label></div>'
+      result = helper.email_preference(:email_preferences, :new_version)
+      expect(result).to eql(div.squish)
+    end
+
+    it 'should output a checked checkbox if the user has the preference' do
+      user = create(:user, email_preferences: [:new_version])
+      allow(helper).to receive(:current_user) { user }
+      div = '<div><input checked="checked" id="user_email_preferences_new_version" name="user[email_preferences][]" type="checkbox" value="new_version" /><label for="user_email_preferences_new_version">New cookbook version</label></div>'
+      result = helper.email_preference(:email_preferences, :new_version)
+      expect(result).to eql(div.squish)
+    end
+  end
+end

--- a/spec/models/unsubscribe_request_spec.rb
+++ b/spec/models/unsubscribe_request_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe UnsubscribeRequest do
+  context 'associations' do
+    it { should belong_to(:user) }
+  end
+
+  context 'validations' do
+    it { should validate_presence_of(:user) }
+    it { should validate_presence_of(:email_preference_name) }
+  end
+
+  it 'should unsubscribe users from emails' do
+    user = create(:user)
+
+    [:new_version, :deleted, :deprecated].each do |name|
+      expect(user.email_preferences?(name)).to eql(true)
+      ur = create(:unsubscribe_request, user: user, email_preference_name: name)
+      ur.make_it_so
+      expect(user.reload.email_preferences?(name)).to eql(false)
+      expect do
+        UnsubscribeRequest.find(ur.id)
+      end.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  it 'should have a token by default' do
+    ur = build(:unsubscribe_request)
+    expect(ur).to be_valid
+    expect(ur.token).to be_present
+  end
+
+  it 'should delete all UnsubscribeRequests for the same email and user' do
+    hank = create(:user)
+    sally = create(:user)
+    ur = create(:unsubscribe_request, user: hank, email_preference_name: 'new_version')
+    create(:unsubscribe_request, user: hank, email_preference_name: 'new_version')
+    create(:unsubscribe_request, user: hank, email_preference_name: 'deleted')
+    create(:unsubscribe_request, user: sally, email_preference_name: 'new_version')
+
+    expect do
+      ur.make_it_so
+    end.to change(UnsubscribeRequest, :count).by(-2)
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -43,6 +43,26 @@ describe User do
     end
   end
 
+  describe 'email preferences' do
+    it 'allows users to express email preferences' do
+      user = create(:user)
+      user.email_preferences = []
+      user.save
+      user.reload
+
+      expect(user.email_preferences).to be_blank
+
+      user.email_preferences << :new_version
+      user.email_preferences << :deleted
+      user.save
+      user.reload
+
+      expect(user.email_preferences?(:new_version)).to eql(true)
+      expect(user.email_preferences?(:deleted)).to eql(true)
+      expect(user.email_preferences?(:deprecated)).to eql(false)
+    end
+  end
+
   describe '#authorized_to_contribute?' do
     it 'is true when the user has signed an ICLA or is a contributor to one or more organizations' do
       contributor_user = create(:user)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,9 @@ ActiveRecord::Migration.check_pending! if defined?(ActiveRecord::Migration)
 # Load factories from FactoryGirl
 FactoryGirl.find_definitions
 
+# Ensure Timecop is run in safe mode
+Timecop.safe_mode = true
+
 # Treat Sidekiq like ActionMailer. In most cases, tests which queue jobs should
 # only care that the job was queued, and not care about the result.
 Sidekiq::Testing.fake!

--- a/spec/workers/cookbook_deletion_worker_spec.rb
+++ b/spec/workers/cookbook_deletion_worker_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 describe CookbookDeletionWorker do
   let(:cookbook) { create(:cookbook) }
   let(:worker) { CookbookDeletionWorker.new }
-  let(:sally) { create(:user, email_notifications: true) }
-  let(:hank) { create(:user, email_notifications: false) }
-  let(:jimmy) { create(:user, email_notifications: true) }
-  let(:fanny) { create(:user, email_notifications: false) }
+  let(:sally) { create(:user, email_preferences: [:deleted]) }
+  let(:hank) { create(:user, email_preferences: [:new_version]) }
+  let(:jimmy) { create(:user, email_preferences: [:deleted]) }
+  let(:fanny) { create(:user, email_preferences: [:deprecated]) }
 
   before do
     create(:cookbook_collaborator, resourceable: cookbook, user: sally)

--- a/spec/workers/cookbook_deprecated_notifier_spec.rb
+++ b/spec/workers/cookbook_deprecated_notifier_spec.rb
@@ -10,7 +10,7 @@ describe CookbookDeprecatedNotifier do
       create(
         :cookbook_follower,
         cookbook: cookbook,
-        user: create(:user, email_notifications: false)
+        user: create(:user, email_preferences: [:new_version, :deleted])
       )
     ]
 

--- a/spec/workers/cookbook_notify_worker_spec.rb
+++ b/spec/workers/cookbook_notify_worker_spec.rb
@@ -7,7 +7,8 @@ describe CookbookNotifyWorker do
     create_list(:cookbook_follower, 3, cookbook: cookbook)
 
     cookbook.cookbook_followers.last.user.tap do |disinterested_user|
-      disinterested_user.update_attribute(:email_notifications, false)
+      disinterested_user.email_preferences.delete(:new_version)
+      disinterested_user.save
     end
 
     cookbook.cookbook_followers.first.user.tap do |imported_user|

--- a/spec/workers/unsubscribe_request_cleanup_worker_spec.rb
+++ b/spec/workers/unsubscribe_request_cleanup_worker_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe UnsubscribeRequestCleanupWorker do
+  it 'deletes UnsubscribeRequests older than 6 months' do
+    Timecop.freeze(7.months.ago) do
+      create(:unsubscribe_request)
+      create(:unsubscribe_request)
+      create(:unsubscribe_request)
+    end
+
+    Timecop.freeze(1.day.ago) do
+      create(:unsubscribe_request)
+    end
+
+    expect do
+      Sidekiq::Testing.inline! do
+        UnsubscribeRequestCleanupWorker.new.perform
+      end
+    end.to change(UnsubscribeRequest, :count).by(-3)
+  end
+end


### PR DESCRIPTION
:convenience_store: 

There are 3 different emails that go out regarding cookbooks:
- New version of a cookbook
- Cookbook deleted
- Cookbook deprecated

Previously, all of those emails were handled through 1 boolean column.  Now each of those 3 is exposed as its own preference on the profile management screen.  Additionally, all of those emails now contain unsubscribe links.

Closes https://github.com/opscode/supermarket/issues/814
