### PR TITLE
Make verification more secure

### DIFF
--- a/app/controllers/curry/pull_request_updates_controller.rb
+++ b/app/controllers/curry/pull_request_updates_controller.rb
@@ -71,7 +71,7 @@ class Curry::PullRequestUpdatesController < ApplicationController
   # verified
   #
   def verify_github_signature
-    if github_signature != expected_signature
+    unless Rack::Utils.secure_compare(github_signature, expected_signature)
       head 400
     end
   end


### PR DESCRIPTION
:convenience_store: 

While reading GH documentation on webhooks, I came across [this page](https://developer.github.com/webhooks/securing) which mentions that when you validate a payload from GH, you should not use a regular equality operator like `==` or `!=`, as these are vulnerable to certain timing attacks. The recommendation is to use `Rack::Utils.secure_compare`, which can compare strings using "constant time", and isn't vulnerable to timing attacks.

[The commit](https://github.com/rack/rack/commit/9a81b961457805f6d1a5c275d053068440421e11) where `secure_compare` was added to Rack, and the commentary that accompanies it, also has some good insight into why a method like this is necessary.
