### PR TITLE
Show contributors even if GH is disabled

### DIFF
--- a/app/views/application/_appheader.html.erb
+++ b/app/views/application/_appheader.html.erb
@@ -1,7 +1,7 @@
 <nav class="appnav">
   <ul class="mainnav">
     <li><%= link_to 'Cookbooks', cookbooks_directory_path, 'data-hover' => 'Cookbooks', :rel => 'cookbooks' %></li>
-    <% if ROLLOUT.active?(:cla) && ROLLOUT.active?(:github) %>
+    <% if ROLLOUT.active?(:cla) %>
       <li><%= link_to 'Contributors', contributors_path, 'data-hover' => 'Contributors', :rel => 'contributors' %></li>
     <% end %>
     <% if ROLLOUT.active?(:tools) %>

--- a/app/views/application/_contributors_list_heading.html.erb
+++ b/app/views/application/_contributors_list_heading.html.erb
@@ -1,8 +1,10 @@
 <div class="heading-with-buttons">
   <h1 class="title">Contributors</h1>
-  <div class="buttons">
-    <%= link_to "Become a Contributor", become_a_contributor_path, class: "button tiny radius right" %>
-  </div>
+    <% if ROLLOUT.active?(:cla) && ROLLOUT.active?(:github) %>
+      <div class="buttons">
+        <%= link_to "Become a Contributor", become_a_contributor_path, class: "button tiny radius right" %>
+      </div>
+    <% end %>
 </div>
 
 <dl class="tabs">

--- a/app/views/contributors/_sidebar.html.erb
+++ b/app/views/contributors/_sidebar.html.erb
@@ -7,7 +7,7 @@
     <% end %>
   </ul>
 
-  <% if current_user %>
+  <% if current_user && ROLLOUT.active?(:github) %>
     <h3>Your Agreements</h3>
 
     <% unless current_user.contributor? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,7 +149,7 @@ Supermarket::Application.routes.draw do
   end
 
   get 'become-a-contributor' => 'contributors#become_a_contributor', constraints: proc { ROLLOUT.active?(:cla) && ROLLOUT.active?(:github) }
-  get 'contributors' => 'contributors#index', constraints: proc { ROLLOUT.active?(:cla) && ROLLOUT.active?(:github) }
+  get 'contributors' => 'contributors#index', constraints: proc { ROLLOUT.active?(:cla) }
 
   get 'chat' => 'irc_logs#index'
   get 'chat/:channel' => 'irc_logs#show'


### PR DESCRIPTION
:convenience_store: 

This shows the top "Contributors" link even when GH is disabled, so you can look at the existing contributors.  I also hid the "Your Agreements" section on that page, because it is full of links that take you to pages for becoming a contributor and signing a CLA.

![](https://dl.dropboxusercontent.com/s/9yqsqim3nz1km0s/2014-12-16%20at%204.18%20PM.png?dl=0)

Closes https://github.com/opscode/supermarket/issues/909
