### PR TITLE
Default the CLA pages to 50 companies / users per page

### DIFF
--- a/app/controllers/ccla_signatures_controller.rb
+++ b/app/controllers/ccla_signatures_controller.rb
@@ -18,7 +18,7 @@ class CclaSignaturesController < ApplicationController
       @ccla_signatures = @ccla_signatures.where('organization_id <> ?', params[:exclude_id])
     end
 
-    @ccla_signatures = @ccla_signatures.page(params[:page]).per(20)
+    @ccla_signatures = @ccla_signatures.page(params[:page]).per(50)
 
     respond_to do |format|
       format.html


### PR DESCRIPTION
We have a lot of wasted whitespace on this page and since we lack a search box it takes a long time to find a user / company.  This would reduce the time spent searching the pages.