### PR TITLE
Add filter by platform to cookbook index API [1228]

### DIFF
--- a/app/controllers/api/v1/cookbooks_controller.rb
+++ b/app/controllers/api/v1/cookbooks_controller.rb
@@ -20,6 +20,7 @@ class Api::V1::CookbooksController < Api::V1Controller
   #   GET /api/v1/cookbooks?start=5&items=15
   #   GET /api/v1/cookbooks?order=recently_updated
   #   GET /api/v1/cookbooks?user=timmy
+  #   GET /api/v1/cookbooks?platforms[]=debian
   #
   def index
     @total = Cookbook.count
@@ -27,6 +28,10 @@ class Api::V1::CookbooksController < Api::V1Controller
 
     if params[:user]
       @cookbooks = @cookbooks.owned_by(params[:user])
+    end
+
+    if params[:platforms].present? && params[:platforms][0].present?
+      @cookbooks = @cookbooks.filter_platforms(params[:platforms])
     end
   end
 

--- a/spec/controllers/api/v1/cookbooks_controller_spec.rb
+++ b/spec/controllers/api/v1/cookbooks_controller_spec.rb
@@ -59,6 +59,15 @@ describe Api::V1::CookbooksController do
       expect(cookbooks.first).to eql(sashimi)
     end
 
+    it 'allows filtering cookbooks by platform' do
+      create(:debian_cookbook_version, cookbook: sashimi)
+
+      get :index, platforms: 'debian', format: :json
+      cookbooks = assigns[:cookbooks]
+      expect(cookbooks.size).to eql(1)
+      expect(cookbooks.first).to eql(sashimi)
+    end
+
     it 'uses the start param to offset the cookbooks sent to the view' do
       get :index, start: 1, format: :json
 

--- a/spec/factories/cookbook_version.rb
+++ b/spec/factories/cookbook_version.rb
@@ -7,5 +7,15 @@ FactoryGirl.define do
     readme '# redis cookbook'
     readme_extension 'md'
     foodcritic_failure false
+
+    trait :debian do
+      after(:build) do |cookbook_version, evaluator|
+        cookbook_version.add_supported_platform("debian", evaluator.version)
+      end
+    end
+  end
+
+  factory :debian_cookbook_version, parent: :cookbook_version do
+    debian
   end
 end


### PR DESCRIPTION
Closes #1228.
Can filter by platforms in the API.
e.g.
https://supermarket.chef.io/api/v1/cookbooks?platforms[]=mac_os_x