### PR TITLE
Upgrade to Ruby 2.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ notifications:
       - https://webhooks.gitter.im/e/c2044eca72685a9b2ef7
 rvm:
   - 2.1.3
+  - 2.2.3
 script:
   - bundle exec rake spec
   - bundle exec rake spec:rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ notifications:
     urls:
       - https://webhooks.gitter.im/e/c2044eca72685a9b2ef7
 rvm:
-  - 2.1.3
   - 2.2.3
 script:
   - bundle exec rake spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     and_feathers (1.0.0.pre.2)
     and_feathers-gzipped_tarball (1.0.0.pre)
     arel (5.0.1.20140414130214)
-    ast (2.0.0)
+    ast (2.1.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
     aws-sdk (1.57.0)
@@ -163,7 +163,7 @@ GEM
     hitimes (1.2.3)
     html_truncator (0.4.0)
       nokogiri (~> 1.5)
-    htmlentities (4.3.2)
+    htmlentities (4.3.4)
     httparty (0.13.1)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
@@ -214,7 +214,7 @@ GEM
     net-ssh-multi (1.2.1)
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
-    newrelic_rpm (3.9.3.241)
+    newrelic_rpm (3.14.0.305)
     nokogiri (1.6.7)
       mini_portile2 (~> 2.0.0.rc2)
     oauth2 (1.0.0)
@@ -257,9 +257,8 @@ GEM
       cocaine (~> 0.5.5)
       mime-types
       mimemagic (= 0.3.0)
-    parser (2.2.0.pre.4)
+    parser (2.3.0.pre.2)
       ast (>= 1.1, < 3.0)
-      slop (~> 3.4, >= 3.4.5)
     pg (0.17.1)
     pg_search (0.7.6)
       activerecord (>= 3.1)
@@ -517,3 +516,6 @@ DEPENDENCIES
   webmock
   yajl-ruby
   yard
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ repositories are:
 
 ## Requirements
 
-- Ruby 2.1.3
+- Ruby 2.2.3
 - PostgreSQL 9.2+
 - Redis 2.4+
 

--- a/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
@@ -100,7 +100,7 @@ describe Api::V1::CookbookVersionsController do
               cookbook_name: cookbook.name,
               cookbook_version: version.to_param,
               foodcritic_failure: true,
-              foodcritic_failure: 'E066',
+              foodcritic_feedback: 'E066',
               fieri_key: 'YOUR_FIERI_KEY',
               format: :json
             )
@@ -154,7 +154,7 @@ describe Api::V1::CookbookVersionsController do
             cookbook_name: cookbook.name,
             cookbook_version: '1010101.1.1',
             foodcritic_failure: true,
-            foodcritic_failure: 'E066',
+            foodcritic_feedback: 'E066',
             fieri_key: 'YOUR_FIERI_KEY',
             format: :json
           )
@@ -171,7 +171,7 @@ describe Api::V1::CookbookVersionsController do
           cookbook_name: cookbook.name,
           cookbook_version: '1010101.1.1',
           foodcritic_failure: true,
-          foodcritic_failure: 'E066',
+          foodcritic_feedback: 'E066',
           fieri_key: 'not_the_key',
           format: :json
         )


### PR DESCRIPTION
Opting for a minor version upgrade to Ruby 2.2.3 instead of patch upgrade to 2.1.7 because of [build trouble](https://github.com/chef/supermarket/pull/1155#issuecomment-156473682).

This will probably be a multi-part process:

- [x] add 2.2.3 to the Travis build matrix
- [x] confirm app unit tests pass under 2.2.3
- [x] update Ruby version in [omnibus-supermarket](https://github.com/chef/omnibus-supermarket/pull/39) 
- [x] confirm upgrade in omnibus passes through CI
- [x] update README here for Ruby version requirement
- [x] remove 2.1.3 from Travis build matrix