### PR TITLE
Fix typo in cookbook release notification email

### DIFF
--- a/app/views/cookbook_mailer/follower_notification_email.html.erb
+++ b/app/views/cookbook_mailer/follower_notification_email.html.erb
@@ -1,5 +1,5 @@
 <h1>New version of <%= @cookbook.name %> released.</h1>
-<p>A new version of <%= @cookbook.name %> has been relased [<%= @cookbook.latest_cookbook_version.version %>].</p>
+<p>A new version of <%= @cookbook.name %> has been released [<%= @cookbook.latest_cookbook_version.version %>].</p>
 <%= link_to 'View Version', cookbook_version_url(@cookbook, @cookbook.latest_cookbook_version), class: 'button accept' %>
 
 <div class="changelog">

--- a/app/views/cookbook_mailer/follower_notification_email.text.erb
+++ b/app/views/cookbook_mailer/follower_notification_email.text.erb
@@ -4,7 +4,7 @@ _________________________________________________________
 
 New version of <%= @cookbook.name %> released.
 
-A new version of <%= @cookbook.name %> has been relased [<%= @cookbook.latest_cookbook_version.version %>].
+A new version of <%= @cookbook.name %> has been released [<%= @cookbook.latest_cookbook_version.version %>].
 
 <%= cookbook_version_url(@cookbook, @cookbook.latest_cookbook_version) %>
 


### PR DESCRIPTION
:fork_and_knife: 

"released" was spelt "relased"

Related to #847.
