### PR TITLE
Change getchef.com to chef.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,9 @@ check with our lawyers about small patches.
 
 It only takes a few minutes to complete a CLA, and you retain the copyright to your contribution.
 
-You can [become a contributor by signing the ICLA or by contributing on behalf of your company](http://supermarket.getchef.com/become-a-contributor).
+You can [become a contributor by signing the ICLA or by contributing on behalf of your company](http://supermarket.chef.io/become-a-contributor).
 
-For more information about licensing, copyright, and CLAs see Chef's [Community Contributions](http://docs.getchef.com/community_contributions.html) page.
+For more information about licensing, copyright, and CLAs see Chef's [Community Contributions](http://docs.chef.io/community_contributions.html) page.
 
 Working with the community
 --------------------------
@@ -31,8 +31,8 @@ These resources will help you learn more about Chef and connect to other members
 
 * [chef](http://lists.opscode.com/sympa/info/chef) and [chef-dev](http://lists.opscode.com/sympa/info/chef-dev) mailing lists
 * #chef and #chef-hacking IRC channels on irc.freenode.net
-* [Chef docs](http://docs.getchef.com)
-* Chef [product page](http://www.getchef.com/chef)
+* [Chef docs](http://docs.chef.io)
+* Chef [product page](http://www.chef.io/chef)
 
 
 Overview

--- a/OWNERS
+++ b/OWNERS
@@ -1,1 +1,1 @@
-Chef Front End Team <front-end@getchef.com>
+Chef Front End Team <front-end@chef.io>

--- a/app/helpers/custom_url_helper.rb
+++ b/app/helpers/custom_url_helper.rb
@@ -6,7 +6,7 @@ module CustomUrlHelper
   #
 
   def chef_domain
-    ENV['CHEF_DOMAIN'] || 'getchef.com'
+    ENV['CHEF_DOMAIN'] || 'chef.io'
   end
 
   def chef_server_url

--- a/app/models/curry/unauthorized_commit_author_comment.rb
+++ b/app/models/curry/unauthorized_commit_author_comment.rb
@@ -44,7 +44,7 @@ class Curry::UnauthorizedCommitAuthorComment
         verified email address. To become authorized to contribute, you will
         need to sign the Contributor License Agreement (CLA) as an individual or
         on behalf of your company. [You can read more on Chef's
-        blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)
+        blog.](#{chef_blog_url('2014/06/23/changes-to-the-contributor-license-agreement-process')})
       ).squish
 
       if @unauthorized_commit_authors.any?(&:email)

--- a/docs/CONFIGURING.md
+++ b/docs/CONFIGURING.md
@@ -61,7 +61,7 @@ the test suite.
 * `S3_ACCESS_KEY_ID` and `S3_SECRET_ACCESS_KEY` are the keys required to put
   files in the above bucket.
 * `CDN_URL` Used to configure a CDN URL for use with Paperclip. Downloads
-will be aliased with this URL, something like `static.getchef.com`.
+will be aliased with this URL, something like `static.chef.io`.
 * `FIERI_URL` is the URL Supermarket will `POST` to for Cookbook evaluation when
   a cookbook is shared
 

--- a/spec/helpers/custom_url_helper_spec.rb
+++ b/spec/helpers/custom_url_helper_spec.rb
@@ -11,7 +11,7 @@ describe CustomUrlHelper do
 
   it 'should have a default domain' do
     expect(ENV['CHEF_DOMAIN']).to be_nil
-    expect(helper.chef_domain).to eql('getchef.com')
+    expect(helper.chef_domain).to eql('chef.io')
   end
 
   it 'should have a server url' do
@@ -21,7 +21,7 @@ describe CustomUrlHelper do
 
   describe 'www url' do
     let(:meth) { :chef_www_url }
-    let(:url) { 'https://www.getchef.com' }
+    let(:url) { 'https://www.chef.io' }
 
     it 'should have a www url that uses the default domain' do
       expect(ENV['CHEF_WWW_URL']).to be_nil
@@ -33,7 +33,7 @@ describe CustomUrlHelper do
 
   describe 'blog url' do
     let(:meth) { :chef_blog_url }
-    let(:url) { 'https://www.getchef.com/blog' }
+    let(:url) { 'https://www.chef.io/blog' }
 
     it 'should have a blog url that uses the www url' do
       expect(ENV['CHEF_BLOG_URL']).to be_nil
@@ -45,7 +45,7 @@ describe CustomUrlHelper do
 
   describe 'docs url' do
     let(:meth) { :chef_docs_url }
-    let(:url) { 'https://docs.getchef.com' }
+    let(:url) { 'https://docs.chef.io' }
 
     it 'should have a docs url that uses the default domain' do
       expect(ENV['CHEF_DOCS_URL']).to be_nil
@@ -57,7 +57,7 @@ describe CustomUrlHelper do
 
   describe 'downloads url' do
     let(:meth) { :chef_downloads_url }
-    let(:url) { 'https://downloads.getchef.com' }
+    let(:url) { 'https://downloads.chef.io' }
 
     it 'should have a downloads url that uses the default domain' do
       expect(ENV['CHEF_DOWNLOADS_URL']).to be_nil
@@ -94,6 +94,6 @@ describe CustomUrlHelper do
 
   it 'should have a learn chef url that uses the default domain' do
     expect(ENV['LEARN_CHEF_URL']).to be_nil
-    expect(helper.learn_chef_url).to eql('https://learn.getchef.com')
+    expect(helper.learn_chef_url).to eql('https://learn.chef.io')
   end
 end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -17,8 +17,8 @@ $ bundle exec rake spec:all
     end
 
     it 'auto renders links with target blank' do
-      expect(helper.render_markdown('http://getchef.com')).
-        to match(Regexp.quote('<a href="http://getchef.com" target="_blank">http://getchef.com</a>'))
+      expect(helper.render_markdown('http://chef.io')).
+        to match(Regexp.quote('<a href="http://chef.io" target="_blank">http://chef.io</a>'))
     end
   end
 

--- a/spec/vcr_cassettes/pull_request_annotation_adds_comment.yml
+++ b/spec/vcr_cassettes/pull_request_annotation_adds_comment.yml
@@ -11,7 +11,7 @@ http_interactions:
         a non GitHub-verified email address in this Pull Request. Chef will have to
         verify by hand that they have signed a Chef CLA.\n\nThe following GitHub users
         do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the
-        CLA here.](https://community.getchef.com)"}'
+        CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -83,7 +83,7 @@ http_interactions:
         are 1 commit author(s) whose commits are authored by a non GitHub-verified
         email address in this Pull Request. Chef will have to verify by hand that
         they have signed a Chef CLA.\n\nThe following GitHub users do not appear to
-        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}'
+        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Mon, 14 Apr 2014 15:35:10 GMT
 - request:
@@ -96,13 +96,13 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         Non-GitHub Verified Committers\\n\\n\n\nThere are 1 commit author(s) whose
         commits are authored by a non GitHub-verified email address. Chef will have
         to manually verify that they are authorized to contribute.\n\n## GitHub Users
         Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub users do
         not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA
-        here.](https://community.getchef.com)"}'
+        here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -174,13 +174,13 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         Non-GitHub Verified Committers\\n\\n\n\nThere are 1 commit author(s) whose
         commits are authored by a non GitHub-verified email address. Chef will have
         to manually verify that they are authorized to contribute.\n\n## GitHub Users
         Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub users do
         not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA
-        here.](https://community.getchef.com)"}'
+        here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Tue, 19 Aug 2014 13:36:31 GMT
 - request:
@@ -270,12 +270,12 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         Non-GitHub Verified Committers\n\nThere are 1 commit author(s) whose commits
         are authored by a non-GitHub verified email address. Chef will have to manually
         verify that they are authorized to contribute.\n\n## GitHub Users Who Are
         Not Authorized To Contribute\n\nThe following GitHub users do not appear to
-        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}'
+        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -347,12 +347,12 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         Non-GitHub Verified Committers\n\nThere are 1 commit author(s) whose commits
         are authored by a non-GitHub verified email address. Chef will have to manually
         verify that they are authorized to contribute.\n\n## GitHub Users Who Are
         Not Authorized To Contribute\n\nThe following GitHub users do not appear to
-        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}'
+        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Wed, 20 Aug 2014 12:08:23 GMT
 - request:
@@ -433,12 +433,12 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         Non-GitHub Verified Committers\n\nThere are 1 commit author(s) whose commits
         are authored by a non-GitHub verified email address. Chef will have to manually
         verify that they are authorized to contribute.\n\n## GitHub Users Who Are
         Not Authorized To Contribute\n\nThe following GitHub users do not appear to
-        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}]'
+        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}]'
     http_version: 
   recorded_at: Wed, 20 Aug 2014 12:08:23 GMT
 recorded_with: VCR 2.9.2

--- a/spec/vcr_cassettes/pull_request_annotation_leaves_two_success_comments.yml
+++ b/spec/vcr_cassettes/pull_request_annotation_leaves_two_success_comments.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: '{"body":"Hi. Your friendly Curry bot here. Just letting you know that
         there are commit authors in this Pull Request who appear to not have signed
         a Chef CLA.\n\nThe following GitHub users do not appear to have signed a CLA:\n\n*
-        @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}'
+        @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -78,7 +78,7 @@ http_interactions:
         Your friendly Curry bot here. Just letting you know that there are commit
         authors in this Pull Request who appear to not have signed a Chef CLA.\n\nThe
         following GitHub users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please
-        sign the CLA here.](https://community.getchef.com)"}'
+        sign the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Tue, 29 Jul 2014 15:14:34 GMT
 - request:
@@ -89,7 +89,7 @@ http_interactions:
       string: '{"body":"Hi. Your friendly Curry bot here. Just letting you know that
         there are commit authors in this Pull Request who appear to not have signed
         a Chef CLA.\n\nThe following GitHub users do not appear to have signed a CLA:\n\n*
-        @bcobb\n\n[Please sign the CLA here.](https://community.getchef.com)"}'
+        @bcobb\n\n[Please sign the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -159,7 +159,7 @@ http_interactions:
         Your friendly Curry bot here. Just letting you know that there are commit
         authors in this Pull Request who appear to not have signed a Chef CLA.\n\nThe
         following GitHub users do not appear to have signed a CLA:\n\n* @bcobb\n\n[Please
-        sign the CLA here.](https://community.getchef.com)"}'
+        sign the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Tue, 29 Jul 2014 15:14:35 GMT
 - request:
@@ -172,10 +172,10 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -247,10 +247,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Tue, 19 Aug 2014 13:36:34 GMT
 - request:
@@ -263,10 +263,10 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @bcobb\n\n[Please sign the
-        CLA here.](https://community.getchef.com)"}'
+        CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -338,10 +338,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @bcobb\n\n[Please sign the
-        CLA here.](https://community.getchef.com)"}'
+        CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Tue, 19 Aug 2014 13:36:35 GMT
 - request:
@@ -431,10 +431,10 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -506,10 +506,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Wed, 20 Aug 2014 12:08:31 GMT
 - request:
@@ -830,10 +830,10 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @bcobb\n\n[Please sign the
-        CLA here.](https://community.getchef.com)"}'
+        CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -905,10 +905,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @bcobb\n\n[Please sign the
-        CLA here.](https://community.getchef.com)"}'
+        CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Wed, 20 Aug 2014 12:08:32 GMT
 - request:
@@ -1144,10 +1144,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"},{"url":"https://api.github.com/repos/gofullstack/paprika/issues/comments/52766438","html_url":"https://github.com/gofullstack/paprika/pull/1#issuecomment-52766438","issue_url":"https://api.github.com/repos/gofullstack/paprika/issues/1","id":52766438,"user":{"login":"brettchalupa","id":928367,"avatar_url":"https://avatars.githubusercontent.com/u/928367?v=2","gravatar_id":"c3e5586f55a9551a91d1e8b26fcc9310","url":"https://api.github.com/users/brettchalupa","html_url":"https://github.com/brettchalupa","followers_url":"https://api.github.com/users/brettchalupa/followers","following_url":"https://api.github.com/users/brettchalupa/following{/other_user}","gists_url":"https://api.github.com/users/brettchalupa/gists{/gist_id}","starred_url":"https://api.github.com/users/brettchalupa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/brettchalupa/subscriptions","organizations_url":"https://api.github.com/users/brettchalupa/orgs","repos_url":"https://api.github.com/users/brettchalupa/repos","events_url":"https://api.github.com/users/brettchalupa/events{/privacy}","received_events_url":"https://api.github.com/users/brettchalupa/received_events","type":"User","site_admin":false},"created_at":"2014-08-20T12:08:31Z","updated_at":"2014-08-20T12:08:31Z","body":"Hi.
+        the CLA here.](https://community.chef.io)"},{"url":"https://api.github.com/repos/gofullstack/paprika/issues/comments/52766438","html_url":"https://github.com/gofullstack/paprika/pull/1#issuecomment-52766438","issue_url":"https://api.github.com/repos/gofullstack/paprika/issues/1","id":52766438,"user":{"login":"brettchalupa","id":928367,"avatar_url":"https://avatars.githubusercontent.com/u/928367?v=2","gravatar_id":"c3e5586f55a9551a91d1e8b26fcc9310","url":"https://api.github.com/users/brettchalupa","html_url":"https://github.com/brettchalupa","followers_url":"https://api.github.com/users/brettchalupa/followers","following_url":"https://api.github.com/users/brettchalupa/following{/other_user}","gists_url":"https://api.github.com/users/brettchalupa/gists{/gist_id}","starred_url":"https://api.github.com/users/brettchalupa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/brettchalupa/subscriptions","organizations_url":"https://api.github.com/users/brettchalupa/orgs","repos_url":"https://api.github.com/users/brettchalupa/repos","events_url":"https://api.github.com/users/brettchalupa/events{/privacy}","received_events_url":"https://api.github.com/users/brettchalupa/received_events","type":"User","site_admin":false},"created_at":"2014-08-20T12:08:31Z","updated_at":"2014-08-20T12:08:31Z","body":"Hi.
         Your friendly Curry bot here. Just letting you know that all commit authors
         have become authorized to contribute. I have added the \"Signed CLA\" label
         to this issue so it can easily be found in the future."},{"url":"https://api.github.com/repos/gofullstack/paprika/issues/comments/52766440","html_url":"https://github.com/gofullstack/paprika/pull/1#issuecomment-52766440","issue_url":"https://api.github.com/repos/gofullstack/paprika/issues/1","id":52766440,"user":{"login":"brettchalupa","id":928367,"avatar_url":"https://avatars.githubusercontent.com/u/928367?v=2","gravatar_id":"c3e5586f55a9551a91d1e8b26fcc9310","url":"https://api.github.com/users/brettchalupa","html_url":"https://github.com/brettchalupa","followers_url":"https://api.github.com/users/brettchalupa/followers","following_url":"https://api.github.com/users/brettchalupa/following{/other_user}","gists_url":"https://api.github.com/users/brettchalupa/gists{/gist_id}","starred_url":"https://api.github.com/users/brettchalupa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/brettchalupa/subscriptions","organizations_url":"https://api.github.com/users/brettchalupa/orgs","repos_url":"https://api.github.com/users/brettchalupa/repos","events_url":"https://api.github.com/users/brettchalupa/events{/privacy}","received_events_url":"https://api.github.com/users/brettchalupa/received_events","type":"User","site_admin":false},"created_at":"2014-08-20T12:08:32Z","updated_at":"2014-08-20T12:08:32Z","body":"Hi.
@@ -1156,10 +1156,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @bcobb\n\n[Please sign the
-        CLA here.](https://community.getchef.com)"},{"url":"https://api.github.com/repos/gofullstack/paprika/issues/comments/52766441","html_url":"https://github.com/gofullstack/paprika/pull/1#issuecomment-52766441","issue_url":"https://api.github.com/repos/gofullstack/paprika/issues/1","id":52766441,"user":{"login":"brettchalupa","id":928367,"avatar_url":"https://avatars.githubusercontent.com/u/928367?v=2","gravatar_id":"c3e5586f55a9551a91d1e8b26fcc9310","url":"https://api.github.com/users/brettchalupa","html_url":"https://github.com/brettchalupa","followers_url":"https://api.github.com/users/brettchalupa/followers","following_url":"https://api.github.com/users/brettchalupa/following{/other_user}","gists_url":"https://api.github.com/users/brettchalupa/gists{/gist_id}","starred_url":"https://api.github.com/users/brettchalupa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/brettchalupa/subscriptions","organizations_url":"https://api.github.com/users/brettchalupa/orgs","repos_url":"https://api.github.com/users/brettchalupa/repos","events_url":"https://api.github.com/users/brettchalupa/events{/privacy}","received_events_url":"https://api.github.com/users/brettchalupa/received_events","type":"User","site_admin":false},"created_at":"2014-08-20T12:08:32Z","updated_at":"2014-08-20T12:08:32Z","body":"Hi.
+        CLA here.](https://community.chef.io)"},{"url":"https://api.github.com/repos/gofullstack/paprika/issues/comments/52766441","html_url":"https://github.com/gofullstack/paprika/pull/1#issuecomment-52766441","issue_url":"https://api.github.com/repos/gofullstack/paprika/issues/1","id":52766441,"user":{"login":"brettchalupa","id":928367,"avatar_url":"https://avatars.githubusercontent.com/u/928367?v=2","gravatar_id":"c3e5586f55a9551a91d1e8b26fcc9310","url":"https://api.github.com/users/brettchalupa","html_url":"https://github.com/brettchalupa","followers_url":"https://api.github.com/users/brettchalupa/followers","following_url":"https://api.github.com/users/brettchalupa/following{/other_user}","gists_url":"https://api.github.com/users/brettchalupa/gists{/gist_id}","starred_url":"https://api.github.com/users/brettchalupa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/brettchalupa/subscriptions","organizations_url":"https://api.github.com/users/brettchalupa/orgs","repos_url":"https://api.github.com/users/brettchalupa/repos","events_url":"https://api.github.com/users/brettchalupa/events{/privacy}","received_events_url":"https://api.github.com/users/brettchalupa/received_events","type":"User","site_admin":false},"created_at":"2014-08-20T12:08:32Z","updated_at":"2014-08-20T12:08:32Z","body":"Hi.
         Your friendly Curry bot here. Just letting you know that all commit authors
         have become authorized to contribute. I have added the \"Signed CLA\" label
         to this issue so it can easily be found in the future."}]'

--- a/spec/vcr_cassettes/pull_request_annotation_no_double_comment.yml
+++ b/spec/vcr_cassettes/pull_request_annotation_no_double_comment.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: '{"body":"Hi. Your friendly Curry bot here. Just letting you know that
         there are commit authors in this Pull Request who appear to not have signed
         a Chef CLA.\n\nThe following GitHub users do not appear to have signed a CLA:\n\n*
-        @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}'
+        @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -78,7 +78,7 @@ http_interactions:
         Your friendly Curry bot here. Just letting you know that there are commit
         authors in this Pull Request who appear to not have signed a Chef CLA.\n\nThe
         following GitHub users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please
-        sign the CLA here.](https://community.getchef.com)"}'
+        sign the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Tue, 29 Jul 2014 14:58:16 GMT
 - request:
@@ -91,10 +91,10 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -166,10 +166,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Tue, 19 Aug 2014 13:36:40 GMT
 - request:
@@ -259,10 +259,10 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -334,10 +334,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Wed, 20 Aug 2014 12:08:24 GMT
 - request:
@@ -649,10 +649,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"},{"url":"https://api.github.com/repos/gofullstack/paprika/issues/comments/52766425","html_url":"https://github.com/gofullstack/paprika/pull/1#issuecomment-52766425","issue_url":"https://api.github.com/repos/gofullstack/paprika/issues/1","id":52766425,"user":{"login":"brettchalupa","id":928367,"avatar_url":"https://avatars.githubusercontent.com/u/928367?v=2","gravatar_id":"c3e5586f55a9551a91d1e8b26fcc9310","url":"https://api.github.com/users/brettchalupa","html_url":"https://github.com/brettchalupa","followers_url":"https://api.github.com/users/brettchalupa/followers","following_url":"https://api.github.com/users/brettchalupa/following{/other_user}","gists_url":"https://api.github.com/users/brettchalupa/gists{/gist_id}","starred_url":"https://api.github.com/users/brettchalupa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/brettchalupa/subscriptions","organizations_url":"https://api.github.com/users/brettchalupa/orgs","repos_url":"https://api.github.com/users/brettchalupa/repos","events_url":"https://api.github.com/users/brettchalupa/events{/privacy}","received_events_url":"https://api.github.com/users/brettchalupa/received_events","type":"User","site_admin":false},"created_at":"2014-08-20T12:08:25Z","updated_at":"2014-08-20T12:08:25Z","body":"Hi.
+        the CLA here.](https://community.chef.io)"},{"url":"https://api.github.com/repos/gofullstack/paprika/issues/comments/52766425","html_url":"https://github.com/gofullstack/paprika/pull/1#issuecomment-52766425","issue_url":"https://api.github.com/repos/gofullstack/paprika/issues/1","id":52766425,"user":{"login":"brettchalupa","id":928367,"avatar_url":"https://avatars.githubusercontent.com/u/928367?v=2","gravatar_id":"c3e5586f55a9551a91d1e8b26fcc9310","url":"https://api.github.com/users/brettchalupa","html_url":"https://github.com/brettchalupa","followers_url":"https://api.github.com/users/brettchalupa/followers","following_url":"https://api.github.com/users/brettchalupa/following{/other_user}","gists_url":"https://api.github.com/users/brettchalupa/gists{/gist_id}","starred_url":"https://api.github.com/users/brettchalupa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/brettchalupa/subscriptions","organizations_url":"https://api.github.com/users/brettchalupa/orgs","repos_url":"https://api.github.com/users/brettchalupa/repos","events_url":"https://api.github.com/users/brettchalupa/events{/privacy}","received_events_url":"https://api.github.com/users/brettchalupa/received_events","type":"User","site_admin":false},"created_at":"2014-08-20T12:08:25Z","updated_at":"2014-08-20T12:08:25Z","body":"Hi.
         Your friendly Curry bot here. Just letting you know that all commit authors
         have become authorized to contribute. I have added the \"Signed CLA\" label
         to this issue so it can easily be found in the future."}]'

--- a/spec/vcr_cassettes/pull_request_annotation_removes_label.yml
+++ b/spec/vcr_cassettes/pull_request_annotation_removes_label.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: '{"body":"Hi. Your friendly Curry bot here. Just letting you know that
         there are commit authors in this Pull Request who appear to not have signed
         a Chef CLA.\n\nThe following GitHub users do not appear to have signed a CLA:\n\n*
-        @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}'
+        @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -78,7 +78,7 @@ http_interactions:
         Your friendly Curry bot here. Just letting you know that there are commit
         authors in this Pull Request who appear to not have signed a Chef CLA.\n\nThe
         following GitHub users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please
-        sign the CLA here.](https://community.getchef.com)"}'
+        sign the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Mon, 14 Apr 2014 15:35:08 GMT
 - request:
@@ -91,10 +91,10 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -166,10 +166,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Tue, 19 Aug 2014 13:36:25 GMT
 - request:
@@ -411,10 +411,10 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -486,10 +486,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Wed, 20 Aug 2014 12:08:15 GMT
 - request:

--- a/spec/vcr_cassettes/pull_request_annotation_updates_comment.yml
+++ b/spec/vcr_cassettes/pull_request_annotation_updates_comment.yml
@@ -11,7 +11,7 @@ http_interactions:
         a non GitHub-verified email address in this Pull Request. Chef will have to
         verify by hand that they have signed a Chef CLA.\n\nThe following GitHub users
         do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the
-        CLA here.](https://community.getchef.com)"}'
+        CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -83,7 +83,7 @@ http_interactions:
         are 1 commit author(s) whose commits are authored by a non GitHub-verified
         email address in this Pull Request. Chef will have to verify by hand that
         they have signed a Chef CLA.\n\nThe following GitHub users do not appear to
-        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}'
+        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Thu, 24 Jul 2014 20:13:42 GMT
 - request:
@@ -96,13 +96,13 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         Non-GitHub Verified Committers\\n\\n\n\nThere are 1 commit author(s) whose
         commits are authored by a non GitHub-verified email address. Chef will have
         to manually verify that they are authorized to contribute.\n\n## GitHub Users
         Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub users do
         not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA
-        here.](https://community.getchef.com)"}'
+        here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -174,13 +174,13 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         Non-GitHub Verified Committers\\n\\n\n\nThere are 1 commit author(s) whose
         commits are authored by a non GitHub-verified email address. Chef will have
         to manually verify that they are authorized to contribute.\n\n## GitHub Users
         Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub users do
         not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA
-        here.](https://community.getchef.com)"}'
+        here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Tue, 19 Aug 2014 13:36:29 GMT
 - request:
@@ -261,12 +261,12 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         Non-GitHub Verified Committers\n\nThere are 1 commit author(s) whose commits
         are authored by a non-GitHub verified email address. Chef will have to manually
         verify that they are authorized to contribute.\n\n## GitHub Users Who Are
         Not Authorized To Contribute\n\nThe following GitHub users do not appear to
-        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}]'
+        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}]'
     http_version: 
   recorded_at: Wed, 20 Aug 2014 12:08:18 GMT
 - request:
@@ -356,12 +356,12 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         Non-GitHub Verified Committers\n\nThere are 1 commit author(s) whose commits
         are authored by a non-GitHub verified email address. Chef will have to manually
         verify that they are authorized to contribute.\n\n## GitHub Users Who Are
         Not Authorized To Contribute\n\nThe following GitHub users do not appear to
-        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}'
+        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -433,12 +433,12 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         Non-GitHub Verified Committers\n\nThere are 1 commit author(s) whose commits
         are authored by a non-GitHub verified email address. Chef will have to manually
         verify that they are authorized to contribute.\n\n## GitHub Users Who Are
         Not Authorized To Contribute\n\nThe following GitHub users do not appear to
-        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}'
+        have signed a CLA:\n\n* @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Wed, 20 Aug 2014 12:08:21 GMT
 - request:

--- a/spec/vcr_cassettes/pull_request_annotation_when_authors_become_authorized.yml
+++ b/spec/vcr_cassettes/pull_request_annotation_when_authors_become_authorized.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: '{"body":"Hi. Your friendly Curry bot here. Just letting you know that
         there are commit authors in this Pull Request who appear to not have signed
         a Chef CLA.\n\nThe following GitHub users do not appear to have signed a CLA:\n\n*
-        @brettchalupa\n\n[Please sign the CLA here.](https://community.getchef.com)"}'
+        @brettchalupa\n\n[Please sign the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -78,7 +78,7 @@ http_interactions:
         Your friendly Curry bot here. Just letting you know that there are commit
         authors in this Pull Request who appear to not have signed a Chef CLA.\n\nThe
         following GitHub users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please
-        sign the CLA here.](https://community.getchef.com)"}'
+        sign the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Mon, 28 Jul 2014 19:47:32 GMT
 - request:
@@ -91,10 +91,10 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -166,10 +166,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\\n\\n\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Tue, 19 Aug 2014 13:36:38 GMT
 - request:
@@ -261,10 +261,10 @@ http_interactions:
         to Chef Software, Inc. projects or are using a non-GitHub verified email address.
         To become authorized to contribute, you will need to sign the Contributor
         License Agreement (CLA) as an individual or on behalf of your company. [You
-        can read more on Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        can read more on Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     headers:
       Accept:
       - application/vnd.github.v3+json
@@ -336,10 +336,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"}'
+        the CLA here.](https://community.chef.io)"}'
     http_version: 
   recorded_at: Wed, 20 Aug 2014 12:08:36 GMT
 - request:
@@ -575,10 +575,10 @@ http_interactions:
         Inc. projects or are using a non-GitHub verified email address. To become
         authorized to contribute, you will need to sign the Contributor License Agreement
         (CLA) as an individual or on behalf of your company. [You can read more on
-        Chef''s blog.](http://www.getchef.com/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
+        Chef''s blog.](http://www.chef.io/blog/2014/06/23/changes-to-the-contributor-license-agreement-process/)\n\n##
         GitHub Users Who Are Not Authorized To Contribute\n\nThe following GitHub
         users do not appear to have signed a CLA:\n\n* @brettchalupa\n\n[Please sign
-        the CLA here.](https://community.getchef.com)"},{"url":"https://api.github.com/repos/gofullstack/paprika/issues/comments/52766446","html_url":"https://github.com/gofullstack/paprika/pull/1#issuecomment-52766446","issue_url":"https://api.github.com/repos/gofullstack/paprika/issues/1","id":52766446,"user":{"login":"brettchalupa","id":928367,"avatar_url":"https://avatars.githubusercontent.com/u/928367?v=2","gravatar_id":"c3e5586f55a9551a91d1e8b26fcc9310","url":"https://api.github.com/users/brettchalupa","html_url":"https://github.com/brettchalupa","followers_url":"https://api.github.com/users/brettchalupa/followers","following_url":"https://api.github.com/users/brettchalupa/following{/other_user}","gists_url":"https://api.github.com/users/brettchalupa/gists{/gist_id}","starred_url":"https://api.github.com/users/brettchalupa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/brettchalupa/subscriptions","organizations_url":"https://api.github.com/users/brettchalupa/orgs","repos_url":"https://api.github.com/users/brettchalupa/repos","events_url":"https://api.github.com/users/brettchalupa/events{/privacy}","received_events_url":"https://api.github.com/users/brettchalupa/received_events","type":"User","site_admin":false},"created_at":"2014-08-20T12:08:36Z","updated_at":"2014-08-20T12:08:36Z","body":"Hi.
+        the CLA here.](https://community.chef.io)"},{"url":"https://api.github.com/repos/gofullstack/paprika/issues/comments/52766446","html_url":"https://github.com/gofullstack/paprika/pull/1#issuecomment-52766446","issue_url":"https://api.github.com/repos/gofullstack/paprika/issues/1","id":52766446,"user":{"login":"brettchalupa","id":928367,"avatar_url":"https://avatars.githubusercontent.com/u/928367?v=2","gravatar_id":"c3e5586f55a9551a91d1e8b26fcc9310","url":"https://api.github.com/users/brettchalupa","html_url":"https://github.com/brettchalupa","followers_url":"https://api.github.com/users/brettchalupa/followers","following_url":"https://api.github.com/users/brettchalupa/following{/other_user}","gists_url":"https://api.github.com/users/brettchalupa/gists{/gist_id}","starred_url":"https://api.github.com/users/brettchalupa/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/brettchalupa/subscriptions","organizations_url":"https://api.github.com/users/brettchalupa/orgs","repos_url":"https://api.github.com/users/brettchalupa/repos","events_url":"https://api.github.com/users/brettchalupa/events{/privacy}","received_events_url":"https://api.github.com/users/brettchalupa/received_events","type":"User","site_admin":false},"created_at":"2014-08-20T12:08:36Z","updated_at":"2014-08-20T12:08:36Z","body":"Hi.
         Your friendly Curry bot here. Just letting you know that all commit authors
         have become authorized to contribute. I have added the \"Signed CLA\" label
         to this issue so it can easily be found in the future."}]'


### PR DESCRIPTION
:convenience_store: 

This is mostly ready to go.  The one glaring omission here is the VCR cassettes, but I think we need to wait until chef.io is live, and then re-run those specs.  The eminent @bcobb gave me a good idea of what needs to happen there.  That will likely happen in a subsequent PR to this one, unless someone else has a better idea.

I don't think we want to merge this until we're ready for the domain to be live.

Closes https://github.com/opscode/supermarket/issues/918
