### PR TITLE
remove gitter reference from announcement banner

### DIFF
--- a/app/views/application/_announcement_banner.html.erb
+++ b/app/views/application/_announcement_banner.html.erb
@@ -26,7 +26,7 @@
     <div class="announcement_info">
       <h3>Supermarket Belongs to the Community</h3>
 
-      <p>Supermarket belongs to the community. While Chef has the responsibility to keep it running and be stewards of its functionality, what it does and how it works is driven by the community. The <a href="https://github.com/chef/supermarket">chef/supermarket</a> repository will continue to be where development of the Supermarket application takes place. Come be part of shaping the direction of Supermarket by opening issues and pull requests or by joining us on the <a href="https://groups.google.com/forum/#!forum/chef-supermarket">supermarket mailing list</a> or in <a href="https://gitter.im/chef/supermarket">Gitter</a>.</p>
+      <p>Supermarket belongs to the community. While Chef has the responsibility to keep it running and be stewards of its functionality, what it does and how it works is driven by the community. The <a href="https://github.com/chef/supermarket">chef/supermarket</a> repository will continue to be where development of the Supermarket application takes place. Come be part of shaping the direction of Supermarket by opening issues and pull requests or by joining us on the <a href="https://groups.google.com/forum/#!forum/chef-supermarket">supermarket mailing list</a>.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The gitter channel was decom'd back in May.  Removing the reference to it from the current announcement banner.