### PR TITLE
Remove the Ruby 2.1.3 pin from the Gemfile, because we're already pinning it in omnibus-supermarket

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org'
 
-# TODO: is value needs to be updated as local dev changes, and removed when
-# local dev doesn't need to specify it anymore
-ruby ENV['CUSTOM_RUBY_VERSION'] || '2.1.3'
+# Ruby version isn't specified here anymore, as it's pinned in Omnibus
+# https://github.com/chef/omnibus-supermarket/blob/master/config/projects/supermarket.rb
 
 gem 'rails', '~> 4.1.5'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,5 @@
 source 'https://rubygems.org'
 
-# Override the Bundler :github shortcut to use HTTPS instead of the git protocol
-# Note: Version 2.x of Bundler should do this by default
-git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
-  "https://github.com/#{repo_name}.git"
-end
-
 gem 'rails', '~> 4.1.5'
 
 gem 'omniauth'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-ruby '2.1.3'
 
 # Override the Bundler :github shortcut to use HTTPS instead of the git protocol
 # Note: Version 2.x of Bundler should do this by default

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'https://rubygems.org'
 
+# TODO: is value needs to be updated as local dev changes, and removed when
+# local dev doesn't need to specify it anymore
+ruby ENV['CUSTOM_RUBY_VERSION'] || '2.1.3'
+
 gem 'rails', '~> 4.1.5'
 
 gem 'omniauth'
@@ -14,7 +18,7 @@ gem 'foreman'
 gem 'pundit'
 gem 'dotenv'
 gem 'coveralls', require: false
-gem 'octokit', github: 'octokit/octokit.rb', require: false
+gem 'octokit', git: 'https://github.com/octokit/octokit.rb.git', require: false
 gem 'sidekiq'
 
 # Pin sprockets to ensure we get the latest security patches. Not pinning this
@@ -24,7 +28,7 @@ gem 'sprockets', '~> 2.11.3'
 
 # Use the version on GitHub because the version published on RubyGems has
 # compatibility problems with Sidekiq 3.0.
-gem 'sidetiq', github: 'tobiassvn/sidetiq', ref: '4f7d7da'
+gem 'sidetiq', git: 'https://github.com/tobiassvn/sidetiq.git', ref: '4f7d7da'
 
 gem 'premailer-rails', group: [:development, :production]
 gem 'nokogiri'
@@ -77,7 +81,7 @@ group :test do
   # constraint error this pins shoulda-matchers at a commit where setting
   # default values for scopes was reverted
   gem 'shoulda-matchers',
-      github: 'thoughtbot/shoulda-matchers',
+      git: 'https://github.com/thoughtbot/shoulda-matchers.git',
       ref: '380d18f0621c66a79445ebc6dcc0048fcc969911'
 
   gem 'database_cleaner'


### PR DESCRIPTION
Also update `:github` lines in the Gemfile to use https instead.