### PR TITLE
set OmniAuth.config.full_host

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -5,10 +5,15 @@
 # If this is not set correctly, OmniAuth may not generate redirect_uri
 # parameters in requests correctly.
 #
+# We do not need to do this in the test environment, since it's using mock_auth
+# there.
+#
 # See http://www.kbedell.com/2011/03/08/overriding-omniauth-callback-url-for-twitter-or-facebook-oath-processing/
-OmniAuth.config.full_host = "#{ENV['PROTOCOL']}://" \
-  "#{ENV['HOST']}" \
-  "#{[80, 443].include?(ENV['PORT'].to_i) ? '' : ':' + ENV['PORT']}"
+unless Rails.env.test?
+  OmniAuth.config.full_host = "#{ENV['PROTOCOL']}://" \
+    "#{ENV['HOST']}" \
+    "#{[80, 443].include?(ENV['PORT'].to_i) ? '' : ':' + ENV['PORT']}"
+end
 
 # Configure middleware used by OmniAuth
 Rails.application.config.middleware.use(OmniAuth::Builder) do


### PR DESCRIPTION
This isn't always set correctly in an omnibus install for some reason. This makes sure it's always set.
