### PR TITLE
Add missing protocol to links in Manage Profile

### DIFF
--- a/app/views/profile/edit.html.erb
+++ b/app/views/profile/edit.html.erb
@@ -147,8 +147,8 @@
             can reset your key here:
           </p>
           <ol>
-            <li>Login or create an account at at: <a href="www.chef.io/account/login">www.chef.io/account/login<a></li>
-            <li>Click on the "Password and Key" tab (<a href="www.chef.io/account/password">www.chef.io/account/password</a>)</li>
+            <li>Login or create an account at at: <a href="https://www.chef.io/account/login">www.chef.io/account/login<a></li>
+            <li>Click on the "Password and Key" tab (<a href="https://www.chef.io/account/password">www.chef.io/account/password</a>)</li>
             <li>Click on <emph>Get a New Key</emph>. This will reset your client
               key.</li>
             <li>Use this key to configure knife to authenticate with the public Chef


### PR DESCRIPTION
Noticed a couple of broken links while trying to configure my machine to share cookbooks to public Supermarket.