### PR TITLE
Adjust guard-rspec's output

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,6 +1,8 @@
 # This group allows to skip running RuboCop when RSpec failed.
 group :red_green_refactor, halt_on_fail: true do
-  guard :rspec, all_on_start: true, cmd: 'bundle exec rspec' do
+  guard :rspec, all_on_start: true,
+                cmd: 'bundle exec rspec --format documentation',
+                run_all: { cmd: 'bundle exec rspec --format progress' } do
     require 'guard/rspec/dsl'
     dsl = Guard::RSpec::Dsl.new(self)
 


### PR DESCRIPTION
dots when running all, spec text when focused on a change

Example:

**Guard starting up, running all specs and rubocop**

```
» be guard
16:22:14 - INFO - Guard::RSpec is running
16:22:14 - INFO - Running all specs
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 55593
......................................................................................................................................................................
......................................................................................................................................................................
......................................................................................................................................................................
......................................................................................................................................................................
......................................................................................................................................................................
......................................................................................................................................................................
......................................................................................................................................................................
......................................................................................................................................................................
......................................................................................................................................................................
......................................................................................................................................................................
.........................................

Finished in 3 minutes 27.2 seconds (files took 6.03 seconds to load)
1701 examples, 0 failures

Randomized with seed 55593


16:25:48 - INFO - Inspecting Ruby code style of all files
Inspecting 461 files
......................................................................................................................................................................
......................................................................................................................................................................
.................................................................................................................................

461 files inspected, no offenses detected
16:25:54 - INFO - Guard is now watching at '/Users/rkidd/work/supermarket'
```

**Guard "seeing a change" to a controller, only running those specs and rubocop, and showing the spec text**

```
[1] guard(main)> c app/controllers/contributors_controller.rb
16:29:47 - INFO - Running: spec/controllers/contributors_controller_spec.rb
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 5244

ContributorsController
  DELETE #destroy
    user is not authorized to destroy Contributor
      doesn't destroy the contributor
      responds with 404
    user is authorized to destroy Contributor
      redirects the user back
      destroys the contributor
  GET #index
    assigns contributors
    assigns contributor_list
    responds with a 200
  PATCH #update
    user is authorized to update Contributor
      updates the contributor
    user is not authorized to update Contributor
      should respond with 404
      doesn't update the contributor
  GET #become_a_contributor
    responds with a 200

Finished in 0.91572 seconds (files took 3.5 seconds to load)
11 examples, 0 failures

Randomized with seed 5244


16:29:52 - INFO - Inspecting Ruby code style: app/controllers/contributors_controller.rb
Inspecting 1 file
.

1 file inspected, no offenses detected
```