### PR TITLE
Add bundle-audit to CI test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,6 @@ rvm:
 script:
   - bundle exec rake spec
   - bundle exec rake spec:rubocop
+  - bundle exec bundle-audit check --update
 services:
   - redis-server

--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 3.1.0'
   gem 'byebug'
   gem 'launchy'
-  gem 'bundler-audit'
+  gem 'bundler-audit', git: 'https://github.com/rubysec/bundler-audit.git', ref: '4e32fca'
   gem 'brakeman'
 
   # Pinned to be greater than or equal to 1.0.0.pre because the gems were prior

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/rubysec/bundler-audit.git
+  revision: 4e32fca89d75f0e249671431ff38aadc02bfb28b
+  ref: 4e32fca
+  specs:
+    bundler-audit (0.4.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
+
+GIT
   remote: https://github.com/tobiassvn/sidetiq.git
   revision: 4f7d7daea3873443b17bf2f3da61619532bbeba2
   ref: 4f7d7da
@@ -65,9 +74,6 @@ GEM
       slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
-    bundler-audit (0.4.0)
-      bundler (~> 1.2)
-      thor (~> 0.18)
     byebug (3.4.0)
       columnize (~> 0.8)
       debugger-linecache (~> 1.2)
@@ -450,7 +456,7 @@ DEPENDENCIES
   and_feathers-gzipped_tarball (>= 1.0.0.pre)
   aws-sdk
   brakeman
-  bundler-audit
+  bundler-audit!
   byebug
   capybara
   chef

--- a/lib/tasks/spec/all.rake
+++ b/lib/tasks/spec/all.rake
@@ -3,6 +3,10 @@ namespace :spec do
     fail unless system 'bundle exec rubocop'
   end
 
+  task :bundle_audit do
+    fail unless system 'bundle exec bundle-audit check --update'
+  end
+
   desc 'Run RSpec tests and rubocop'
-  task all: [:spec, :javascripts, :rubocop]
+  task all: [:spec, :javascripts, :rubocop, :bundle_audit]
 end


### PR DESCRIPTION
Pin bundler-audit to a version with `check --update` option. This
unreleased version lets us perform an update of the vulnerability
database during the check.