### PR TITLE
fix factory_girl warnings

### DIFF
--- a/spec/factories/cookbook.rb
+++ b/spec/factories/cookbook.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     deprecated false
     featured false
 
-    ignore do
+    transient do
       cookbook_versions_count 2
     end
 

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :organization do
-    ignore do
+    transient do
       ccla_signatures_count 2
     end
 

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
 
     sequence(:email) { |n| "johndoe#{n}@example.com" }
 
-    ignore do
+    transient do
       create_chef_account true
     end
 


### PR DESCRIPTION
There were deprecation messages that showed up when we upgraded to newer factory_girl. This makes them go away.
