### PR TITLE
Make cookbook transfer more obvious

### DIFF
--- a/app/authorizers/cookbook_authorizer.rb
+++ b/app/authorizers/cookbook_authorizer.rb
@@ -45,7 +45,7 @@ class CookbookAuthorizer < Authorizer::Base
   # @return [Boolean]
   #
   def transfer_ownership?
-    user.is?(:admin)
+    owner? || user.is?(:admin)
   end
 
   #

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -145,18 +145,6 @@ class CookbooksController < ApplicationController
   end
 
   #
-  # PUT /cookbooks/:cookbook/transfer_ownership
-  #
-  # Transfers ownership of cookbook to another user and redirects
-  # back to the cookbook.
-  #
-  def transfer_ownership
-    authorize! @cookbook
-    @cookbook.update_attributes(transfer_ownership_params)
-    redirect_to @cookbook, notice: t('cookbook.transfered_ownership', cookbook: @cookbook.name, user: @cookbook.owner.username)
-  end
-
-  #
   # PUT /cookbooks/:cookbook/deprecate
   #
   # Deprecates the cookbook, sets the replacement cookbook, kicks off a notifier
@@ -255,10 +243,6 @@ class CookbooksController < ApplicationController
 
   def cookbook_urls_params
     params.require(:cookbook).permit(:source_url, :issues_url)
-  end
-
-  def transfer_ownership_params
-    params.require(:cookbook).permit(:user_id)
   end
 
   def cookbook_deprecation_params

--- a/app/controllers/transfer_ownership_controller.rb
+++ b/app/controllers/transfer_ownership_controller.rb
@@ -1,0 +1,66 @@
+class TransferOwnershipController < ApplicationController
+  before_filter :find_transfer_request, only: [:accept, :decline]
+
+  #
+  # PUT /cookbooks/:id/transfer_ownership
+  #
+  # Attempts to transfer ownership of cookbook to another user and redirects
+  # back to the cookbook.
+  #
+  def transfer
+    @cookbook = Cookbook.with_name(params[:id]).first!
+    authorize! @cookbook, :transfer_ownership?
+    recipient = User.find(transfer_ownership_params[:user_id])
+    msg = @cookbook.transfer_ownership(current_user, recipient)
+    redirect_to @cookbook, notice: t(msg, cookbook: @cookbook.name, user: recipient.username)
+  end
+
+  #
+  # GET /ownership_transfer/:token/accept
+  #
+  # Accepts an OwnershipTransferRequest and redirects back to the cookbook.
+  #
+  def accept
+    @transfer_request.accept!
+    redirect_to @transfer_request.cookbook,
+                notice: t(
+                  'cookbook.ownership_transfer.invite_accepted',
+                  cookbook: @transfer_request.cookbook.name
+                )
+  end
+
+  #
+  # GET /ownership_transfer/:token/decline
+  #
+  # Declines an OwnershipTransferRequest and redirects back to the cookbook.
+  #
+  def decline
+    @transfer_request.decline!
+    redirect_to @transfer_request.cookbook,
+                notice: t(
+                  'cookbook.ownership_transfer.invite_declined',
+                  cookbook: @transfer_request.cookbook.name
+                )
+  end
+
+  private
+
+  #
+  # Finds an OwnershipTransferRequest for the given token.
+  #
+  # Note that OwnershipTransferRequests that have already been accepted or
+  # declined will not show up here and will generate a 404.
+  #
+  # @return [OwnershipTransferRequest]
+  #
+  def find_transfer_request
+    @transfer_request = OwnershipTransferRequest.find_by!(
+      token: params[:token],
+      accepted: nil
+    )
+  end
+
+  def transfer_ownership_params
+    params.require(:cookbook).permit(:user_id)
+  end
+end

--- a/app/helpers/contributors_helper.rb
+++ b/app/helpers/contributors_helper.rb
@@ -36,8 +36,8 @@ module ContributorsHelper
   end
 
   #
-  # Show the appropriate text for removing contributors from a resource. Owners
-  # should see "Remove Contributor", while contributors should see "Remove
+  # Show the appropriate text for removing collaborators from a resource. Owners
+  # should see "Remove Collaborator", while collaborators should see "Remove
   # Myself".
   #
   # @param owner [User] the owner of a resource in question
@@ -46,7 +46,7 @@ module ContributorsHelper
   #
   def contributor_removal_text(owner)
     if current_user == owner
-      'Remove Contributor'
+      'Remove Collaborator'
     else
       'Remove Myself'
     end

--- a/app/mailers/cookbook_mailer.rb
+++ b/app/mailers/cookbook_mailer.rb
@@ -55,4 +55,25 @@ class CookbookMailer < ActionMailer::Base
 
     mail(to: @to, subject: subject)
   end
+
+  #
+  # Sends email to the recipient of an OwnershipTransferRequest, asking if they
+  # want to become the new owner of a Cookbook. This is generated when
+  # a Cookbook owner initiates a transfer of ownership to someone that's not
+  # currently a Collaborator on the Cookbook.
+  #
+  # @param transfer_request [OwnershipTransferRequest]
+  #
+  def transfer_ownership_email(transfer_request)
+    @transfer_request = transfer_request
+    @sender = transfer_request.sender.name
+    @cookbook = transfer_request.cookbook.name
+
+    subject = %(
+      #{@sender} wants to transfer ownership of the #{@cookbook} cookbook to
+      you.
+    ).squish
+
+    mail(to: transfer_request.recipient.email, subject: subject)
+  end
 end

--- a/app/models/concerns/tokenable.rb
+++ b/app/models/concerns/tokenable.rb
@@ -7,9 +7,9 @@ module Tokenable
   #
   # Callback: create and assign a confirmation token when a new email is added.
   #
-  def generate_token(column)
+  def generate_token(column = :token)
     begin
-      self[column] = SecureRandom.urlsafe_base64
+      self[column] = SecureRandom.hex
     end while self.class.exists?(column => self[column])
   end
 end

--- a/app/models/email_preference.rb
+++ b/app/models/email_preference.rb
@@ -1,4 +1,6 @@
 class EmailPreference < ActiveRecord::Base
+  include Tokenable
+
   # Associations
   # --------------------
   belongs_to :system_email
@@ -12,7 +14,7 @@ class EmailPreference < ActiveRecord::Base
 
   # Callbacks
   # --------------------
-  before_validation :ensure_token
+  before_validation { generate_token }
 
   #
   # Setup a default set of +EmailPreference+s for a +User+. This is called when
@@ -34,14 +36,5 @@ class EmailPreference < ActiveRecord::Base
   #
   def to_param
     token
-  end
-
-  private
-
-  #
-  # Ensure that a token exists when this object is created
-  #
-  def ensure_token
-    self.token = SecureRandom.hex
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -14,7 +14,7 @@ class Invitation < ActiveRecord::Base
 
   # Callbacks
   # --------------------
-  before_validation { generate_token(:token) }
+  before_validation { generate_token }
 
   scope :pending, -> { where(accepted: nil) }
   scope :declined, -> { where(accepted: false) }

--- a/app/models/ownership_transfer_request.rb
+++ b/app/models/ownership_transfer_request.rb
@@ -1,0 +1,49 @@
+class OwnershipTransferRequest < ActiveRecord::Base
+  include Tokenable
+
+  # Associations
+  # --------------------
+  belongs_to :cookbook
+  belongs_to :recipient, class_name: 'User'
+  belongs_to :sender, class_name: 'User'
+
+  # Validations
+  # --------------------
+  validates :token, presence: true, uniqueness: true
+  validates :cookbook, presence: true
+  validates :recipient, presence: true
+  validates :sender, presence: true
+
+  # Callbacks
+  # --------------------
+  before_validation { generate_token }
+
+  #
+  # Accept this transfer request. This will mark this request as accepted, and
+  # update the cookbook in question to have the new owner.
+  #
+  # Note that this method will not do anything if this request has already been
+  # responded to.
+  #
+  def accept!
+    return unless accepted.nil?
+    update_attribute(:accepted, true)
+    cookbook.update_attribute(:user_id, recipient.id)
+  end
+
+  #
+  # Decline this transfer request. This will mark this request as declined, and
+  # do nothing else.
+  #
+  # Note that this method will not do anything if this request has already been
+  # responded to.
+  #
+  def decline!
+    return unless accepted.nil?
+    update_attribute(:accepted, false)
+  end
+
+  def to_param
+    token
+  end
+end

--- a/app/views/cookbook_mailer/transfer_ownership_email.html.erb
+++ b/app/views/cookbook_mailer/transfer_ownership_email.html.erb
@@ -1,0 +1,4 @@
+<h1><%= @sender %> wants to transfer ownership of the <%= @cookbook %> cookbook to you.</h1>
+
+<%= link_to 'Accept', accept_transfer_url(@transfer_request), class: 'button accept' %>
+<%= link_to 'Decline', decline_transfer_url(@transfer_request), class: 'button decline' %>

--- a/app/views/cookbook_mailer/transfer_ownership_email.text.erb
+++ b/app/views/cookbook_mailer/transfer_ownership_email.text.erb
@@ -1,0 +1,4 @@
+<%= @sender %> wants to transfer ownership of the <%= @cookbook %> cookbook to you.
+
+To accept, click here: <%= accept_transfer_url(@transfer_request) %>
+To decline, click here: <%= decline_transfer_url(@transfer_request) %>

--- a/app/views/cookbooks/_manage_cookbook.html.erb
+++ b/app/views/cookbooks/_manage_cookbook.html.erb
@@ -25,7 +25,7 @@
       <h1>Transfer Ownership</h1>
       <a class="close-reveal-modal">&#215;</a>
 
-      <%= form_for cookbook, url: transfer_ownership_cookbook_path(cookbook), method: :put do |f| %>
+      <%= form_for cookbook, url: transfer_ownership_path(cookbook), method: :put do |f| %>
         <div class="row collapse">
           <div class="small-9 columns">
             <%= f.hidden_field :user_id, class: 'collaborators', 'data-url' => collaborators_path(ineligible_user_ids: Collaborator.ineligible_owners_for(cookbook).map(&:id)) %>

--- a/app/views/resources/_collaborators.html.erb
+++ b/app/views/resources/_collaborators.html.erb
@@ -2,15 +2,10 @@
   <% collaborators.each do |collaborator| %>
     <div class="gravatar-container">
       <% collaboration_permissions_for(collaborator) do |transfer, destroy| %>
-        <% if transfer || destroy %>
+        <% if destroy %>
           <%= link_to gravatar_for(collaborator.user, size: 80), collaborator.user, title: collaborator.user.name, data: { :dropdown => contributor_options_id(collaborator.user)} %>
           <ul id="<%= contributor_options_id(collaborator.user) %>" data-dropdown-content class="f-dropdown">
-            <% if transfer %>
-              <li><%= link_to '<i class="fa fa-random"></i> Transfer Ownership'.html_safe, transfer_collaborator_path(collaborator), rel: 'transfer-cookbook-ownership', method: :put %></li>
-            <% end %>
-            <% if destroy %>
-              <li><%= link_to "<i class='fa fa-times-circle'></i> #{contributor_removal_text(resource.owner)}".html_safe, collaborator_path(collaborator), rel: 'remove-cookbook-collaborator', remote: true, method: :delete %></li>
-            <% end %>
+            <li><%= link_to "<i class='fa fa-times-circle'></i> #{contributor_removal_text(resource.owner)}".html_safe, collaborator_path(collaborator), rel: 'remove-cookbook-collaborator', remote: true, method: :delete %></li>
           </ul>
         <% else %>
           <%= link_to gravatar_for(collaborator.user, size: 80), collaborator.user, title: collaborator.user.username %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,7 +15,11 @@ en:
     added: 'Collaborator added.'
     owner_changed: 'You successfully transferred ownership of %{resource} to %{user}.'
   cookbook:
-    transfered_ownership: "%{cookbook} transferred to %{user}."
+    ownership_transfer:
+      done: "%{cookbook} transferred to %{user}."
+      email_sent: "Ownership transfer email sent to %{user}."
+      invite_accepted: "You are the new owner of %{cookbook}."
+      invite_declined: "You have declined ownership of %{cookbook}."
     deprecated: "%{cookbook} deprecated in favor of %{replacement_cookbook}."
     undeprecated: "%{cookbook} is no longer deprecated."
     featured: "%{cookbook} is now %{state}."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,12 +33,15 @@ Supermarket::Application.routes.draw do
   get 'status' => 'api/v1/health#show', defaults: { format: :json }
   get 'unsubscribe/:token' => 'email_preferences#unsubscribe', as: :unsubscribe
 
+  put 'cookbooks/:id/transfer_ownership' => 'transfer_ownership#transfer', as: :transfer_ownership
+  get 'ownership_transfer/:token/accept' => 'transfer_ownership#accept', as: :accept_transfer
+  get 'ownership_transfer/:token/decline' => 'transfer_ownership#decline', as: :decline_transfer
+
   resources :cookbooks, only: [:index, :show, :update] do
     member do
       get :download
       put :follow
       delete :unfollow
-      put :transfer_ownership
       put :deprecate
       delete :deprecate, action: 'undeprecate'
       put :toggle_featured

--- a/db/migrate/20141013212617_create_ownership_transfer_requests.rb
+++ b/db/migrate/20141013212617_create_ownership_transfer_requests.rb
@@ -1,0 +1,16 @@
+class CreateOwnershipTransferRequests < ActiveRecord::Migration
+  def change
+    create_table :ownership_transfer_requests do |t|
+      t.integer :cookbook_id, null: false
+      t.integer :recipient_id, null: false
+      t.integer :sender_id, null: false
+      t.string :token, null: false
+      t.boolean :accepted
+      t.timestamps
+    end
+
+    add_index :ownership_transfer_requests, :recipient_id
+    add_index :ownership_transfer_requests, :cookbook_id
+    add_index :ownership_transfer_requests, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141007195503) do
+ActiveRecord::Schema.define(version: 20141013212617) do
 
   create_table "accounts", force: true do |t|
     t.integer  "user_id"
@@ -323,6 +323,20 @@ ActiveRecord::Schema.define(version: 20141007195503) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "ownership_transfer_requests", force: true do |t|
+    t.integer  "cookbook_id",  null: false
+    t.integer  "recipient_id", null: false
+    t.integer  "sender_id",    null: false
+    t.string   "token",        null: false
+    t.boolean  "accepted"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "ownership_transfer_requests", ["cookbook_id"], name: "index_ownership_transfer_requests_on_cookbook_id", using: :btree
+  add_index "ownership_transfer_requests", ["recipient_id"], name: "index_ownership_transfer_requests_on_recipient_id", using: :btree
+  add_index "ownership_transfer_requests", ["token"], name: "index_ownership_transfer_requests_on_token", unique: true, using: :btree
 
   create_table "supported_platforms", force: true do |t|
     t.string   "name",                                    null: false

--- a/spec/controllers/cookbooks_controller_spec.rb
+++ b/spec/controllers/cookbooks_controller_spec.rb
@@ -358,35 +358,6 @@ describe CookbooksController do
     end
   end
 
-  describe 'PUT #transfer_ownership' do
-    let(:cookbook) { create(:cookbook) }
-    let(:new_owner) { create(:user) }
-
-    context 'the current user is an admin' do
-      before { sign_in(create(:admin)) }
-
-      it 'changes the cookbooks owner' do
-        put :transfer_ownership, id: cookbook, cookbook: { user_id: new_owner.id }
-        cookbook.reload
-        expect(cookbook.owner).to eql(new_owner)
-      end
-
-      it 'redirects back to the cookbook' do
-        put :transfer_ownership, id: cookbook, cookbook: { user_id: new_owner.id }
-        expect(response).to redirect_to(assigns[:cookbook])
-      end
-    end
-
-    context 'the current user is not an admin' do
-      before { sign_in(create(:user)) }
-
-      it 'returns a 404' do
-        put :transfer_ownership, id: cookbook, cookbook: { user_id: new_owner.id }
-        expect(response.status.to_i).to eql(404)
-      end
-    end
-  end
-
   describe 'PUT #deprecate' do
     let(:user) { create(:user) }
     let!(:cookbook) { create(:cookbook, owner: user) }

--- a/spec/controllers/transfer_ownership_controller_spec.rb
+++ b/spec/controllers/transfer_ownership_controller_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+
+describe TransferOwnershipController do
+  describe 'PUT #transfer' do
+    let(:cookbook) { create(:cookbook) }
+    let(:new_owner) { create(:user) }
+
+    before do
+      cookbook_collection = double('cookbook_collection', :first! => cookbook)
+      allow(Cookbook).to receive(:with_name) { cookbook_collection }
+    end
+
+    shared_examples 'admin_or_owner' do
+      before { sign_in(user) }
+
+      it 'attempts to change the cookbooks owner' do
+        expect(cookbook).to receive(:transfer_ownership).with(
+          user,
+          new_owner
+        ) { 'cookbook.ownership_transfer.done' }
+        put :transfer, id: cookbook, cookbook: { user_id: new_owner.id }
+      end
+
+      it 'redirects back to the cookbook' do
+        put :transfer, id: cookbook, cookbook: { user_id: new_owner.id }
+        expect(response).to redirect_to(assigns[:cookbook])
+      end
+    end
+
+    context 'the current user is an admin' do
+      let(:user) { create(:admin) }
+      it_behaves_like 'admin_or_owner'
+    end
+
+    context 'the current user is the cookbook owner' do
+      let(:user) { cookbook.owner }
+      it_behaves_like 'admin_or_owner'
+    end
+
+    context 'the current user is not an admin nor an owner of the cookbook' do
+      before { sign_in(create(:user)) }
+
+      it 'returns a 404' do
+        put :transfer, id: cookbook, cookbook: { user_id: new_owner.id }
+        expect(response.status.to_i).to eql(404)
+      end
+    end
+  end
+
+  context 'transfer requests' do
+    let(:transfer_request) { create(:ownership_transfer_request) }
+
+    shared_examples 'a transfer request' do
+      it 'redirects back to the cookbook' do
+        post :accept, token: transfer_request
+        expect(response).to redirect_to(assigns[:transfer_request].cookbook)
+      end
+
+      it 'finds transfer requests based on token' do
+        post :accept, token: transfer_request
+        expect(assigns[:transfer_request]).to eql(transfer_request)
+      end
+
+      it 'returns a 404 if the transfer request given has already been updated' do
+        transfer_request.update_attribute(:accepted, true)
+        post :accept, token: transfer_request
+        expect(response.status.to_i).to eql(404)
+      end
+    end
+
+    describe 'GET #accept' do
+      it 'attempts to accept the transfer request' do
+        allow(OwnershipTransferRequest).to receive(:find_by!) { transfer_request }
+        expect(transfer_request.accepted).to be_nil
+        expect(transfer_request).to receive(:accept!)
+        get :accept, token: transfer_request
+      end
+
+      it_behaves_like 'a transfer request'
+    end
+
+    describe 'GET #decline' do
+      it 'attempts to decline the transfer request' do
+        allow(OwnershipTransferRequest).to receive(:find_by!) { transfer_request }
+        expect(transfer_request.accepted).to be_nil
+        expect(transfer_request).to receive(:decline!)
+        get :decline, token: transfer_request
+      end
+
+      it_behaves_like 'a transfer request'
+    end
+  end
+end

--- a/spec/factories/ownership_transfer_request.rb
+++ b/spec/factories/ownership_transfer_request.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :ownership_transfer_request do
+    association :cookbook
+    association :recipient, factory: :user
+    association :sender, factory: :user
+  end
+end

--- a/spec/helpers/contributors_helper_spec.rb
+++ b/spec/helpers/contributors_helper_spec.rb
@@ -30,7 +30,7 @@ describe ContributorsHelper do
 
     it 'returns "Remove Contributor" if you are the owner' do
       allow(helper).to receive(:current_user) { sally }
-      expect(helper.contributor_removal_text(cookbook.owner)).to eql('Remove Contributor')
+      expect(helper.contributor_removal_text(cookbook.owner)).to eql('Remove Collaborator')
     end
 
     it 'returns "Remove Myself" if you are a contributor' do

--- a/spec/models/email_preference_spec.rb
+++ b/spec/models/email_preference_spec.rb
@@ -27,12 +27,4 @@ describe EmailPreference do
     expect(hank.email_preferences.size).to eql(3)
     expect(hank.system_emails.map(&:name)).to include('lol', 'wut', 'yiss')
   end
-
-  it 'should have a unique token' do
-    ep = create(:email_preference)
-    ep2 = build(:email_preference)
-    expect(SecureRandom).to receive(:hex) { ep.token }
-    expect(ep2).to_not be_valid
-    expect(ep2.errors[:token]).to_not be_nil
-  end
 end

--- a/spec/models/ownership_transfer_request_spec.rb
+++ b/spec/models/ownership_transfer_request_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe OwnershipTransferRequest do
+  context 'associations' do
+    it { should belong_to(:cookbook) }
+    it { should belong_to(:recipient) }
+    it { should belong_to(:sender) }
+  end
+
+  context 'validations' do
+    it { should validate_presence_of(:cookbook) }
+    it { should validate_presence_of(:recipient) }
+    it { should validate_presence_of(:sender) }
+  end
+
+  it 'should have a token by default' do
+    otr = build(:ownership_transfer_request)
+    expect(otr).to be_valid
+    expect(otr.token).to be_present
+  end
+
+  context 'accept and decline' do
+    let(:transfer_request) { create(:ownership_transfer_request) }
+
+    shared_examples 'returning early' do
+      it 'should not do anything if it has already been accepted or declined' do
+        transfer_request.update_attribute(:accepted, false)
+        transfer_request.reload
+        expect(transfer_request).to_not receive(:update_attribute)
+        transfer_request.accept!
+        transfer_request.reload
+        expect(transfer_request.accepted).to eql(false)
+      end
+    end
+
+    describe '#accept!' do
+      it 'should mark itself as accepted' do
+        expect(transfer_request.accepted).to be_nil
+        transfer_request.accept!
+        transfer_request.reload
+        expect(transfer_request.accepted).to eql(true)
+      end
+
+      it 'should transfer ownership to someone else' do
+        cookbook = transfer_request.cookbook
+        sally = cookbook.owner
+        jimmy = transfer_request.recipient
+        transfer_request.accept!
+        cookbook.reload
+        expect(cookbook.owner).to eql(jimmy)
+      end
+
+      it_should_behave_like 'returning early'
+    end
+
+    describe '#decline!' do
+      it 'should mark itself as declined' do
+        expect(transfer_request.accepted).to be_nil
+        transfer_request.decline!
+        transfer_request.reload
+        expect(transfer_request.accepted).to eql(false)
+      end
+
+      it_should_behave_like 'returning early'
+    end
+  end
+end


### PR DESCRIPTION
:convenience_store: 

This (hopefully) makes the process of transferring a cookbook to a new owner more intuitive.

Previously, there were 2 ways to transfer cookbook ownership:
- an admin could transfer the cookbook to anyone they wanted.
- the cookbook owner could transfer the cookbook to an existing collaborator by clicking on the collaborator's avatar on the cookbook details page.

Now, ownership transfer happens from the "Manage Cookbook" select menu on the right side of the page.  If the logged in user is an admin, things work as they did before.  They can select anyone to transfer ownership to, and it happens instantly.  Similarly, if the cookbook owner is logged in, and they search for a user to transfer ownership to, and that user is already a collaborator on the cookbook, then the transfer happens immediately.  

But, cookbook owners are welcome to search for any user they wish, whether they're existing collaborators or not.  If the user selected is not a collaborator, they'll receive an email informing them that someone wants to give them ownership of a cookbook and prompting them to accept or decline the invitation.  If they accept, they're the new owner.  If they decline (or fail to respond), nothing changes.

Closes https://github.com/opscode/supermarket/issues/825
