### PR TITLE
Initialize ROLLOUT lazily

### DIFF
--- a/config/initializers/rollout.rb
+++ b/config/initializers/rollout.rb
@@ -1,24 +1,32 @@
-require 'redis'
+def Object.const_missing(const)
+  if const == :ROLLOUT
+    require 'redis'
 
-redis_url = ENV['REDIS_URL'] || 'redis://localhost:6379/0/supermarket'
+    redis_url = ENV['REDIS_URL'] || 'redis://localhost:6379/0/supermarket'
 
-redis = Redis.new(url: redis_url)
-ROLLOUT = Rollout.new(redis)
+    redis = Redis.new(url: redis_url)
+    Object.const_set('ROLLOUT', Rollout.new(redis))
 
-features = ENV['FEATURES'].to_s.split(',')
+    features = ENV['FEATURES'].to_s.split(',')
 
-#
-# Features that are defined in rollout but are no longer defined
-# in ENV['FEATURES'] need to be deactivated.
-#
-(ROLLOUT.features - features).each do |feature|
-  ROLLOUT.deactivate(feature)
-end
+    #
+    # Features that are defined in rollout but are no longer defined
+    # in ENV['FEATURES'] need to be deactivated.
+    #
+    (ROLLOUT.features - features).each do |feature|
+      ROLLOUT.deactivate(feature)
+    end
 
-#
-# Features that are defined in ENV['FEATURES'] but are
-# not defined in rollout need to be activated.
-#
-(features - ROLLOUT.features).each do |feature|
-  ROLLOUT.activate(feature)
+    #
+    # Features that are defined in ENV['FEATURES'] but are
+    # not defined in rollout need to be activated.
+    #
+    (features - ROLLOUT.features).each do |feature|
+      ROLLOUT.activate(feature)
+    end
+
+    ROLLOUT
+  else
+    super
+  end
 end


### PR DESCRIPTION
:convenience_store: 

This is so we can run rake tasks like asset compilation w/o needing to have Redis running.
