### PR TITLE
Cleanup old email notifications

### DIFF
--- a/db/migrate/20141007195503_remove_email_notifications_from_user.rb
+++ b/db/migrate/20141007195503_remove_email_notifications_from_user.rb
@@ -1,0 +1,9 @@
+class RemoveEmailNotificationsFromUser < ActiveRecord::Migration
+  def up
+    remove_column :users, :email_notifications
+  end
+
+  def down
+    add_column :users, :email_notifications, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141002205024) do
+ActiveRecord::Schema.define(version: 20141007195503) do
 
   create_table "accounts", force: true do |t|
     t.integer  "user_id"
@@ -363,12 +363,11 @@ ActiveRecord::Schema.define(version: 20141002205024) do
     t.datetime "updated_at"
     t.string   "company"
     t.integer  "roles_mask"
-    t.string   "email",               default: "",   null: false
+    t.string   "email",              default: "", null: false
     t.string   "jira_username"
     t.string   "irc_nickname"
     t.string   "twitter_username"
     t.text     "public_key"
-    t.boolean  "email_notifications", default: true
     t.string   "install_preference"
   end
 

--- a/lib/tasks/email_preferences.rake
+++ b/lib/tasks/email_preferences.rake
@@ -1,8 +1,0 @@
-namespace :email_preferences do
-  task migrate: :environment do
-    User.where(email_notifications: true).find_each do |user|
-      EmailPreference.default_set_for_user(user)
-      user.update_attribute(:email_notifications, false)
-    end
-  end
-end


### PR DESCRIPTION
:convenience_store: 

Now that the new email preferences system is deployed to production, this removes the old `email_notifications` column, and the unneeded rake task that was used to migrate users.
