### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Supermarket includes a collection of Chef cookbooks and a preconfigured
 
   ```
   $ vagrant plugin install vagrant-omnibus
-
+  ```
 
 1. Install the `vagrant-berkshelf` plugin:
 


### PR DESCRIPTION
I discovered that Homebrew installs a 9.3 version of Postgresql.  When I attempted to start my Postgresql server in my dev directory, it informed me that the app needed a 9.2 version of Postgresql.  I've added a note to the install instructions to make this clear.
