### PR TITLE
Make search-bar as wide as the whole page when using xlarge screen

### DIFF
--- a/app/assets/stylesheets/cookbooks/search.scss
+++ b/app/assets/stylesheets/cookbooks/search.scss
@@ -9,7 +9,14 @@
 .search_form {
   @include grid-row();
   position: relative;
-  max-width: $max-width;
+  max-width: 100%;
+}
+
+.search_bar{
+  @include grid-row();
+  position: relative;
+  max-width: 100%;
+  background-color: $primary_blue;
 }
 
 .quick_search {
@@ -218,11 +225,13 @@ input[type="search"].cookbook_search_textfield {
 }
 
 .advanced_search_body {
-  @include grid-column($columns: 12, $collapse: true);
+  @include grid-row();
   @include border-radius(rem-calc(3));
   background-color: white;
   border-bottom: rem-calc(2) solid lighten($secondary_gray, 30%);
   display: none;
+  max-width: $max-width;
+  padding: rem-calc(0 55);
 
   h4 {
     color: black;
@@ -232,10 +241,28 @@ input[type="search"].cookbook_search_textfield {
   }
 }
 
+@media #{$mobile-only} {
+  .advanced_search_body {
+    padding: rem-calc(0 20);
+  }
+}
+
+@media #{$small-only} {
+  .advanced_search_body {
+    padding: rem-calc(0 20);
+  }
+}
+
+@media #{$xlarge-up} {
+  .advanced_search_body {
+    padding: rem-calc(0 40);
+  }
+}
+
 .advanced_search_platforms {
   @include grid-column($columns: 12, $collapse: true);
-  padding-left: rem-calc(80);
-  padding-right: rem-calc(50);
+  padding-left: rem-calc(70);
+  padding-right: rem-calc(20);
 }
 
 .advanced_search_platform {
@@ -252,7 +279,7 @@ input[type="search"].cookbook_search_textfield {
   input {
     margin:0;
     margin-right: rem-calc(5);
-    margin-left: rem-calc(25);
+    margin-left: rem-calc(10);
     padding: 0;
     position: relative;
     top: rem-calc(-2);

--- a/app/views/application/_search.html.erb
+++ b/app/views/application/_search.html.erb
@@ -1,50 +1,50 @@
-<div class="search_bar">
-    <%= form_tag @search[:path], class: 'search_form', method: :get do %>
-      <div class="quick_search">
-        <div class="search_toggle">
-          <a class="button expand large" data-dropdown="search-types" rel="toggle-search-types"><span><%= @search[:name] %></span> <i class="fa fa-chevron-down"></i></a>
+<%= form_tag @search[:path], class: 'search_form', method: :get do %>
+  <div class="search_bar">
+    <div class="quick_search">
+      <div class="search_toggle">
+        <a class="button expand large" data-dropdown="search-types" rel="toggle-search-types"><span><%= @search[:name] %></span> <i class="fa fa-chevron-down"></i></a>
 
-          <ul id="search-types" data-dropdown-content class="f-dropdown">
-            <li><a href="#" data-url=<%= cookbooks_path %> rel="toggle-cookbook-search">Cookbooks</a></li>
-            <li><a href="#" data-url=<%= tools_path %> rel="toggle-tool-search">Tools</a></li>
-          </ul>
-        </div>
-
-        <div class="search_field">
-          <i class="fa fa-search"></i>
-          <%= search_field_tag :q, params[:q], placeholder: 'Search', class: 'cookbook_search_textfield' %>
-        </div>
-
-        <%= hidden_field_tag :order, params[:order] if params[:order].present? %>
-
-        <div class="search_button">
-          <%= button_tag(type: 'submit', class: 'cookbook_search_button', name: nil) do %>
-            GO
-          <% end %>
-        </div>
-
-        <div class="advanced_search_toggle">
-          <span>Advanced Options <i class="fa fa-chevron-down" id="toggle-arrow"></i><span>
-        </div>
+        <ul id="search-types" data-dropdown-content class="f-dropdown">
+          <li><a href="#" data-url=<%= cookbooks_path %> rel="toggle-cookbook-search">Cookbooks</a></li>
+          <li><a href="#" data-url=<%= tools_path %> rel="toggle-tool-search">Tools</a></li>
+        </ul>
       </div>
 
-      <div class="advanced_search_body">
-        <h4> Select Supported Platforms </h4>
-        <div class = "advanced_search_platforms" >
-
-          <% %w(aix amazon centos debian fedora freebsd gentoo mac_os_x omnios openbsd oracle redhat ubuntu scientific smartos solaris suse windows).each do |platform| %>
-            <div class="advanced_search_platform">
-                <label>
-                  <%=check_box_tag 'platforms[]', platform, params[:platforms] ? params[:platforms].include?(platform) : false %>
-                  <%= platform %>
-                </label>
-            </div>
-          <% end %>
-        </div>
-
-        <div class= "advanced_textfield">
-          <%= search_field_tag 'platforms[]', nil, placeholder: "You can write platform name here if it's not on the list", class: 'platform_search_textfield' %>
-        </div>
+      <div class="search_field">
+        <i class="fa fa-search"></i>
+        <%= search_field_tag :q, params[:q], placeholder: 'Search', class: 'cookbook_search_textfield' %>
       </div>
-  <% end %>
-</div>
+
+      <%= hidden_field_tag :order, params[:order] if params[:order].present? %>
+
+      <div class="search_button">
+        <%= button_tag(type: 'submit', class: 'cookbook_search_button', name: nil) do %>
+          GO
+        <% end %>
+      </div>
+
+      <div class="advanced_search_toggle">
+        <span>Advanced Options <i class="fa fa-chevron-down" id="toggle-arrow"></i><span>
+      </div>
+    </div>
+  </div>
+
+  <div class="advanced_search_body">
+    <h4> Select Supported Platforms </h4>
+    <div class = "advanced_search_platforms" >
+
+      <% %w(aix amazon centos debian fedora freebsd gentoo mac_os_x omnios openbsd oracle redhat ubuntu scientific smartos solaris suse windows).each do |platform| %>
+        <div class="advanced_search_platform">
+            <label>
+              <%=check_box_tag 'platforms[]', platform, params[:platforms] ? params[:platforms].include?(platform) : false %>
+              <%= platform %>
+            </label>
+        </div>
+      <% end %>
+    </div>
+
+    <div class= "advanced_textfield">
+      <%= search_field_tag 'platforms[]', nil, placeholder: "You can write platform name here if it's not on the list", class: 'platform_search_textfield' %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
I noticed that my last PR #1028 had an unintentional side effect. When you use supermarket on a large screen it fails to keep search-bar as wide as the whole page. So here is a fix for that.