### PR TITLE
add zebra striping to adoption list

### DIFF
--- a/app/assets/stylesheets/simple_listing.scss
+++ b/app/assets/stylesheets/simple_listing.scss
@@ -14,6 +14,10 @@
     display: none;
   }
 
+  li:nth-child(odd) {
+    background-color: $secondary_gray;
+  }
+
   li {
     @include dark-links;
     border-bottom: rem-calc(2) solid lighten($secondary_gray, 32%);

--- a/app/assets/stylesheets/simple_listing.scss
+++ b/app/assets/stylesheets/simple_listing.scss
@@ -14,7 +14,7 @@
     display: none;
   }
 
-  li:nth-child(odd) {
+  &.zebra li:nth-child(odd) {
     background-color: $secondary_gray;
   }
 

--- a/app/views/cookbooks/available_for_adoption.html.erb
+++ b/app/views/cookbooks/available_for_adoption.html.erb
@@ -12,7 +12,7 @@
     </h1>
   </div>
 
-  <ul class="simple_listing">
+  <ul class="simple_listing zebra">
     <% @available_cookbooks.each do |cookbook| %>
       <%= render "simple_cookbook", cookbook: cookbook %>
     <% end %>

--- a/app/views/cookbooks/available_for_adoption.html.erb
+++ b/app/views/cookbooks/available_for_adoption.html.erb
@@ -14,7 +14,7 @@
 
   <ul class="simple_listing">
     <% @available_cookbooks.each do |cookbook| %>
-      <li><%= render "simple_cookbook", cookbook: cookbook %></li>
+      <%= render "simple_cookbook", cookbook: cookbook %>
     <% end %>
   </ul>
 </div>


### PR DESCRIPTION
- Use CSS3 built-in method for selecting list pattern children
- Remove one level of `li` nesting

> As a Supermarket Viewer
When viewing the [Adoption Cookbooks page](https://supermarket.chef.io/available_for_adoption)
Then I want to be able to visually differentiate quickly between lines.

I tried to achieve this in two methods. This PR and another here: https://github.com/chef/supermarket/compare/chef:master...miketheman:scss_simple_listing

I think this method is the "cleaner" one, as it cleans up one level of LI nesting, and uses a [built-in selector](http://www.w3schools.com/cssref/sel_nth-child.asp) instead of using Rails logic to tag items when rendering.

The end result of both methods is the same, appears like so:
![screen shot 2015-05-10 at 10 07 00 am](https://cloud.githubusercontent.com/assets/529516/7554790/e3e21fde-f703-11e4-8509-612d6e26fe13.png)

I wasn't certain which coloring to use, so I chose one that seemed reasonably viewable.