### PR TITLE
Fix sitemap generation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,5 @@
 require File.expand_path('../boot', __FILE__)
-
 require 'dotenv'
-
 require 'rails'
 
 Dotenv.overload('.env', ".env.#{Rails.env}").tap do |env|

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,6 +1,10 @@
 # Set the host name for URL creation
 if Rails.env.production?
-  SitemapGenerator::Sitemap.default_host = root_url
+  SitemapGenerator::Sitemap.default_host = if ENV['PORT'].present?
+                                             "#{ENV['PROTOCOL']}://#{ENV['HOST']}:#{ENV['PORT']}"
+                                           else
+                                             "#{ENV['PROTOCOL']}://#{ENV['HOST']}"
+                                           end
 else
   SitemapGenerator::Sitemap.default_host = 'http://www.example.com'
 end


### PR DESCRIPTION
:convenience_store: 

Previously, the sitemap gem threw an error when running `bundle exec rake sitemap:refresh:no_ping` because it didn't know what host to use for the `root_url`.  Now we just construct that host manually using ENV vars.

/cc @jtimberman 
