### PR TITLE
Make categories optional

### DIFF
--- a/app/controllers/api/v1/cookbook_uploads_controller.rb
+++ b/app/controllers/api/v1/cookbook_uploads_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::CookbookUploadsController < Api::V1Controller
   # Accepts cookbooks to share. A sharing request is a multipart POST. Two of
   # those parts are relevant to this method: +cookbook+ and +tarball+.
   #
-  # The +cookbook+ part is a serialized JSON object which must contain a
+  # The +cookbook+ part is a serialized JSON object which can optionally contain a
   # +"category"+ key. The value of this key is the name of the category to
   # which this cookbook belongs.
   #
@@ -26,8 +26,7 @@ class Api::V1::CookbookUploadsController < Api::V1Controller
   # this action.
   #
   # There are also several failure modes for sharing a cookbook. These include,
-  # but are not limited to, forgetting to specify a category, specifying a
-  # non-existent category, forgetting to upload a tarball, uploading a tarball
+  # but are not limited to, forgetting to upload a tarball, uploading a tarball
   # without a metadata.json entry, and so forth.
   #
   # The majority of the work happens between +CookbookUpload+,

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -89,7 +89,6 @@ class Cookbook < ActiveRecord::Base
   validates :name, presence: true, uniqueness: { case_sensitive: false }, format: /\A[\w_-]+\z/i
   validates :lowercase_name, presence: true, uniqueness: true
   validates :cookbook_versions, presence: true
-  validates :category, presence: true
   validates :source_url, url: {
     allow_blank: true,
     allow_nil: true

--- a/app/models/cookbook_upload.rb
+++ b/app/models/cookbook_upload.rb
@@ -7,8 +7,7 @@ class CookbookUpload
   # @param user [User] the user uploading the cookbook
   # @param params [Hash] the upload parameters
   # @option params [String] :cookbook a JSON string which contains cookbook
-  #   data. In particular, it should contain a +"category"+ key when
-  #   deserialized
+  #   data.
   # @option params [File] :tarball the cookbook tarball artifact
   #
   def initialize(user, params)
@@ -92,7 +91,7 @@ class CookbookUpload
         e.add(:base, message)
       end
 
-      if category.nil?
+      if category.nil? && @params.category_name.present?
         message = I18n.t(
           'api.error_messages.non_existent_category',
           category_name: @params.category_name

--- a/app/models/cookbook_upload/parameters.rb
+++ b/app/models/cookbook_upload/parameters.rb
@@ -26,8 +26,7 @@ class CookbookUpload
     #
     # @param params [Hash] the "raw" parameters
     # @option params [String] :cookbook a JSON string which specifies cookbook
-    #   attributes; in particular, it should contain a +"category"+ key when
-    #   deserialized
+    #   attributes
     # @option params [File] :tarball the cookbook tarball artifact
     #
     def initialize(params)

--- a/app/views/api/v1/cookbooks/_cookbook.json.jbuilder
+++ b/app/views/api/v1/cookbooks/_cookbook.json.jbuilder
@@ -1,7 +1,7 @@
 json.name cookbook.name
 json.maintainer cookbook.maintainer
 json.description cookbook.description
-json.category cookbook.category.name
+json.category cookbook.category.try(:name)
 json.latest_version latest_cookbook_version_url(cookbook)
 json.external_url cookbook.source_url
 json.average_rating nil

--- a/db/migrate/20141124212519_make_category_optional.rb
+++ b/db/migrate/20141124212519_make_category_optional.rb
@@ -1,0 +1,9 @@
+class MakeCategoryOptional < ActiveRecord::Migration
+  def up
+    change_column :cookbooks, :category_id, :integer, null: true
+  end
+
+  def down
+    change_column :cookbooks, :category_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141114192958) do
+ActiveRecord::Schema.define(version: 20141124212519) do
 
   create_table "accounts", force: true do |t|
     t.integer  "user_id"
@@ -191,7 +191,7 @@ ActiveRecord::Schema.define(version: 20141114192958) do
     t.datetime "updated_at"
     t.string   "source_url"
     t.boolean  "deprecated",               default: false
-    t.integer  "category_id",                              null: false
+    t.integer  "category_id"
     t.string   "lowercase_name"
     t.string   "issues_url"
     t.integer  "cookbook_followers_count", default: 0

--- a/spec/api/cookbook_create_spec.rb
+++ b/spec/api/cookbook_create_spec.rb
@@ -33,6 +33,12 @@ describe 'POST /api/v1/cookbooks' do
     it_behaves_like 'valid cookbook'
   end
 
+  context 'no category is given' do
+    before(:each) { share_cookbook('redis-test', user, category: nil) }
+
+    it_behaves_like 'valid cookbook'
+  end
+
   context "the user doesn't provide valid params" do
     before(:each) { share_cookbook('redis-test', user, payload: {}) }
 

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -116,7 +116,6 @@ describe Cookbook do
 
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:cookbook_versions) }
-    it { should validate_presence_of(:category) }
   end
 
   describe '#lowercase_name' do

--- a/spec/models/cookbook_upload_spec.rb
+++ b/spec/models/cookbook_upload_spec.rb
@@ -222,18 +222,13 @@ describe CookbookUpload do
         to include(I18n.t('api.error_messages.invalid_metadata'))
     end
 
-    it 'yields an error if the cookbook parameters do not specify a category' do
+    it 'does not yield an error if the cookbook parameters do not specify a category' do
       tarball = File.open('spec/support/cookbook_fixtures/redis-test-v1.tgz')
 
       upload = CookbookUpload.new(user, cookbook: '{}', tarball: tarball)
       errors = upload.finish { |e, _| e }
 
-      error_message = I18n.t(
-        'api.error_messages.non_existent_category',
-        category_name: ''
-      )
-
-      expect(errors.full_messages).to include(error_message)
+      expect(errors.full_messages).to be_empty
     end
 
     it 'yields an error if the cookbook parameters specify an invalid category' do

--- a/spec/support/api_spec_helpers.rb
+++ b/spec/support/api_spec_helpers.rb
@@ -19,6 +19,7 @@ module ApiSpecHelpers
   #
   def share_cookbook(cookbook_name, user, opts = {})
     cookbooks_path = '/api/v1/cookbooks'
+    cookbook_params = {}
 
     tarball = cookbook_upload(cookbook_name, opts)
     private_key = private_key(opts.fetch(:with_invalid_private_key, false))
@@ -33,8 +34,14 @@ module ApiSpecHelpers
 
     opts.fetch(:omitted_headers, []).each { |h| header.delete(h) }
 
-    category = create(:category, name: opts.fetch(:category, 'other').titleize)
-    payload = opts.fetch(:payload, cookbook: "{\"category\": \"#{category.name}\"}", tarball: tarball)
+    category = opts.fetch(:category, 'other')
+
+    unless category.nil?
+      new_category = create(:category, name: category.titleize)
+      cookbook_params[:category] = new_category.name
+    end
+
+    payload = opts.fetch(:payload, cookbook: JSON.generate(cookbook_params), tarball: tarball)
 
     post cookbooks_path, payload, header
   end


### PR DESCRIPTION
:convenience_store: 

Categories have been missing from the UI for awhile but were still required by the API and at the model level.  This removes all of that so that categories are optional now.

Note that knife still requires a category (AFAIK), so if you're using knife, you still need to specify one.  There is an outstanding issue on the chef repo to remove that constraint from knife.  https://github.com/opscode/chef/issues/2099
