### PR TITLE
Make the View Source button more prominent

### DIFF
--- a/app/views/cookbooks/_sidebar.html.erb
+++ b/app/views/cookbooks/_sidebar.html.erb
@@ -37,7 +37,7 @@
 
     <div class="cookbook-urls">
       <% if cookbook.source_url.present? %>
-        <%= link_to 'View Source', cookbook.source_url, class: 'button secondary radius tiny source-url', itemprop: 'codeRepository' %>
+        <%= link_to 'View Source', cookbook.source_url, class: 'button radius tiny source-url', itemprop: 'codeRepository' %>
       <% end %>
 
       <% if cookbook.issues_url.present? %>


### PR DESCRIPTION
:fork_and_knife: 

Change the view source button from a secondary button to a primary button to
make it more visible.

Closes #820.
