### PR TITLE
Change all calls to Time.now into Time.current

### DIFF
--- a/app/models/ccla_signature.rb
+++ b/app/models/ccla_signature.rb
@@ -32,7 +32,7 @@ class CclaSignature < ActiveRecord::Base
 
   # Callbacks
   # --------------------
-  before_create -> (record) { record.signed_at ||= Time.now }
+  before_create -> (record) { record.signed_at ||= Time.current }
 
   # Search
   # --------------------

--- a/app/models/cla_report.rb
+++ b/app/models/cla_report.rb
@@ -70,7 +70,7 @@ class ClaReport < ActiveRecord::Base
 
     report.csv = StringIO.new(csv_string)
     report.csv_content_type = 'text/csv'
-    report.csv_file_name = "#{Time.now.to_i}.csv"
+    report.csv_file_name = "#{Time.current.to_i}.csv"
     report.save!
 
     report

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -267,7 +267,7 @@ class Cookbook < ActiveRecord::Base
         changelog_extension: changelog.extension
       )
 
-      self.updated_at = Time.now
+      self.updated_at = Time.current
 
       [:source_url, :issues_url].each do |url|
         url_val = metadata.send(url)

--- a/app/models/icla_signature.rb
+++ b/app/models/icla_signature.rb
@@ -28,7 +28,7 @@ class IclaSignature < ActiveRecord::Base
 
   # Callbacks
   # --------------------
-  before_create -> (record) { record.signed_at ||= Time.now }
+  before_create -> (record) { record.signed_at ||= Time.current }
 
   def name
     "#{first_name} #{last_name}"

--- a/app/views/tools/index.atom.builder
+++ b/app/views/tools/index.atom.builder
@@ -1,6 +1,6 @@
 atom_feed language: 'en-US' do |feed|
   feed.title 'Tools & Plugins'
-  feed.updated Time.now
+  feed.updated Time.current
 
   @tools.each do |tool|
     feed.entry tool do |entry|

--- a/lib/supermarket/health.rb
+++ b/lib/supermarket/health.rb
@@ -56,7 +56,7 @@ module Supermarket
       postgres_health_metric do
         @supermarket[:expired_ocid_tokens] = Account.
           for('chef_oauth2').
-          where('oauth_expires < ?', Time.now).
+          where('oauth_expires < ?', Time.current).
           count
       end
     end

--- a/spec/support/api_spec_helpers.rb
+++ b/spec/support/api_spec_helpers.rb
@@ -28,7 +28,7 @@ module ApiSpecHelpers
       http_method: 'post',
       path: cookbooks_path,
       user_id: user.username,
-      timestamp: Time.now.utc.iso8601,
+      timestamp: Time.current.utc.iso8601,
       body: tarball.read
     ).sign(private_key)
 
@@ -59,7 +59,7 @@ module ApiSpecHelpers
       http_method: 'delete',
       path: cookbook_path,
       user_id: user.username,
-      timestamp: Time.now.utc.iso8601,
+      timestamp: Time.current.utc.iso8601,
       body: ''
     ).sign(private_key)
 
@@ -80,7 +80,7 @@ module ApiSpecHelpers
       http_method: 'delete',
       path: cookbook_version_path,
       user_id: user.username,
-      timestamp: Time.now.utc.iso8601,
+      timestamp: Time.current.utc.iso8601,
       body: ''
     ).sign(private_key)
 

--- a/spec/support/omni_auth_control.rb
+++ b/spec/support/omni_auth_control.rb
@@ -1,5 +1,5 @@
 module OmniAuthControl
-  EXPIRATION = Time.now.to_i
+  EXPIRATION = Time.current.to_i
 
   def self.stub_github!(user = User.new)
     OmniAuth.config.mock_auth[:github] = github_hash(user)

--- a/spec/workers/oauth_token_refresh_schedule_worker_spec.rb
+++ b/spec/workers/oauth_token_refresh_schedule_worker_spec.rb
@@ -4,7 +4,7 @@ describe OauthTokenRefreshScheduleWorker do
   context 'on the first run' do
     it 'refreshes only tokens which expire within 25 minutes from now' do
       last_run = -1 # Sidetiq uses -1 to denote the first run
-      now = Time.now
+      now = Time.current
 
       [-0.1, 0, 12.5, 25, 26.1].each do |expiry|
         create(:user).tap do |user|
@@ -25,7 +25,7 @@ describe OauthTokenRefreshScheduleWorker do
   context 'on subsequent runs' do
     it 'refreshes only tokens which expire within 25 minutes from now' do
       last_run = 5.minutes.ago
-      now = Time.now
+      now = Time.current
 
       [-0.1, 0, 12.5, 25, 26.1].each do |expiry|
         create(:user).tap do |user|

--- a/spec/workers/oauth_token_refresh_worker_spec.rb
+++ b/spec/workers/oauth_token_refresh_worker_spec.rb
@@ -93,7 +93,7 @@ describe OauthTokenRefreshWorker do
     let(:refreshed_token) do
       double('OmniAuth2::AccessToken',
              token: 'Iamatoken',
-             expires_at: Time.now + 1.hour,
+             expires_at: Time.current + 1.hour,
              refresh_token: 'AnotherToken'
       )
     end


### PR DESCRIPTION
Per a few resources' recommendations[1], calls for current time in a Rails
app should be to `Time.current` not `Time.now`.

[1] Resources:
* http://rails-bestpractices.com/posts/2014/10/22/use-time-zone-now-instead-of-time-now/
* http://danilenko.org/2012/7/6/rails_timezones/
* http://winstonyw.com/2014/03/03/time_now_vs_time_zone_now/

Addresses issue #1139