### PR TITLE
fix error with empty collections in atom feeds

### DIFF
--- a/app/helpers/cookbook_versions_helper.rb
+++ b/app/helpers/cookbook_versions_helper.rb
@@ -2,6 +2,23 @@ module CookbookVersionsHelper
   include MarkdownHelper
 
   #
+  # Encapsulates the logic required to return an updated_at timestamp for an
+  # Atom feed, while handling possibly empty collections
+  #
+  # @param collection [Array<Object>] some collection to be checked
+  #
+  # @return [ActiveSupport::TimeWithZone] the most recent updated_at, or right
+  # now
+  #
+  def safe_updated_at(collection)
+    if collection.present?
+      collection.max_by(&:updated_at).updated_at
+    else
+      Time.zone.now
+    end
+  end
+
+  #
   # Returns an abbreviated Changelog or a description if no Changelog is
   # available for the given CookbookVersion, suitable for showing in an Atom
   # feed.

--- a/app/views/cookbooks/index.atom.builder
+++ b/app/views/cookbooks/index.atom.builder
@@ -1,6 +1,6 @@
 atom_feed language: 'en-US' do |feed|
   feed.title 'Cookbooks'
-  feed.updated @cookbooks.max_by(&:updated_at).updated_at
+  feed.updated safe_updated_at(@cookbooks)
 
   @cookbooks.each do |cookbook|
     feed.entry cookbook, url: cookbook_url(cookbook) do |entry|

--- a/app/views/users/followed_cookbook_activity.atom.builder
+++ b/app/views/users/followed_cookbook_activity.atom.builder
@@ -1,6 +1,6 @@
 atom_feed language: 'en-US' do |feed|
   feed.title "#{@user.username}'s Followed Cookbook Activity"
-  feed.updated @followed_cookbook_activity.max_by(&:updated_at).updated_at
+  feed.updated safe_updated_at(@followed_cookbook_activity)
 
   @followed_cookbook_activity.each do |cookbook_version|
     feed.entry cookbook_version, url: cookbook_version_url(cookbook_version.cookbook, cookbook_version.version) do |entry|

--- a/spec/helpers/cookbook_versions_helper_spec.rb
+++ b/spec/helpers/cookbook_versions_helper_spec.rb
@@ -10,4 +10,18 @@ describe CookbookVersionsHelper do
       expect(render_document('_hi_', '')).to eql('_hi_')
     end
   end
+
+  describe '#safe_updated_at' do
+    it 'works if the collection has stuff in it' do
+      expect(helper.safe_updated_at([create(:cookbook)])).to be <= Time.zone.now
+    end
+
+    it 'works if the collection is empty' do
+      expect(helper.safe_updated_at([])).to be <= Time.zone.now
+    end
+
+    it 'works if the collection is nil' do
+      expect(helper.safe_updated_at(nil)).to be <= Time.zone.now
+    end
+  end
 end

--- a/spec/views/cookbooks/index.atom.builder_spec.rb
+++ b/spec/views/cookbooks/index.atom.builder_spec.rb
@@ -31,31 +31,46 @@ describe 'cookbooks/index.atom.builder' do
     )
   end
 
-  before do
-    assign(:cookbooks, [test_cookbook, test_cookbook2])
-    render
+  describe 'some cookbooks' do
+    before do
+      assign(:cookbooks, [test_cookbook, test_cookbook2])
+      render
+    end
+
+    it 'displays the feed title' do
+      expect(xml_body['feed']['title']).to eql('Cookbooks')
+    end
+
+    it 'displays when the feed was updated' do
+      expect(Date.parse(xml_body['feed']['updated'])).to_not be_nil
+    end
+
+    it 'displays cookbook entries' do
+      expect(xml_body['feed']['entry'].count).to eql(2)
+    end
+
+    it 'displays information about a cookbook' do
+      cookbook = xml_body['feed']['entry'].first
+
+      expect(cookbook['title']).to eql('test')
+      expect(cookbook['author']['name']).to eql(test_cookbook.owner.username)
+      expect(cookbook['author']['uri']).to eql(user_url(test_cookbook.owner))
+      expect(cookbook['content']).to match(/this cookbook is so rad/)
+      expect(cookbook['content']).to match(/we added so much stuff/)
+      expect(cookbook['link']['href']).to eql('http://test.host/cookbooks/test')
+    end
   end
 
-  it 'displays the feed title' do
-    expect(xml_body['feed']['title']).to eql('Cookbooks')
-  end
+  describe 'no cookbooks' do
+    before do
+      assign(:cookbooks, [])
+      render
+    end
 
-  it 'displays when the feed was updated' do
-    expect(Date.parse(xml_body['feed']['updated'])).to_not be_nil
-  end
-
-  it 'displays cookbook entries' do
-    expect(xml_body['feed']['entry'].count).to eql(2)
-  end
-
-  it 'displays information about a cookbook' do
-    cookbook = xml_body['feed']['entry'].first
-
-    expect(cookbook['title']).to eql('test')
-    expect(cookbook['author']['name']).to eql(test_cookbook.owner.username)
-    expect(cookbook['author']['uri']).to eql(user_url(test_cookbook.owner))
-    expect(cookbook['content']).to match(/this cookbook is so rad/)
-    expect(cookbook['content']).to match(/we added so much stuff/)
-    expect(cookbook['link']['href']).to eql('http://test.host/cookbooks/test')
+    it 'still works if @cookbooks is empty' do
+      expect do
+        expect(Date.parse(xml_body['feed']['updated'])).to_not be_nil
+      end.to_not raise_error
+    end
   end
 end

--- a/spec/views/users/followed_cookbook_activity.atom.builder_spec.rb
+++ b/spec/views/users/followed_cookbook_activity.atom.builder_spec.rb
@@ -31,37 +31,53 @@ describe 'users/followed_cookbook_activity.atom.builder' do
     )
   end
 
-  before do
-    assign(
-      :followed_cookbook_activity,
-      [test_cookbook.cookbook_versions.first, test_cookbook2.cookbook_versions.first]
-    )
+  before { assign(:user, double(User, username: 'johndoe')) }
 
-    assign(:user, double(User, username: 'johndoe'))
-    render
+  describe 'some activity' do
+    before do
+      assign(
+        :followed_cookbook_activity,
+        [test_cookbook.cookbook_versions.first, test_cookbook2.cookbook_versions.first]
+      )
+
+      render
+    end
+
+    it 'displays the feed title' do
+      expect(xml_body['feed']['title']).to eql("johndoe's Followed Cookbook Activity")
+    end
+
+    it 'displays when the feed was updated' do
+      expect(Date.parse(xml_body['feed']['updated'])).to_not be_nil
+    end
+
+    it 'displays followed cookbook activity entries' do
+      expect(xml_body['feed']['entry'].count).to eql(2)
+    end
+
+    it 'displays information about cookbook activity' do
+      activity = xml_body['feed']['entry'].first
+
+      expect(activity['title']).to match(/#{test_cookbook.name}/)
+      expect(activity['content']).to match(/this cookbook is so rad/)
+      expect(activity['content']).to match(/we added so much stuff/)
+      expect(activity['author']['name']).to eql(test_cookbook.maintainer)
+      expect(activity['author']['uri']).to eql(user_url(test_cookbook.owner))
+      expect(activity['link']['href']).
+        to eql(cookbook_version_url(test_cookbook, test_cookbook.cookbook_versions.first.version))
+    end
   end
 
-  it 'displays the feed title' do
-    expect(xml_body['feed']['title']).to eql("johndoe's Followed Cookbook Activity")
-  end
+  describe 'no activity' do
+    before do
+      assign(:followed_cookbook_activity, [])
+      render
+    end
 
-  it 'displays when the feed was updated' do
-    expect(Date.parse(xml_body['feed']['updated'])).to_not be_nil
-  end
-
-  it 'displays followed cookbook activity entries' do
-    expect(xml_body['feed']['entry'].count).to eql(2)
-  end
-
-  it 'displays information about cookbook activity' do
-    activity = xml_body['feed']['entry'].first
-
-    expect(activity['title']).to match(/#{test_cookbook.name}/)
-    expect(activity['content']).to match(/this cookbook is so rad/)
-    expect(activity['content']).to match(/we added so much stuff/)
-    expect(activity['author']['name']).to eql(test_cookbook.maintainer)
-    expect(activity['author']['uri']).to eql(user_url(test_cookbook.owner))
-    expect(activity['link']['href']).
-      to eql(cookbook_version_url(test_cookbook, test_cookbook.cookbook_versions.first.version))
+    it 'still works if @followed_cookbook_activity is empty' do
+      expect do
+        expect(Date.parse(xml_body['feed']['updated'])).to_not be_nil
+      end.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
:convenience_store: 

This fixes a production error that appeared in Sentry.
