### PR TITLE
add ability of admins to add collaborators

### DIFF
--- a/app/authorizers/cookbook_authorizer.rb
+++ b/app/authorizers/cookbook_authorizer.rb
@@ -26,7 +26,7 @@ class CookbookAuthorizer < Authorizer::Base
   # @return [Boolean]
   #
   def create_collaborator?
-    owner?
+    owner_or_admin?
   end
 
   #

--- a/spec/authorizers/cookbook_authorizer_spec.rb
+++ b/spec/authorizers/cookbook_authorizer_spec.rb
@@ -65,7 +65,7 @@ describe CookbookAuthorizer do
     it { should permit_authorization(:manage) }
     it { should_not permit_authorization(:create) }
     it { should_not permit_authorization(:destroy) }
-    it { should_not permit_authorization(:create_collaborator) }
+    it { should permit_authorization(:create_collaborator) }
     it { should permit_authorization(:manage_cookbook_urls) }
     it { should permit_authorization(:manage_adoption) }
   end


### PR DESCRIPTION
This means that I can add myself to chef cookbooks as an admin and
then can upload cookbooks.  Otherwise I have to pester Sean even
though I'm an "admin", although I can issue a transfer request but
that is going to be even more annoying.