### PR TITLE
Fix signer creation in seeds

### DIFF
--- a/app/models/ccla_signature.rb
+++ b/app/models/ccla_signature.rb
@@ -32,7 +32,7 @@ class CclaSignature < ActiveRecord::Base
 
   # Callbacks
   # --------------------
-  before_create -> (record) { record.signed_at = Time.now }
+  before_create -> (record) { record.signed_at ||= Time.now }
 
   # Search
   # --------------------

--- a/app/models/icla_signature.rb
+++ b/app/models/icla_signature.rb
@@ -28,7 +28,7 @@ class IclaSignature < ActiveRecord::Base
 
   # Callbacks
   # --------------------
-  before_create -> (record) { record.signed_at = Time.now }
+  before_create -> (record) { record.signed_at ||= Time.now }
 
   def name
     "#{first_name} #{last_name}"

--- a/spec/models/ccla_signature_spec.rb
+++ b/spec/models/ccla_signature_spec.rb
@@ -40,31 +40,31 @@ describe CclaSignature do
 
   describe '.by_organization' do
     context 'when multiple organizations have signed a CCLA' do
-      let(:organization_one) { create(:organization) }
-      let(:organization_two) { create(:organization) }
-      let!(:organization_one_signature) { create(:ccla_signature, organization: organization_one, signed_at: 1.year.ago) }
-      let!(:organization_two_signature) { create(:ccla_signature, organization: organization_two, signed_at: 1.day.ago) }
+      let(:old_org) { create(:organization, ccla_signatures_count: 0) }
+      let(:recent_org) { create(:organization, ccla_signatures_count: 0) }
+      let!(:recent_org_signature) { create(:ccla_signature, organization: recent_org, signed_at: 1.day.ago) }
+      let!(:old_org_signature) { create(:ccla_signature, organization: old_org, signed_at: 1.year.ago) }
 
       it 'should return the signatures' do
         expect(CclaSignature.by_organization.count).to eql(2)
       end
 
       it 'should order the signatures ascending by signed at date' do
-        expect(CclaSignature.by_organization.first).to eql(organization_one_signature)
+        expect(CclaSignature.by_organization.first).to eql(old_org_signature)
       end
     end
 
     context 'when a organizaiton has re-signed a CCLA' do
-      let(:organization) { create(:organization) }
-      let!(:one_year_ago) { create(:ccla_signature, organization: organization, signed_at: 1.year.ago) }
-      let!(:one_day_ago) { create(:ccla_signature, organization: organization, signed_at: 1.day.ago) }
+      let(:organization) { create(:organization, ccla_signatures_count: 0) }
+      let!(:recent_signature) { create(:ccla_signature, organization: organization, signed_at: 1.month.ago) }
+      let!(:old_signature) { create(:ccla_signature, organization: organization, signed_at: 1.year.ago) }
 
       it 'should return the latest signature' do
-        expect(CclaSignature.by_organization).to include(one_day_ago)
+        expect(CclaSignature.by_organization).to include(recent_signature)
       end
 
       it 'should not return older signatures' do
-        expect(CclaSignature.by_organization).to_not include(one_year_ago)
+        expect(CclaSignature.by_organization).to_not include(old_signature)
       end
     end
   end

--- a/spec/models/icla_signature_spec.rb
+++ b/spec/models/icla_signature_spec.rb
@@ -35,8 +35,8 @@ describe IclaSignature do
     context 'when multiple users have signed an ICLA' do
       let(:user_one) { create(:user) }
       let(:user_two) { create(:user) }
-      let!(:user_one_signature) { create(:icla_signature, user: user_one, signed_at: 1.year.ago) }
       let!(:user_two_signature) { create(:icla_signature, user: user_two, signed_at: 1.day.ago) }
+      let!(:user_one_signature) { create(:icla_signature, user: user_one, signed_at: 1.year.ago) }
 
       it 'should return the signatures' do
         expect(IclaSignature.by_user.count).to eql(2)
@@ -63,8 +63,8 @@ describe IclaSignature do
 
     context 'when a user has re-signed an ICLA' do
       let(:user) { create(:user) }
-      let!(:one_year_ago) { create(:icla_signature, user: user, signed_at: 1.year.ago) }
       let!(:one_day_ago) { create(:icla_signature, user: user, signed_at: 1.day.ago) }
+      let!(:one_year_ago) { create(:icla_signature, user: user, signed_at: 1.year.ago) }
 
       it 'should return the latest signature' do
         expect(IclaSignature.by_user).to include(one_day_ago)

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -19,11 +19,11 @@ describe Organization do
 
   describe '#latest_ccla_signature' do
     it 'returns the latest ccla signature based on date signed' do
-      organization = create(:organization)
-      one_year_ago = create(:ccla_signature, signed_at: 1.year.ago, organization: organization)
-      one_month_ago = create(:ccla_signature, signed_at: 1.month.ago, organization: organization)
+      organization = create(:organization, ccla_signatures_count: 0)
+      recent_signature = create(:ccla_signature, signed_at: 1.month.ago, organization: organization)
+      old_signature = create(:ccla_signature, signed_at: 1.year.ago, organization: organization)
 
-      expect(organization.latest_ccla_signature).to eql(one_month_ago)
+      expect(organization.latest_ccla_signature).to eql(recent_signature)
     end
   end
 


### PR DESCRIPTION
Fixes #1132 

Adds a loop to seeds.rb creating a bunch of users for the existing "create signatures" logic to use.

In the process, discovered that the CCLA and ICLA tests were relying on spec let ordering for logic around `signed_at`. Reordered tests, instantiating the more recent signature first. This revealed that the `signed_at` passed in to the factory was being overwritten by the `before_create` callback in both signature classes. Updated the callback to use a set value or default to `Time.now` as before.