### PR TITLE
Upgrade to Ruby 2.1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ notifications:
       - https://webhooks.gitter.im/e/c2044eca72685a9b2ef7
 rvm:
   - 2.1.3
+  - 2.1.7
 script:
   - bundle exec rake spec
   - bundle exec rake spec:rubocop


### PR DESCRIPTION
This will probably be a multi-part process:

- [x] add 2.1.7 to the Travis build matrix
- [x] confirm app unit tests pass under 2.1.7
- [ ] update Ruby version in [omnibus-supermarket](https://github.com/chef/omnibus-supermarket/blob/master/config/projects/supermarket.rb#L33)
- [ ] confirm upgrade in omnibus passes through CI
- [ ] update README here for Ruby version requirement