### PR TITLE
fix post-sign-out url

### DIFF
--- a/app/views/pages/welcome.html.erb
+++ b/app/views/pages/welcome.html.erb
@@ -4,7 +4,7 @@
 <div class="page withspace">
   <% if flash[:signout] %>
     <div class="signout-message">
-      <p>You have been signed out of Supermarket but may still be signed in to your Chef account. Visit <%= link_to ENV['CHEF_IDENTITY_URL'] %> to sign out completely.</p>
+      <p>You have been signed out of Supermarket but may still be signed in to your Chef account. Visit <%= link_to ENV['CHEF_IDENTITY_URL'], ENV['CHEF_IDENTITY_URL'] %> to sign out completely.</p>
     </div>
   <% end %>
 


### PR DESCRIPTION
Giving `link_to` a single argument here makes it link to / and show the correct URL. This makes both work.
