### PR TITLE
refactors removing a collaborator logic into a shared controller concern

### DIFF
--- a/app/controllers/collaborators_controller.rb
+++ b/app/controllers/collaborators_controller.rb
@@ -52,9 +52,7 @@ class CollaboratorsController < ApplicationController
   def destroy
     respond_to do |format|
       format.js do
-        authorize!(@collaborator)
-
-        @collaborator.destroy
+        remove_collaborator(@collaborator)
         head :ok
       end
     end

--- a/app/controllers/concerns/collaborator_processing.rb
+++ b/app/controllers/concerns/collaborator_processing.rb
@@ -23,6 +23,11 @@ module CollaboratorProcessing
     end
   end
 
+  def remove_collaborator(collaborator)
+    authorize!(collaborator, 'destroy?')
+    collaborator.destroy
+  end
+
   private
 
   def ineligible_ids(resource)

--- a/spec/controllers/collaborators_controller_spec.rb
+++ b/spec/controllers/collaborators_controller_spec.rb
@@ -83,34 +83,10 @@ describe CollaboratorsController do
     describe 'DELETE #destroy' do
       let!(:collaborator) { create(:cookbook_collaborator, resourceable: cookbook, user: hank) }
 
-      it 'deletes a collaborator if the signed in user is the resource owner' do
+      it 'calls the remove collaborator method' do
         sign_in fanny
-
-        expect do
-          delete :destroy, id: collaborator, format: :js
-        end.to change { Collaborator.count }.by(-1)
-
-        expect(response).to be_success
-      end
-
-      it 'deletes a collaborator if the signed in user is a collaborator on this resource' do
-        sign_in hank
-
-        expect do
-          delete :destroy, id: collaborator, format: :js
-        end.to change { Collaborator.count }.by(-1)
-
-        expect(response).to be_success
-      end
-
-      it 'fails if the signed in user is not the cookbook owner and also not a collaborator' do
-        sign_in hanky
-
-        expect do
-          delete :destroy, cookbook_id: cookbook, id: hank, format: :js
-        end.to_not change { Collaborator.count }
-
-        expect(response).to_not be_success
+        expect(controller).to receive(:remove_collaborator).with(collaborator)
+        delete :destroy, id: collaborator, format: :js
       end
     end
 

--- a/spec/controllers/concerns/collaborator_processing_spec.rb
+++ b/spec/controllers/concerns/collaborator_processing_spec.rb
@@ -121,7 +121,7 @@ describe FakesController do
 
     let!(:collaborator) { create(:cookbook_collaborator, resourceable: cookbook, user: hank) }
 
-    it 'deletes a collaborator if the signed in user is the resource owner' do
+    it 'allows a resource owner to remove a collaborator' do
       sign_in fanny
 
       expect do
@@ -131,7 +131,7 @@ describe FakesController do
       expect(response).to be_success
     end
 
-    it 'deletes a collaborator if the signed in user is a collaborator on this resource' do
+    it 'allows a collaborator to remove themselves as a collaborator' do
       sign_in hank
 
       expect do
@@ -141,7 +141,7 @@ describe FakesController do
       expect(response).to be_success
     end
 
-    it 'fails if the signed in user is not the cookbook owner and also not a collaborator' do
+    it 'does not allow a non-owner to remove a collborator other than themselves' do
       sign_in hanky
 
       expect do

--- a/spec/controllers/concerns/collaborator_processing_spec.rb
+++ b/spec/controllers/concerns/collaborator_processing_spec.rb
@@ -114,4 +114,39 @@ describe FakesController do
       end
     end
   end
+
+  context 'removing users' do
+    let!(:hank) { create(:user, first_name: 'Hank') }
+    let!(:hanky) { create(:user, first_name: 'Hanky') }
+
+    let!(:collaborator) { create(:cookbook_collaborator, resourceable: cookbook, user: hank) }
+
+    it 'deletes a collaborator if the signed in user is the resource owner' do
+      sign_in fanny
+
+      expect do
+        subject.remove_collaborator(collaborator)
+      end.to change { Collaborator.count }.by(-1)
+
+      expect(response).to be_success
+    end
+
+    it 'deletes a collaborator if the signed in user is a collaborator on this resource' do
+      sign_in hank
+
+      expect do
+        subject.remove_collaborator(collaborator)
+      end.to change { Collaborator.count }.by(-1)
+
+      expect(response).to be_success
+    end
+
+    it 'fails if the signed in user is not the cookbook owner and also not a collaborator' do
+      sign_in hanky
+
+      expect do
+        subject.remove_collaborator(collaborator)
+      end.to raise_error(Pundit::NotAuthorizedError)
+    end
+  end
 end

--- a/spec/controllers/concerns/collaborator_processing_spec.rb
+++ b/spec/controllers/concerns/collaborator_processing_spec.rb
@@ -141,7 +141,18 @@ describe FakesController do
       expect(response).to be_success
     end
 
-    it 'does not allow a non-owner to remove a collborator other than themselves' do
+    it 'does not allow a non-collaborator to remove a collaborator' do
+      sign_in hanky
+
+      expect do
+        subject.remove_collaborator(collaborator)
+      end.to raise_error(Pundit::NotAuthorizedError)
+    end
+
+    it 'does not allow a collaborator to remove a collaborator other than themselves' do
+      hanky_collaborator = create(:cookbook_collaborator, resourceable: cookbook, user: hanky)
+      expect(cookbook.collaborators).to include(hanky_collaborator)
+
       sign_in hanky
 
       expect do


### PR DESCRIPTION
This is similar to #1146, but it refactors removing a collaborator into the shared controller concern.  This continues to lay the foundation for the groups feature, which requires the ability to remove a collaborator from multiple controllers.  The reason this is in a controller concern, rather than a service object, is that Pundit (our authorization service) requires access to controller methods such as current_user.