### PR TITLE
Fix mixlib-shellout-1.6.0 yank 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     mixlib-cli (1.5.0)
     mixlib-config (2.1.0)
     mixlib-log (1.6.0)
-    mixlib-shellout (1.6.0)
+    mixlib-shellout (1.6.1)
     multi_json (1.10.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)


### PR DESCRIPTION
Without this fix we are blocked on deploying a private supermarket.
