### PR TITLE
Updating Announcements Banner

### DIFF
--- a/app/views/application/_announcement_banner.html.erb
+++ b/app/views/application/_announcement_banner.html.erb
@@ -1,19 +1,28 @@
 <div class="announcement_banner">
   <div class="announcement_banner_header">
-    <h3>Supermarket is Now Open. Here is what you should know.</h3>
+    <h3>New Supermarket Announcements!</h3>
   </div>
 
   <div class="announcement_banner_content">
     <div class="announcement_info">
-      <h3>We&#8217;re Hiring</h3>
-
-      <p>As we continue to support the efforts of the amazing Chefs in the community, we plan to hire additional engineers to help continue the progress we have already made. These engineers will work closely with the community and help shape the direction of Supermarket. If you want to come work with amazing coworkers and a vibrant community, please take a look at our job postings for a <%= link_to 'Software Development Engineer', chef_www_url('careers/om5bZfwl') %> and a <%= link_to 'User Experience Engineer', chef_www_url('careers/o2abZfw6') %>.</p>
+      <h3>The Chef Community Cookbooks Survey</h3>
+      <p>
+        We would love to know more about what you think about community cookbooks and are runnning a quick survey.  This will help us understand the role they play in your use of Chef. As a community member, you are invited to participate. You have a unique understanding of the role community cookbooks have in your work, and we value your opinion. Most people take about 5 minutes to complete this survey. There are no right or wrong answers; we are interested in your opinions.
+        <br />
+        <a href="https://www.surveymonkey.com/s/M9Y9YYN">Chef Community Cookbooks Survey</a>
+      </p>
     </div>
+
     <div class="announcement_info">
-      <h3>Giveaways and Prizes</h3>
+      <h3>Adoptable Cookbooks List</h3>
 
-      <p>What would grand opening be without a giveaway? In keeping with the supermarket theme, we are giving away a t-shirt to everyone that completes the <a href="http://evocalize.com/consumer/rs/chef/supermarket">survey</a> about Supermarket by 2014&#8211;08&#8211;08 23:59:59 UTC. But why stop there? We will be randomly selecting two of the people who complete the survey to each win free registration to the <%= link_to 'Chef Community Summit, October 2nd and 3rd, 2014.', chef_blog_url('event/chef-community-summit') %></p>
+      <p>
+        Looking for a cookbook to adopt?  You can now see a list of cookbooks available for adoption!
+        <br />
+        <%= link_to 'List of Adoptable Cookbooks', available_for_adoption_path %>
+      </p>
     </div>
+
     <div class="announcement_info">
       <h3>Supermarket Belongs to the Community</h3>
 


### PR DESCRIPTION
The Announcement banner is currently not active on public Supermarket.  After this is deployed, it needs to be activated through rails console.  

ROLLOUT.enable(:announcement)  (I think, will verify) needs to be run from console.