### PR TITLE
stop rendering autodependencies

### DIFF
--- a/app/models/universe.rb
+++ b/app/models/universe.rb
@@ -39,6 +39,7 @@ module Universe
       FROM cookbook_versions
         INNER JOIN cookbooks ON cookbooks.id = cookbook_versions.cookbook_id
         LEFT JOIN cookbook_dependencies ON cookbook_dependencies.cookbook_version_id = cookbook_versions.id
+          AND cookbook_dependencies.name != cookbooks.name
     )
 
     cookbooks = ActiveRecord::Base.connection.execute(sql).to_a

--- a/spec/api/universe_spec.rb
+++ b/spec/api/universe_spec.rb
@@ -40,6 +40,8 @@ describe 'GET /universe' do
     create(:cookbook_dependency, cookbook_version: redis_version1, cookbook: apt, name: 'apt', version_constraint: '>= 1.0.0')
     create(:cookbook_dependency, cookbook_version: redis_version1, cookbook: narf, name: 'narf', version_constraint: '>= 1.1.0')
     create(:cookbook_dependency, cookbook_version: redis_version2, cookbook: apt, name: 'apt', version_constraint: '>= 1.0.0')
+    # this creates a self-dependency from redis to redis which must be stripped before returning
+    create(:cookbook_dependency, cookbook_version: redis_version2, cookbook: redis, name: 'redis', version_constraint: '>= 1.0.0')
   end
 
   it 'returns a 200' do


### PR DESCRIPTION
cookbook autodependencies are bad to feed into depsolvers.  cookbooks
all automatically are dependencies of themselves, but some people still
do:

name 'foo'
depends 'foo'

what this can actually do is create depsolver loops where all the
versions of a cookbook create dependency loops which satsify this
constraint and make the depsolver work much harder than it should.

this patch just stops supermarket from publishing this information out
and starts to stop the pain.

additionally, there should be a migration added to clean these up and
there should be filtering on the input side.  knife and the chef server
also need to clean them up as well on the client and server side.

at the same time, though, we need to not completely break old cookbooks,
so we'll probably be stuck with maintaining cookbooks that have
auto dependencies in metadata.rb for some time, but we can gradually
make the tools all start ignoring those deps.