### PR TITLE
Fix a Get Chef link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
             <% end %>
           </ul>
           <ul class="off-canvas-list">
-            <li><%= link_to 'Get Chef', root_url, target: '_blank' %></li>
+            <li><%= link_to 'Get Chef', chef_www_url, target: '_blank' %></li>
             <li><%= link_to 'Learn Chef', learn_chef_url, target: '_blank' %></li>
             <li><%= link_to 'Docs', chef_docs_url, target: '_blank' %></li>
             <li><%= link_to 'Training', "#{chef_domain}/training", target: '_blank' %></li>


### PR DESCRIPTION
This changes the Get Chef link in the hamburger menu to point to the Chef home page.
