### PR TITLE
Bring Ruby version back in to 2.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ notifications:
     urls:
       - https://webhooks.gitter.im/e/c2044eca72685a9b2ef7
 rvm:
-  - 2.2.3
+  - 2.1.8
 script:
   - bundle exec rake spec
   - bundle exec rake spec:rubocop

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ repositories are:
 
 ## Requirements
 
-- Ruby 2.2.3
+- Ruby 2.1.8
 - PostgreSQL 9.2+
 - Redis 2.4+
 


### PR DESCRIPTION
Fixes #1183 by reverting back to 2.1 series.

- [x] Get chef/omnibus-software#538 merged
- [x] PR for `chef/omnibus-supermarket` to update omnibus-software gem
- [x] Merge this when omni-supermarket PR is merged.