### PR TITLE
Clarify text in the link to Curry's repositories

### DIFF
--- a/app/views/application/_appheader.html.erb
+++ b/app/views/application/_appheader.html.erb
@@ -30,7 +30,7 @@
 
         <% if current_user && current_user.is?(:admin) && ROLLOUT.active?(:cla) && ROLLOUT.active?(:github) %>
           <li>
-            <%= link_to "Watched Repositories", curry_repositories_url, :class => 'fa fa-github', rel: 'manage_repositories' %>
+            <%= link_to "Configure Curry", curry_repositories_url, :class => 'fa fa-github', rel: 'manage_repositories' %>
           </li>
         <% end %>
 


### PR DESCRIPTION
:fork_and_knife: 

Here's my stab at addressing @juliandunn's comment in #975. Notably, it transitions from a noun-y link to a verb-y link, like the others in the menu.