### PR TITLE
Add collaborator refactor 2

### DIFF
--- a/app/controllers/concerns/collaborator_processing.rb
+++ b/app/controllers/concerns/collaborator_processing.rb
@@ -1,0 +1,3 @@
+module CollaboratorProcessing
+  extend ActiveSupport::Concern
+end

--- a/app/controllers/concerns/collaborator_processing.rb
+++ b/app/controllers/concerns/collaborator_processing.rb
@@ -1,3 +1,15 @@
 module CollaboratorProcessing
   extend ActiveSupport::Concern
+
+  included do
+    helper_method :add_users_as_collaborators
+  end
+
+  def add_users_as_collaborators(resourceable_type, resourceable_id)
+    resource = resourceable_type.constantize.find(
+      resourceable_id
+    )
+  end
+
+
 end

--- a/app/controllers/concerns/collaborator_processing.rb
+++ b/app/controllers/concerns/collaborator_processing.rb
@@ -16,7 +16,7 @@ module CollaboratorProcessing
 
       # Passes object and action to Supermarket::Authorization,
       # which in turn passes them to Pundit for authorization
-      authorize!(collaborator, "create?")
+      authorize!(collaborator, 'create?')
 
       collaborator.save!
       CollaboratorMailer.delay.added_email(collaborator)

--- a/app/controllers/concerns/collaborator_processing.rb
+++ b/app/controllers/concerns/collaborator_processing.rb
@@ -5,11 +5,7 @@ module CollaboratorProcessing
     helper_method :add_users_as_collaborators
   end
 
-  def add_users_as_collaborators(resourceable_type, resourceable_id, user_ids)
-    resource = resourceable_type.constantize.find(
-      resourceable_id
-    )
-
+  def add_users_as_collaborators(resource, user_ids)
     user_ids = user_ids.split(',') - ineligible_ids(resource)
 
     User.where(id: user_ids).each do |user|

--- a/app/controllers/concerns/collaborator_processing.rb
+++ b/app/controllers/concerns/collaborator_processing.rb
@@ -5,11 +5,25 @@ module CollaboratorProcessing
     helper_method :add_users_as_collaborators
   end
 
-  def add_users_as_collaborators(resourceable_type, resourceable_id)
+  def add_users_as_collaborators(resourceable_type, resourceable_id, user_ids)
     resource = resourceable_type.constantize.find(
       resourceable_id
     )
+
+    Collaborator.ineligible_collaborators_for(resource).map(&:id).map(&:to_s)
+
+    user_ids = user_ids.split(',') - ineligible_ids(resource)
+    User.where(id: user_ids)
+
   end
 
+  private
 
+  def ineligible_ids(resource)
+    if Collaborator.ineligible_collaborators_for(resource)
+      Collaborator.ineligible_collaborators_for(resource).map(&:id).map(&:to_s)
+    else
+      []
+    end
+  end
 end

--- a/spec/controllers/concerns/collaborator_processing_spec.rb
+++ b/spec/controllers/concerns/collaborator_processing_spec.rb
@@ -80,15 +80,16 @@ describe FakesController do
           expect(cookbook.owner).to eq(fanny)
         end
 
-        it 'saves the new collaborator' do
+        before do
           allow(Collaborator).to receive(:new).and_return(new_collaborator)
+        end
+
+        it 'saves the new collaborator' do
           expect(new_collaborator).to receive(:save!)
           subject.add_users_as_collaborators(cookbook, user_ids)
         end
 
         it 'queues a mailer' do
-          allow(Collaborator).to receive(:new).and_return(new_collaborator)
-
           collaborator_mailer = double('CollaboratorMailer', delay: 'true')
           expect(CollaboratorMailer).to receive(:delay).and_return(collaborator_mailer)
 
@@ -105,8 +106,10 @@ describe FakesController do
           expect(cookbook.owner).to_not eq(hank)
         end
 
-        it 'does something' do
-
+        it 'returns an error' do
+          expect do
+            subject.add_users_as_collaborators(cookbook, user_ids)
+          end.to raise_error(Pundit::NotAuthorizedError)
         end
       end
     end

--- a/spec/controllers/concerns/collaborator_processing_spec.rb
+++ b/spec/controllers/concerns/collaborator_processing_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+class FakesController < ApplicationController
+  include CollaboratorProcessing
+end
+
+describe FakesController do
+
+end

--- a/spec/controllers/concerns/collaborator_processing_spec.rb
+++ b/spec/controllers/concerns/collaborator_processing_spec.rb
@@ -5,5 +5,32 @@ class FakesController < ApplicationController
 end
 
 describe FakesController do
+  let(:cookbook) { create(:cookbook) }
 
+  context 'finding the resource' do
+    context 'when the resource is a cookbook' do
+      it 'finds the correct cookbook' do
+        expect(Cookbook).to receive(:find).with(cookbook.id).and_return(cookbook)
+        subject.add_users_as_collaborators('Cookbook', cookbook.id)
+      end
+    end
+
+    context 'when the resource is a tool' do
+      let(:tool) { create(:tool) }
+
+      it 'finds the correct tool' do
+        expect(Tool).to receive(:find).with(tool.id).and_return(tool)
+        subject.add_users_as_collaborators('Tool', tool.id)
+      end
+    end
+  end
+
+  context 'finding users' do
+    context 'finding non-eligible user ids' do
+#      it 'finds non-eligible users' do
+#        expect(Collaborator).to receive(:ineligible_collaborators_for).with(cookbook)
+#        subject.add_users_as_collaborators
+#      end
+    end
+  end
 end

--- a/spec/controllers/concerns/collaborator_processing_spec.rb
+++ b/spec/controllers/concerns/collaborator_processing_spec.rb
@@ -20,24 +20,6 @@ describe FakesController do
     sign_in fanny
   end
 
-  context 'finding the resource' do
-    context 'when the resource is a cookbook' do
-      it 'finds the correct cookbook' do
-        expect(Cookbook).to receive(:find).with(cookbook.id).and_return(cookbook)
-        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
-      end
-    end
-
-    context 'when the resource is a tool' do
-      let(:tool) { create(:tool, owner: fanny) }
-
-      it 'finds the correct tool' do
-        expect(Tool).to receive(:find).with(tool.id).and_return(tool)
-        subject.add_users_as_collaborators('Tool', tool.id, user_ids)
-      end
-    end
-  end
-
   context 'adding users' do
     context 'finding non-eligible user ids' do
 
@@ -47,12 +29,12 @@ describe FakesController do
 
       it 'finds non-eligible users' do
         expect(Collaborator).to receive(:ineligible_collaborators_for).with(cookbook)
-        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+        subject.add_users_as_collaborators(cookbook, user_ids)
       end
 
       it 'maps the user ids' do
         expect(users).to receive(:map).and_return([user1.id, user2.id, user3.id])
-        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+        subject.add_users_as_collaborators(cookbook, user_ids)
       end
 
       it 'converts the ids to strings' do
@@ -60,20 +42,20 @@ describe FakesController do
 
         allow(users).to receive(:map).and_return(id_array)
         expect(id_array).to receive(:map).and_return(["#{user1.id}","#{user2.id}","#{user3.id}"])
-        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+        subject.add_users_as_collaborators(cookbook, user_ids)
       end
     end
 
     context 'finding users' do
       it 'finds all eligible users' do
         expect(User).to receive(:where).with(id: ["#{user1.id}","#{user2.id}","#{user3.id}"]).and_return(users)
-        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+        subject.add_users_as_collaborators(cookbook, user_ids)
       end
 
       it 'does not include non-eligible users' do
         allow(Collaborator).to receive(:ineligible_collaborators_for).and_return([user2])
         expect(User).to receive(:where).with(id: ["#{user1.id}","#{user3.id}"]).and_return([user1,user2])
-        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+        subject.add_users_as_collaborators(cookbook, user_ids)
       end
     end
 
@@ -84,12 +66,12 @@ describe FakesController do
 
       it 'creates a new collaborator' do
         expect(Collaborator).to receive(:new).with( user_id: user.id, resourceable: cookbook ).and_return(new_collaborator)
-        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+        subject.add_users_as_collaborators(cookbook, user_ids)
       end
 
       it 'authorizes the collaborator' do
         expect(subject).to receive(:authorize!)
-        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+        subject.add_users_as_collaborators(cookbook, user_ids)
       end
 
       context 'when the current user is the owner of the resource' do
@@ -101,7 +83,7 @@ describe FakesController do
         it 'saves the new collaborator' do
           allow(Collaborator).to receive(:new).and_return(new_collaborator)
           expect(new_collaborator).to receive(:save!)
-          subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+          subject.add_users_as_collaborators(cookbook, user_ids)
         end
 
         it 'queues a mailer' do
@@ -111,7 +93,7 @@ describe FakesController do
           expect(CollaboratorMailer).to receive(:delay).and_return(collaborator_mailer)
 
           expect(collaborator_mailer).to receive(:added_email).with(new_collaborator)
-          subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+          subject.add_users_as_collaborators(cookbook, user_ids)
         end
       end
 

--- a/spec/controllers/concerns/collaborator_processing_spec.rb
+++ b/spec/controllers/concerns/collaborator_processing_spec.rb
@@ -6,12 +6,22 @@ end
 
 describe FakesController do
   let(:cookbook) { create(:cookbook) }
+  let(:user1) { create(:user) }
+  let(:user2) { create(:user) }
+  let(:user3) { create(:user) }
+
+  let(:users) {[user1, user2, user3]}
+  let(:user_ids) { "#{user1.id},#{user2.id},#{user3.id}" }
+
+  before do
+    allow(subject).to receive(:current_user) { create(:user) }
+  end
 
   context 'finding the resource' do
     context 'when the resource is a cookbook' do
       it 'finds the correct cookbook' do
         expect(Cookbook).to receive(:find).with(cookbook.id).and_return(cookbook)
-        subject.add_users_as_collaborators('Cookbook', cookbook.id)
+        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
       end
     end
 
@@ -20,17 +30,48 @@ describe FakesController do
 
       it 'finds the correct tool' do
         expect(Tool).to receive(:find).with(tool.id).and_return(tool)
-        subject.add_users_as_collaborators('Tool', tool.id)
+        subject.add_users_as_collaborators('Tool', tool.id, user_ids)
       end
     end
   end
 
-  context 'finding users' do
+  context 'adding users' do
     context 'finding non-eligible user ids' do
-#      it 'finds non-eligible users' do
-#        expect(Collaborator).to receive(:ineligible_collaborators_for).with(cookbook)
-#        subject.add_users_as_collaborators
-#      end
+
+      before do
+        allow(Collaborator).to receive(:ineligible_collaborators_for).and_return(users)
+      end
+
+      it 'finds non-eligible users' do
+        expect(Collaborator).to receive(:ineligible_collaborators_for).with(cookbook)
+        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+      end
+
+      it 'maps the user ids' do
+        expect(users).to receive(:map).and_return([user1.id, user2.id, user3.id])
+        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+      end
+
+      it 'converts the ids to strings' do
+        id_array = [user1.id,user2.id,user3.id]
+
+        allow(users).to receive(:map).and_return(id_array)
+        expect(id_array).to receive(:map).and_return(user_ids)
+        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+      end
+    end
+
+    context 'finding users' do
+      it 'finds all eligible users' do
+        expect(User).to receive(:where).with(id: ["#{user1.id}","#{user2.id}","#{user3.id}"]).and_return(users)
+        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+      end
+
+      it 'does not include non-eligible users' do
+        allow(Collaborator).to receive(:ineligible_collaborators_for).and_return([user2])
+        expect(User).to receive(:where).with(id: ["#{user1.id}","#{user3.id}"]).and_return([user1,user2])
+        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+      end
     end
   end
 end

--- a/spec/controllers/concerns/collaborator_processing_spec.rb
+++ b/spec/controllers/concerns/collaborator_processing_spec.rb
@@ -5,7 +5,9 @@ class FakesController < ApplicationController
 end
 
 describe FakesController do
-  let(:cookbook) { create(:cookbook) }
+  let!(:fanny) { create(:user, first_name: 'Fanny') }
+  let!(:cookbook) { create(:cookbook, owner: fanny) }
+
   let(:user1) { create(:user) }
   let(:user2) { create(:user) }
   let(:user3) { create(:user) }
@@ -15,6 +17,7 @@ describe FakesController do
 
   before do
     allow(subject).to receive(:current_user) { create(:user) }
+    sign_in fanny
   end
 
   context 'finding the resource' do
@@ -26,7 +29,7 @@ describe FakesController do
     end
 
     context 'when the resource is a tool' do
-      let(:tool) { create(:tool) }
+      let(:tool) { create(:tool, owner: fanny) }
 
       it 'finds the correct tool' do
         expect(Tool).to receive(:find).with(tool.id).and_return(tool)
@@ -56,7 +59,7 @@ describe FakesController do
         id_array = [user1.id,user2.id,user3.id]
 
         allow(users).to receive(:map).and_return(id_array)
-        expect(id_array).to receive(:map).and_return(user_ids)
+        expect(id_array).to receive(:map).and_return(["#{user1.id}","#{user2.id}","#{user3.id}"])
         subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
       end
     end
@@ -71,6 +74,58 @@ describe FakesController do
         allow(Collaborator).to receive(:ineligible_collaborators_for).and_return([user2])
         expect(User).to receive(:where).with(id: ["#{user1.id}","#{user3.id}"]).and_return([user1,user2])
         subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+      end
+    end
+
+    context 'for each user' do
+      let(:user) { create(:user) }
+      let(:user_ids) { "#{user.id}" }
+      let(:new_collaborator) { build(:cookbook_collaborator, user: user, resourceable: cookbook) }
+
+      it 'creates a new collaborator' do
+        expect(Collaborator).to receive(:new).with( user_id: user.id, resourceable: cookbook ).and_return(new_collaborator)
+        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+      end
+
+      it 'authorizes the collaborator' do
+        expect(subject).to receive(:authorize!)
+        subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+      end
+
+      context 'when the current user is the owner of the resource' do
+        before do
+          expect(subject.current_user).to eq(fanny)
+          expect(cookbook.owner).to eq(fanny)
+        end
+
+        it 'saves the new collaborator' do
+          allow(Collaborator).to receive(:new).and_return(new_collaborator)
+          expect(new_collaborator).to receive(:save!)
+          subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+        end
+
+        it 'queues a mailer' do
+          allow(Collaborator).to receive(:new).and_return(new_collaborator)
+
+          collaborator_mailer = double('CollaboratorMailer', delay: 'true')
+          expect(CollaboratorMailer).to receive(:delay).and_return(collaborator_mailer)
+
+          expect(collaborator_mailer).to receive(:added_email).with(new_collaborator)
+          subject.add_users_as_collaborators('Cookbook', cookbook.id, user_ids)
+        end
+      end
+
+      context 'when the current user is not the owner of the resource' do
+        let(:hank) { create(:user, first_name: 'Hank') }
+        before do
+          sign_in hank
+          expect(subject.current_user).to eq(hank)
+          expect(cookbook.owner).to_not eq(hank)
+        end
+
+        it 'does something' do
+
+        end
       end
     end
   end

--- a/spec/controllers/concerns/collaborator_processing_spec.rb
+++ b/spec/controllers/concerns/collaborator_processing_spec.rb
@@ -12,7 +12,7 @@ describe FakesController do
   let(:user2) { create(:user) }
   let(:user3) { create(:user) }
 
-  let(:users) {[user1, user2, user3]}
+  let(:users) { [user1, user2, user3] }
   let(:user_ids) { "#{user1.id},#{user2.id},#{user3.id}" }
 
   before do
@@ -38,23 +38,23 @@ describe FakesController do
       end
 
       it 'converts the ids to strings' do
-        id_array = [user1.id,user2.id,user3.id]
+        id_array = [user1.id, user2.id, user3.id]
 
         allow(users).to receive(:map).and_return(id_array)
-        expect(id_array).to receive(:map).and_return(["#{user1.id}","#{user2.id}","#{user3.id}"])
+        expect(id_array).to receive(:map).and_return(["#{user1.id}", "#{user2.id}", "#{user3.id}"])
         subject.add_users_as_collaborators(cookbook, user_ids)
       end
     end
 
     context 'finding users' do
       it 'finds all eligible users' do
-        expect(User).to receive(:where).with(id: ["#{user1.id}","#{user2.id}","#{user3.id}"]).and_return(users)
+        expect(User).to receive(:where).with(id: ["#{user1.id}", "#{user2.id}", "#{user3.id}"]).and_return(users)
         subject.add_users_as_collaborators(cookbook, user_ids)
       end
 
       it 'does not include non-eligible users' do
         allow(Collaborator).to receive(:ineligible_collaborators_for).and_return([user2])
-        expect(User).to receive(:where).with(id: ["#{user1.id}","#{user3.id}"]).and_return([user1,user2])
+        expect(User).to receive(:where).with(id: ["#{user1.id}", "#{user3.id}"]).and_return([user1, user2])
         subject.add_users_as_collaborators(cookbook, user_ids)
       end
     end
@@ -65,7 +65,7 @@ describe FakesController do
       let(:new_collaborator) { build(:cookbook_collaborator, user: user, resourceable: cookbook) }
 
       it 'creates a new collaborator' do
-        expect(Collaborator).to receive(:new).with( user_id: user.id, resourceable: cookbook ).and_return(new_collaborator)
+        expect(Collaborator).to receive(:new).with(user_id: user.id, resourceable: cookbook).and_return(new_collaborator)
         subject.add_users_as_collaborators(cookbook, user_ids)
       end
 


### PR DESCRIPTION
This refactors the logic around adding a collaborator out of the collaborator controller into a concern.  I realized this refactor was needed during the process of coding the groups feature for Supermarket.  When that feature is launched, we will need the ability to add collaborators (and all the checking that is part of that process) to be accessible from more places than just one action in the collaborator controller.  Rather than repeat the code in multiple controllers, I refactored it into the concern you see here.