### PR TITLE
Make user admin task

### DIFF
--- a/app/services/make_user_admin.rb
+++ b/app/services/make_user_admin.rb
@@ -7,10 +7,30 @@ class MakeUserAdmin
 
   def call
     begin
-      User.find(@user)
+      user = User.find(@user)
+      add_admin_role(user)
     rescue ActiveRecord::RecordNotFound
-      "User not found in Supermarket.  Make sure the user exists in Supermarket before making it an admin."
+      user_not_found_message
     end
+  end
+
+  private
+
+  def user_not_found_message
+    "User not found in Supermarket.  Make sure the user exists in Supermarket before making it an admin."
+  end
+
+  def successful_promotion_message(user)
+    "#{user.username} has been promoted to Admin!"
+  end
+
+  def unsuccessful_promotion_message(user)
+    "#{user.username} was not able to be promoted to Admin at this time.  Please try again later."
+  end
+
+  def add_admin_role(user)
+    user.roles.push('admin')
+    user.save ? successful_promotion_message(user) : unsuccessful_promotion_message(user)
   end
 
 end

--- a/app/services/make_user_admin.rb
+++ b/app/services/make_user_admin.rb
@@ -1,17 +1,11 @@
 class MakeUserAdmin
-  attr_accessor :user
-
-  def initialize(user)
-    @user = user
+  def initialize(user_name)
+    @user_name = user_name
   end
 
   def call
-    begin
-      user = User.find(@user)
-      add_admin_role(user)
-    rescue ActiveRecord::RecordNotFound
-      user_not_found_message
-    end
+    user = User.with_username(@user_name).first
+    user.present? ? add_admin_role(user) : user_not_found_message
   end
 
   private
@@ -29,7 +23,7 @@ class MakeUserAdmin
   end
 
   def add_admin_role(user)
-    user.roles.push('admin')
+    user.roles = user.roles + ["admin"]
     user.save ? successful_promotion_message(user) : unsuccessful_promotion_message(user)
   end
 

--- a/app/services/make_user_admin.rb
+++ b/app/services/make_user_admin.rb
@@ -11,7 +11,7 @@ class MakeUserAdmin
   private
 
   def user_not_found_message
-    "User not found in Supermarket.  Make sure the user exists in Supermarket before making it an admin."
+    'User not found in Supermarket.  Make sure the user exists in Supermarket before making it an admin.'
   end
 
   def successful_promotion_message(user)
@@ -23,8 +23,7 @@ class MakeUserAdmin
   end
 
   def add_admin_role(user)
-    user.roles = user.roles + ["admin"]
+    user.roles = user.roles + ['admin']
     user.save ? successful_promotion_message(user) : unsuccessful_promotion_message(user)
   end
-
 end

--- a/app/services/make_user_admin.rb
+++ b/app/services/make_user_admin.rb
@@ -22,7 +22,13 @@ class MakeUserAdmin
     I18n.t('user.unsuccessful_promotion_message', name: user.username)
   end
 
+  def user_already_admin_message(user)
+    I18n.t('user.already_admin', name: user.username)
+  end
+
   def add_admin_role(user)
+    return user_already_admin_message(user) if user.roles.include?('admin')
+
     user.roles = user.roles + ['admin']
     user.save ? successful_promotion_message(user) : unsuccessful_promotion_message(user)
   end

--- a/app/services/make_user_admin.rb
+++ b/app/services/make_user_admin.rb
@@ -1,0 +1,13 @@
+class MakeUserAdmin
+  attr_accessor :user
+
+  def initialize(user)
+    @user = find_user(user)
+  end
+
+  private
+
+  def find_user(user)
+    User.find(user)
+  end
+end

--- a/app/services/make_user_admin.rb
+++ b/app/services/make_user_admin.rb
@@ -2,12 +2,15 @@ class MakeUserAdmin
   attr_accessor :user
 
   def initialize(user)
-    @user = find_user(user)
+    @user = user
   end
 
-  private
-
-  def find_user(user)
-    User.find(user)
+  def call
+    begin
+      User.find(@user)
+    rescue ActiveRecord::RecordNotFound
+      "User not found in Supermarket.  Make sure the user exists in Supermarket before making it an admin."
+    end
   end
+
 end

--- a/app/services/make_user_admin.rb
+++ b/app/services/make_user_admin.rb
@@ -5,21 +5,21 @@ class MakeUserAdmin
 
   def call
     user = User.with_username(@user_name).first
-    user.present? ? add_admin_role(user) : user_not_found_message
+    user.present? ? add_admin_role(user) : user_not_found_message(@user_name)
   end
 
   private
 
-  def user_not_found_message
-    'User not found in Supermarket.  Make sure the user exists in Supermarket before making it an admin.'
+  def user_not_found_message(user_name)
+    I18n.t('user.not_found', name: user_name)
   end
 
   def successful_promotion_message(user)
-    "#{user.username} has been promoted to Admin!"
+    I18n.t('user.successful_promotion_message', name: user.username)
   end
 
   def unsuccessful_promotion_message(user)
-    "#{user.username} was not able to be promoted to Admin at this time.  Please try again later."
+    I18n.t('user.unsuccessful_promotion_message', name: user.username)
   end
 
   def add_admin_role(user)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
     made_admin: "%{name} is now an admin."
     revoked_admin: "%{name} is no longer an admin."
     not_found: "%{name} was not found in Supermarket.  Make sure the user exists in Supermarket before making it an admin."
+    already_admin: "%{name} is already an admin."
     successful_promotion_message: "%{name} has been made an admin!"
     unsuccessful_promotion_message: "%{name} was not able to be promoted to an admin at this time.  Please try again later."
   account:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,9 @@ en:
     must_be_signed_in: "You must be signed in to do that."
     made_admin: "%{name} is now an admin."
     revoked_admin: "%{name} is no longer an admin."
+    not_found: "%{name} was not found in Supermarket.  Make sure the user exists in Supermarket before making it an admin."
+    successful_promotion_message: "%{name} has been made an admin!"
+    unsuccessful_promotion_message: "%{name} was not able to be promoted to an admin at this time.  Please try again later."
   account:
     already_connected: "The %{provider} account (%{username}) you are trying to link is already linked to another Supermarket user."
     disconnected: "Account disconnected."

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,8 +1,8 @@
 namespace :user do
 
   # Usage: rake user:make_admin user="#{username of user to be made an admin}"
-  desc "Take a username, find the user, and make that user an admin"
-  task :make_admin => :environment do
+  desc 'Take a username, find the user, and make that user an admin'
+  task make_admin: :environment do
     make_admin_user = MakeUserAdmin.new(ENV['user']).call
     puts make_admin_user
   end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,0 +1,9 @@
+namespace :user do
+
+  # Usage: rake user:make_admin user="#{username of user to be made an admin}"
+  desc "Take a username, find the user, and make that user an admin"
+  task :make_admin => :environment do
+    make_admin_user = MakeUserAdmin.new(ENV['user']).call
+    puts make_admin_user
+  end
+end

--- a/spec/services/make_user_admin_spec.rb
+++ b/spec/services/make_user_admin_spec.rb
@@ -55,6 +55,18 @@ describe MakeUserAdmin do
         expect(make_user_admin.call).to include("#{user.username} was not able to be promoted to an admin at this time.  Please try again later.")
       end
     end
-  end
 
+    context 'when the user is already an admin' do
+      before do
+        user.roles = user.roles + ['admin']
+        user.save!
+        expect(user.roles).to include('admin')
+      end
+
+      it 'returns a message' do
+        make_user_admin = MakeUserAdmin.new(user.username)
+        expect(make_user_admin.call).to include("#{user.username} is already an admin.")
+      end
+    end
+  end
 end

--- a/spec/services/make_user_admin_spec.rb
+++ b/spec/services/make_user_admin_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe MakeUserAdmin do
+
+  context "finding the user" do
+    let(:user) { create(:user) }
+
+    it "searches for the user" do
+      expect(User).to receive(:find).and_return(user)
+      MakeUserAdmin.new(user)
+    end
+
+    context "when it exists" do
+      let(:make_user_admin) { MakeUserAdmin.new(user) }
+
+      before do
+        allow(User).to receive(:find).and_return(user)
+      end
+
+      it "assigns the correct user" do
+        expect(make_user_admin.user).to eq(user)
+      end
+    end
+
+    context "when it does not exist" do
+      it "returns an error"
+    end
+  end
+
+  context "promoting the user to admin" do
+    context "when successful" do
+      it "adds the admin role"
+
+      it "saves the user"
+    end
+
+    context "when not successful" do
+      it "returns an error"
+    end
+  end
+
+end

--- a/spec/services/make_user_admin_spec.rb
+++ b/spec/services/make_user_admin_spec.rb
@@ -1,24 +1,13 @@
 require 'spec_helper'
 
 describe MakeUserAdmin do
+  let(:user) { create(:user) }
+  let(:make_user_admin) { MakeUserAdmin.new(user) }
 
   context "finding the user" do
-    let(:user) { create(:user) }
-    let(:make_user_admin) { MakeUserAdmin.new(user) }
-
     it "searches for the user" do
       expect(User).to receive(:find).and_return(user)
       make_user_admin.call
-    end
-
-    context "when it exists" do
-      let(:make_user_admin) { MakeUserAdmin.new(user) }
-
-      before do
-        allow(User).to receive(:find).and_return(user)
-      end
-
-      it "assigns the correct user"
     end
 
     context "when it does not exist" do
@@ -33,14 +22,38 @@ describe MakeUserAdmin do
   end
 
   context "promoting the user to admin" do
-    context "when successful" do
-      it "adds the admin role"
+    let(:roles) { user.roles }
 
-      it "saves the user"
+    before do
+      allow(User).to receive(:find).and_return(user)
+      allow(user).to receive(:roles).and_return(roles)
+    end
+
+    context "when successful" do
+      it "adds the admin role" do
+        expect(user.roles).to receive(:push).with('admin')
+        make_user_admin.call
+      end
+
+      it "saves the user" do
+        expect(user).to receive(:save)
+        make_user_admin.call
+      end
+
+      it "returns a success message" do
+        expect(make_user_admin.call).to include("#{user.username} has been promoted to Admin!")
+      end
     end
 
     context "when not successful" do
-      it "returns an error"
+      before do
+        allow(User).to receive(:find).and_return(user)
+        allow(user).to receive(:save).and_return(false)
+      end
+
+      it "returns an error" do
+        expect(make_user_admin.call).to include("#{user.username} was not able to be promoted to Admin at this time.  Please try again later.")
+      end
     end
   end
 

--- a/spec/services/make_user_admin_spec.rb
+++ b/spec/services/make_user_admin_spec.rb
@@ -4,10 +4,11 @@ describe MakeUserAdmin do
 
   context "finding the user" do
     let(:user) { create(:user) }
+    let(:make_user_admin) { MakeUserAdmin.new(user) }
 
     it "searches for the user" do
       expect(User).to receive(:find).and_return(user)
-      MakeUserAdmin.new(user)
+      make_user_admin.call
     end
 
     context "when it exists" do
@@ -17,13 +18,17 @@ describe MakeUserAdmin do
         allow(User).to receive(:find).and_return(user)
       end
 
-      it "assigns the correct user" do
-        expect(make_user_admin.user).to eq(user)
-      end
+      it "assigns the correct user"
     end
 
     context "when it does not exist" do
-      it "returns an error"
+      before do
+        allow(User).to receive(:find).and_raise(ActiveRecord::RecordNotFound)
+      end
+
+      it "returns an error" do
+        expect(make_user_admin.call).to include("User not found in Supermarket")
+      end
     end
   end
 

--- a/spec/services/make_user_admin_spec.rb
+++ b/spec/services/make_user_admin_spec.rb
@@ -16,7 +16,7 @@ describe MakeUserAdmin do
       end
 
       it 'returns an error' do
-        expect(make_user_admin.call).to include('User not found in Supermarket')
+        expect(make_user_admin.call).to include("#{user.username} was not found in Supermarket")
       end
     end
   end
@@ -33,7 +33,7 @@ describe MakeUserAdmin do
       end
 
       it 'returns a success message' do
-        expect(make_user_admin.call).to include("#{user.username} has been promoted to Admin!")
+        expect(make_user_admin.call).to include("#{user.username} has been made an admin!")
       end
 
       it 'adds the admin role to the user' do
@@ -52,7 +52,7 @@ describe MakeUserAdmin do
       end
 
       it 'returns an error' do
-        expect(make_user_admin.call).to include("#{user.username} was not able to be promoted to Admin at this time.  Please try again later.")
+        expect(make_user_admin.call).to include("#{user.username} was not able to be promoted to an admin at this time.  Please try again later.")
       end
     end
   end

--- a/spec/services/make_user_admin_spec.rb
+++ b/spec/services/make_user_admin_spec.rb
@@ -4,54 +4,54 @@ describe MakeUserAdmin do
   let(:user) { create(:user) }
   let(:make_user_admin) { MakeUserAdmin.new(user.username) }
 
-  context "finding the user" do
-    it "searches for the user by the username" do
+  context 'finding the user' do
+    it 'searches for the user by the username' do
       expect(User).to receive(:with_username).with(user.username).and_return([user])
       make_user_admin.call
     end
 
-    context "when it does not exist" do
+    context 'when it does not exist' do
       before do
         allow(User).to receive(:with_username).and_return([])
       end
 
-      it "returns an error" do
-        expect(make_user_admin.call).to include("User not found in Supermarket")
+      it 'returns an error' do
+        expect(make_user_admin.call).to include('User not found in Supermarket')
       end
     end
   end
 
-  context "promoting the user to admin" do
+  context 'promoting the user to admin' do
     before do
       allow(User).to receive(:with_username).and_return([user])
     end
 
-    context "when successful" do
-      it "saves the user" do
+    context 'when successful' do
+      it 'saves the user' do
         expect(user).to receive(:save)
         make_user_admin.call
       end
 
-      it "returns a success message" do
+      it 'returns a success message' do
         expect(make_user_admin.call).to include("#{user.username} has been promoted to Admin!")
       end
 
-      it "adds the admin role to the user" do
-        expect(user.roles).to_not include("admin")
+      it 'adds the admin role to the user' do
+        expect(user.roles).to_not include('admin')
         make_user_admin = MakeUserAdmin.new(user.username)
         make_user_admin.call
         user.reload
-        expect(user.roles).to include("admin")
+        expect(user.roles).to include('admin')
       end
     end
 
-    context "when not successful" do
+    context 'when not successful' do
       before do
         allow(User).to receive(:find).and_return(user)
         allow(user).to receive(:save).and_return(false)
       end
 
-      it "returns an error" do
+      it 'returns an error' do
         expect(make_user_admin.call).to include("#{user.username} was not able to be promoted to Admin at this time.  Please try again later.")
       end
     end


### PR DESCRIPTION
This adds a rake task users can use to promote an existing user to Admin.

This is intended to be called by a supermarket-ctl command, which I will add to the [omnibus-supermarket](https://github.com/chef/omnibus-supermarket) repo.

I will update this when the pull request to supermarket-ctl is also ready to go.  Once that is added, this should be good to merge.