### PR TITLE
Add some platforms and dependencies to seed.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -215,10 +215,9 @@ if Rails.env.development?
   # Default cookbooks for use in development.
   #
   platforms = {
-    'app' => ['windows', 'ubuntu'],
-    'apt' => ['debian', 'ubuntu'],
-    'postgres' => ['fedora', 'debian', 'suse', 'amazon', 'centos', 'redhat', 'scientific', 'oracle','ubuntu'],
-    'clojure' => ['redhat']
+    'app' => %w(windows, ubuntu),
+    'apt' => %w(debian, ubuntu),
+    'postgres' => %w(fedora, debian, suse, amazon, centos, redhat, scientific, oracle, ubuntu)
   }
 
   %w(apt redis postgres node ruby haskell clojure java mysql apache2 nginx yum app).each do |name|
@@ -247,6 +246,15 @@ if Rails.env.development?
       platforms[name].each do |platform|
         cookbook_version.add_supported_platform(platform, '>=0.0')
       end
+    end
+
+    unless name == 'apt'
+      dependency = CookbookDependency.where(
+        name: 'apt',
+        cookbook: Cookbook.find_by(name: 'apt'),
+        cookbook_version: cookbook_version
+      ).first_or_create!
+      cookbook_version.cookbook_dependencies << dependency
     end
 
     cookbook.cookbook_versions << cookbook_version
@@ -278,7 +286,7 @@ if Rails.env.development?
       type: 'ohai_plugin',
       description: 'Great ohai plugin.',
       source_url: 'http://example.com',
-      instructions: "Install the plugin in /etc/chef/ohai_plugins.",
+      instructions: 'Install the plugin in /etc/chef/ohai_plugins.',
       owner: user
     )
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -214,7 +214,14 @@ if Rails.env.development?
   #
   # Default cookbooks for use in development.
   #
-  %w(redis postgres node ruby haskell clojure java mysql apache2 nginx yum apt).each do |name|
+  platforms = {
+    'app' => ['windows', 'ubuntu'],
+    'apt' => ['debian', 'ubuntu'],
+    'postgres' => ['fedora', 'debian', 'suse', 'amazon', 'centos', 'redhat', 'scientific', 'oracle','ubuntu'],
+    'clojure' => ['redhat']
+  }
+
+  %w(apt redis postgres node ruby haskell clojure java mysql apache2 nginx yum app).each do |name|
     cookbook = Cookbook.where(
       name: name
     ).first_or_initialize(
@@ -235,6 +242,12 @@ if Rails.env.development?
       readme: File.read('README.md'),
       readme_extension: 'md'
     )
+
+    if platforms.key?(name)
+      platforms[name].each do |platform|
+        cookbook_version.add_supported_platform(platform, '>=0.0')
+      end
+    end
 
     cookbook.cookbook_versions << cookbook_version
     cookbook.save!


### PR DESCRIPTION
I've been working with cookbook search based on supported platforms. To experiment with it I
added some platforms and dependencies to seed.rb. I thought that it might be useful in
general to have those in development env database so I open this PR for discussion. 

This PR adds some platforms to 3 cookbooks and makes all default cookbooks depend on apt.

@nellshamrell - I didn't open issue about this since I already had this start to offer.

