### PR TITLE
adding in links to Chef corporate legalese in common footer

### DIFF
--- a/app/assets/stylesheets/appfooter.scss
+++ b/app/assets/stylesheets/appfooter.scss
@@ -1,0 +1,5 @@
+@import "foundation/components/grid";
+
+.footerlink {
+  margin-right: rem-calc(25);
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,6 +11,7 @@
 *
 *= require typography
 *= require appheader
+*= require appfooter
 *= require announcement_banner
 *= require_tree ./cookbooks
 *= require_tree ./profile

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -65,7 +65,10 @@
         </div>
         <footer class="footer">
           &copy; 2008&thinsp;&ndash;&thinsp;<%= Time.new.year %> Chef Software, Inc. All Rights Reserved.
-          <br><br><%= link_to 'Code of Conduct', chef_docs_url('community_guidelines.html') %>
+          <br><br><%= link_to 'Code of Conduct', chef_docs_url('community_guidelines.html'), :class => 'footerlink' %>
+          <%= link_to 'Terms and Conditions of Use', chef_www_url('terms-of-service'), :class => 'footerlink' %>
+          <%= link_to 'Privacy Policy', chef_www_url('privacy-policy'), :class => 'footerlink' %>
+          <%= link_to 'Trademark Policy', chef_www_url('trademark-policy'), :class=> 'footerlink' %>
         </footer>
 
         <a class="exit-off-canvas"></a>


### PR DESCRIPTION
Fixes #972 

How it used to look:

![screen shot 2015-04-08 at 1 50 14 pm](https://cloud.githubusercontent.com/assets/813007/7055157/471a4f12-ddf6-11e4-8108-18bd189e375a.png)

How it will look: 
![screen shot 2015-04-08 at 1 50 28 pm](https://cloud.githubusercontent.com/assets/813007/7055166/5039ff7a-ddf6-11e4-9a87-7a88b641a402.png)


