### PR TITLE
Add a migration to ensure current DB extensions are enabled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_install:
   - bundle config build.nokogiri --use-system-libraries
 before_script:
   - psql -c 'create database supermarket_test;' -U postgres
-  - psql supermarket_test -c 'create extension pg_trgm' -U postgres
   - bundle exec rake db:schema:load
 bundler_args: --without development --jobs 7
 cache:

--- a/db/migrate/20160109212307_enable_pg_extensions.rb
+++ b/db/migrate/20160109212307_enable_pg_extensions.rb
@@ -1,0 +1,5 @@
+class EnablePgExtensions < ActiveRecord::Migration
+  def change
+    enable_extension "pg_trgm"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151201232841) do
+ActiveRecord::Schema.define(version: 20160109212307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
These extensions are already included in the schema. But [pg_trgm was added directly to schema.rb](https://github.com/chef/supermarket/commit/99d7990d85e36821c57d43d2861316f46c0407de) leaving newly migrated databases (e.g. dev and test) without the extensions being included in the resultant post-migration schema.rb.

plpgsql is included from the PG adapter on platforms that need it, so it is not included directly in this migration.

pg_trgrm is needed for PG search to work.