### PR TITLE
Remove commas from platform names in seed.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -215,9 +215,9 @@ if Rails.env.development?
   # Default cookbooks for use in development.
   #
   platforms = {
-    'app' => %w(windows, ubuntu),
-    'apt' => %w(debian, ubuntu),
-    'postgres' => %w(fedora, debian, suse, amazon, centos, redhat, scientific, oracle, ubuntu)
+    'app' => %w(windows ubuntu),
+    'apt' => %w(debian ubuntu),
+    'postgres' => %w(fedora debian suse amazon centos redhat scientific oracle ubuntu)
   }
 
   %w(apt redis postgres node ruby haskell clojure java mysql apache2 nginx yum app).each do |name|


### PR DESCRIPTION
I forgot commas to platform names in seed.rb. We probably don't want them there. Sorry about that :smile: 