### PR TITLE
Add detail from exception thrown during version validation

### DIFF
--- a/lib/active_model/validations/chef_version_constraint_validator.rb
+++ b/lib/active_model/validations/chef_version_constraint_validator.rb
@@ -34,8 +34,9 @@ module ActiveModel
       #
       def validate_each(record, attribute, value)
         Chef::VersionConstraint.new(value)
-      rescue Chef::Exceptions::InvalidVersionConstraint, Chef::Exceptions::InvalidCookbookVersion
-        record.errors.add(attribute, options.fetch(:message), value: value)
+      rescue Chef::Exceptions::InvalidVersionConstraint, Chef::Exceptions::InvalidCookbookVersion => e
+        msg = "#{options.fetch(:message)}. #{e.class}: #{e.message}"
+        record.errors.add(attribute, msg, value: value)
       end
     end
   end

--- a/spec/lib/active_model/validations/chef_version_constraint_validator_spec.rb
+++ b/spec/lib/active_model/validations/chef_version_constraint_validator_spec.rb
@@ -30,6 +30,14 @@ describe ActiveModel::Validations::ChefVersionConstraintValidator do
     expect(dependency.errors[:version]).to_not be_empty
   end
 
+  it 'includes why the constraint is invalid' do
+    dependency = dependency_class.new(version: '2')
+
+    expect { dependency.valid? }
+      .to change { dependency.errors[:version] }
+      .to include(/'2' does not match 'x.y.z' or 'x.y'/)
+  end
+
   it 'has a configurable error message' do
     dependency_class = Class.new do
       include ActiveModel::Model
@@ -40,8 +48,9 @@ describe ActiveModel::Validations::ChefVersionConstraintValidator do
     end
 
     dependency = dependency_class.new(version: 'haha')
-    dependency.valid?
 
-    expect(dependency.errors[:version]).to eql(['oh no'])
+    expect { dependency.valid? }
+      .to change { dependency.errors[:version] }
+      .to include(/oh no/)
   end
 end

--- a/spec/models/cookbook_dependency_spec.rb
+++ b/spec/models/cookbook_dependency_spec.rb
@@ -13,19 +13,17 @@ describe CookbookDependency do
     it 'does not allow "snarfle" as a version constraint' do
       platform = CookbookDependency.new(version_constraint: 'snarfle')
 
-      platform.valid?
-
-      expect(platform.errors[:version_constraint]).
-        to include('is not a valid Chef version constraint')
+      expect { platform.valid? }
+        .to change { platform.errors[:version_constraint] }
+        .to include(/is not a valid Chef version constraint/)
     end
 
     it 'does not allow blank version constraints' do
       platform = CookbookDependency.new(version_constraint: '')
 
-      platform.valid?
-
-      expect(platform.errors[:version_constraint]).
-        to include('is not a valid Chef version constraint')
+      expect { platform.valid? }
+        .to change { platform.errors[:version_constraint] }
+        .to include(/is not a valid Chef version constraint/)
     end
 
     it 'must have a unique name and version constraint per CookbookVersion' do

--- a/spec/models/supported_platform_spec.rb
+++ b/spec/models/supported_platform_spec.rb
@@ -16,19 +16,17 @@ describe SupportedPlatform do
     it 'does not allow "snarfle" as a version constraint' do
       platform = SupportedPlatform.new(version_constraint: 'snarfle')
 
-      platform.valid?
-
-      expect(platform.errors[:version_constraint]).
-        to include('is not a valid Chef version constraint')
+      expect { platform.valid? }
+        .to change { platform.errors[:version_constraint] }
+        .to include(/is not a valid Chef version constraint/)
     end
 
     it 'does not allow blank version constraints' do
       platform = SupportedPlatform.new(version_constraint: '')
 
-      platform.valid?
-
-      expect(platform.errors[:version_constraint]).
-        to include('is not a valid Chef version constraint')
+      expect { platform.valid? }
+        .to change { platform.errors[:version_constraint] }
+        .to include(/is not a valid Chef version constraint/)
     end
   end
 


### PR DESCRIPTION
The default message was vague for an invalid dependency or platform version
constraint. For example:

```
Stove::Cli | >>>> The Chef Server did not understand the request because it was malformed.
{ "error_code"=>"INVALID_DATA",
  "error_messages"=>["Version constraint is not a valid Chef version constraint"]
}
```

The error above did not contain enough information for a cookbook author to determine which of the versions they had declared in metadata was invalid.

This change includes the exception class and detail from the original exception thrown about what is invalid about the data given. With this change, the error above would appear as:

```
Stove::Cli | >>>> The Chef Server did not understand the request because it was malformed.
{ "error_code"=>"INVALID_DATA",
  "error_messages"=>["Version constraint is not a valid Chef version constraint. Chef::Exceptions::InvalidCookbookVersion: '2' does not match 'x.y.z' or 'x.y'"]}
```

Updated spec expectations to use blocks to call out the action under test and to check for a regex match among the validation errors instead of an exact string inclusion.