### PR TITLE
Use the correct tarball url when Supermarket stores cookbooks on disk

### DIFF
--- a/app/workers/fieri_notify_worker.rb
+++ b/app/workers/fieri_notify_worker.rb
@@ -21,9 +21,25 @@ class FieriNotifyWorker
     data = {
       'cookbook_name' => cookbook_version.name,
       'cookbook_version' => cookbook_version.version,
-      'cookbook_artifact_url' => cookbook_version.tarball.url
+      'cookbook_artifact_url' => cookbook_artifact_url(cookbook_version)
     }
 
     response = Net::HTTP.post_form(uri, data)
+  end
+
+  private
+
+  def cookbook_artifact_url(cookbook_version)
+    if s3_configured?
+      cookbook_version.tarball.url
+    else
+      "#{Supermarket::Host.full_url}#{cookbook_version.tarball.url}"
+    end
+  end
+
+  def s3_configured?
+    %w(S3_BUCKET S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY).all? do |key|
+      ENV[key].present?
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,8 @@ Supermarket::Application.routes.draw do
       delete 'cookbooks/:cookbook' => 'cookbook_uploads#destroy'
       delete 'cookbooks/:cookbook/versions/:version' => 'cookbook_uploads#destroy_version', constraints: { version: VERSION_PATTERN }
       get 'users/:user' => 'users#show', as: :user
-      post '/cookbook-verisons/evaluation' => 'cookbook_versions#evaluation', as: :cookbook_versions_evaluation, constraints: proc { ROLLOUT.active?(:fieri) }
+
+      post '/cookbook-versions/evaluation' => 'cookbook_versions#evaluation', as: :cookbook_versions_evaluation, constraints: proc { ROLLOUT.active?(:fieri) }
 
       get 'tools/:tool' => 'tools#show', as: :tool
       get 'tools' => 'tools#index', as: :tools

--- a/spec/api/cookbook_evaluation_results_spec.rb
+++ b/spec/api/cookbook_evaluation_results_spec.rb
@@ -6,7 +6,7 @@ describe 'POST /api/v1/cookbook_evalution_results' do
 
   it 'returns a 200' do
     post(
-      '/api/v1/cookbook-verisons/evaluation',
+      '/api/v1/cookbook-versions/evaluation',
       cookbook_name: cookbook.name,
       cookbook_version: cookbook_version.version,
       foodcritic_failure: false,

--- a/spec/routing/cookbook_version_routes_spec.rb
+++ b/spec/routing/cookbook_version_routes_spec.rb
@@ -29,6 +29,12 @@ describe 'cookbook version routes' do
         expect(get: '/api/v1/cookbooks/redis/versions/latest/download', format: :json).to route_to(controller: 'api/v1/cookbook_versions', action: 'download', format: :json, cookbook: 'redis', version: 'latest')
       end
     end
+
+    context '#evaluation' do
+      it 'can route using cookbook_versions#evaluation' do
+        expect(post: '/api/v1/cookbook-versions/evaluation', format: :json).to route_to(controller: 'api/v1/cookbook_versions', action: 'evaluation', format: :json)
+      end
+    end
   end
 
   context 'public website' do

--- a/spec/workers/fieri_notify_worker_spec.rb
+++ b/spec/workers/fieri_notify_worker_spec.rb
@@ -12,4 +12,49 @@ describe FieriNotifyWorker do
 
     expect(result.class).to eql(Net::HTTPOK)
   end
+
+  context 'setting the correct cookbook artifact url' do
+    let(:version) { create(:cookbook_version, cookbook: cookbook) }
+
+    before do
+      allow(CookbookVersion).to receive(:find).and_return(version)
+    end
+
+    context 'when not using S3 for cookbook storage' do
+      before do
+        ENV['S3_BUCKET'] = nil
+      end
+
+      it 'includes the correct cookbook artifact url' do
+        expect(Net::HTTP).to receive(:post_form).with(anything, hash_including("cookbook_artifact_url" => "#{Supermarket::Host.full_url}#{version.tarball.url}"))
+
+        worker = FieriNotifyWorker.new
+        worker.perform(version.id)
+      end
+    end
+
+    context 'when using S3 for cookbook storage' do
+      before do
+        ENV['S3_BUCKET'] = 'mybucket'
+        ENV['S3_ACCESS_KEY_ID'] = '123'
+        ENV['S3_SECRET_ACCESS_KEY'] = '456'
+
+        # Paths for cookbooks are configured in config/initializers/paperclip.rb
+        # These variables are set to simulate cookbooks which are configured to
+        # be stored on S3
+        default_s3_url = "https://s3.amazonaws.com/"
+        s3_path = version.tarball.url.sub(%r{^/system}, '') # S3 cookbook paths do not have /system at the beginning of them
+
+        s3_tarball_url = "#{default_s3_url}#{ENV['S3_BUCKET']}#{s3_path}"
+
+        allow(version).to receive_message_chain(:tarball, :url).and_return(s3_tarball_url)
+      end
+
+      it 'includes the correct cookbook artifact url' do
+        expect(Net::HTTP).to receive(:post_form).with(anything, hash_including("cookbook_artifact_url" => version.tarball.url.to_s))
+        worker = FieriNotifyWorker.new
+        worker.perform(version.id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds code to submit the correct tarball url to fieri when a Supermarket stores cookbooks on the local disk rather than S3

Fix for the first checklist item in #1227 