### PR TITLE
Allow cookbook deprecations without a replacement cookbook

### DIFF
--- a/app/assets/javascripts/cookbookDeprecate.js
+++ b/app/assets/javascripts/cookbookDeprecate.js
@@ -28,8 +28,4 @@ $(document).on('opened', '[data-reveal]', function () {
   }
 
   $('.cookbook-deprecate').select2(settings);
-
-  $('.cookbook-deprecate').on("select2-selecting", function(e) {
-    $('.submit-deprecation').prop('disabled', false);
-  });
 });

--- a/app/controllers/cookbooks_controller.rb
+++ b/app/controllers/cookbooks_controller.rb
@@ -165,19 +165,16 @@ class CookbooksController < ApplicationController
   def deprecate
     authorize! @cookbook
 
-    replacement_cookbook = Cookbook.with_name(
-      cookbook_deprecation_params[:replacement]
-    ).first!
+    replacement_cookbook_name = cookbook_deprecation_params[:cookbook][:replacement]
 
-    if @cookbook.deprecate(replacement_cookbook)
+    if @cookbook.deprecate(replacement_cookbook_name)
       CookbookDeprecatedNotifier.perform_async(@cookbook.id)
 
       redirect_to(
         @cookbook,
         notice: t(
           'cookbook.deprecated',
-          cookbook: @cookbook.name,
-          replacement_cookbook: replacement_cookbook.name
+          cookbook: @cookbook.name
         )
       )
     else
@@ -281,7 +278,7 @@ class CookbooksController < ApplicationController
   end
 
   def cookbook_deprecation_params
-    params.require(:cookbook).permit(:replacement)
+    params.permit(cookbook: [:replacement])
   end
 
   def render_follow_button

--- a/app/mailers/cookbook_mailer.rb
+++ b/app/mailers/cookbook_mailer.rb
@@ -48,10 +48,10 @@ class CookbookMailer < ActionMailer::Base
     @email_preference = user.email_preference_for('Cookbook deprecated')
     @to = user.email
 
-    subject = %(
-      The #{@cookbook.name} cookbook has been deprecated in favor
-      of the #{@replacement_cookbook.name} cookbook
-    ).squish
+    subject = "The #{@cookbook.name} cookbook has been deprecated"
+    if @replacement_cookbook
+      subject += "in favor of the #{@replacement_cookbook.name} cookbook"
+    end
 
     mail(to: @to, subject: subject)
   end

--- a/app/mailers/cookbook_mailer.rb
+++ b/app/mailers/cookbook_mailer.rb
@@ -50,7 +50,7 @@ class CookbookMailer < ActionMailer::Base
 
     subject = "The #{@cookbook.name} cookbook has been deprecated"
     if @replacement_cookbook
-      subject += "in favor of the #{@replacement_cookbook.name} cookbook"
+      subject += " in favor of the #{@replacement_cookbook.name} cookbook"
     end
 
     mail(to: @to, subject: subject)

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -112,7 +112,6 @@ class Cookbook < ActiveRecord::Base
     allow_blank: true,
     allow_nil: true
   }
-  validates :replacement, presence: true, if: :deprecated?
 
   #
   # The total number of times a cookbook has been downloaded from Supermarket
@@ -351,21 +350,23 @@ class Cookbook < ActiveRecord::Base
   #
   # A cookbook can only be replaced with a cookbook that is not deprecated.
   #
-  # @param replacement_cookbook [Cookbook] the cookbook to succeed this cookbook
-  #   once deprecated
+  # @param replacement_cookbook_name [String] the name of the cookbook to
+  #   succeed this cookbook once deprecated
   #
   # @return [Boolean] whether or not the cookbook was successfully deprecated
   #   and  saved
   #
-  def deprecate(replacement_cookbook)
-    if replacement_cookbook.deprecated?
+  def deprecate(replacement_cookbook_name = '')
+    replacement_cookbook = Cookbook.find_by_name replacement_cookbook_name
+
+    if replacement_cookbook.present? && replacement_cookbook.deprecated?
       errors.add(:base, I18n.t('cookbook.deprecate_with_deprecated_failure'))
       return false
-    else
-      self.deprecated = true
-      self.replacement = replacement_cookbook
-      save
     end
+
+    self.deprecated = true
+    self.replacement = replacement_cookbook if replacement_cookbook.present?
+    save
   end
 
   #

--- a/app/views/cookbook_mailer/cookbook_deprecated_email.html.erb
+++ b/app/views/cookbook_mailer/cookbook_deprecated_email.html.erb
@@ -1,3 +1,9 @@
-<p>The <%= link_to @cookbook.name, cookbook_url(@cookbook) %> cookbook has been deprecated in favor of the <%= link_to @replacement_cookbook.name, cookbook_url(@replacement_cookbook) %> cookbook.</p>
+<p>The <%= link_to @cookbook.name, cookbook_url(@cookbook) %> cookbook has been
+   deprecated.</p>
+
+<% if @replacement_cookbook -%>
+<p>The owner recommends using the <%= link_to @replacement_cookbook.name, cookbook_url(@replacement_cookbook) %>
+   cookbook.</p>
+<% end -%>
 
 <%= link_to 'Unsubscribe', unsubscribe_url(@email_preference) %>

--- a/app/views/cookbook_mailer/cookbook_deprecated_email.text.erb
+++ b/app/views/cookbook_mailer/cookbook_deprecated_email.text.erb
@@ -1,3 +1,7 @@
-The <%= @cookbook.name %> cookbook [<%= cookbook_url(@cookbook) %>] has been deprecated in favor of the <%= @replacement_cookbook.name %> cookbook [<%= cookbook_url(@replacement_cookbook) %>].
+The <%= @cookbook.name %> cookbook [<%= cookbook_url(@cookbook) %>] has been deprecated.
+
+<% if @replacement_cookbook -%>
+The owner recommends using the <%= @replacement_cookbook.name %> cookbook [ <%= cookbook_url(@replacement_cookbook) %> ].
+<% end -%>
 
 Unsubscribe from this email: <%= unsubscribe_url(@email_preference) %>

--- a/app/views/cookbooks/_manage_cookbook.html.erb
+++ b/app/views/cookbooks/_manage_cookbook.html.erb
@@ -61,7 +61,7 @@
             <%= f.hidden_field :replacement, class: 'cookbook-deprecate', 'data-url' => deprecate_search_cookbook_path(cookbook) %>
           </div>
           <div class="small-3 columns">
-            <%= f.submit 'Deprecate', class: 'button radius postfix submit-deprecation', disabled: true %>
+            <%= f.submit 'Deprecate', class: 'button radius postfix submit-deprecation' %>
           </div>
         </div>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
       email_sent: "Ownership transfer email sent to %{user}."
       invite_accepted: "You are the new owner of %{cookbook}."
       invite_declined: "You have declined ownership of %{cookbook}."
-    deprecated: "%{cookbook} deprecated in favor of %{replacement_cookbook}."
+    deprecated: "%{cookbook} deprecated."
     undeprecated: "%{cookbook} is no longer deprecated."
     featured: "%{cookbook} is now %{state}."
     deprecate_with_deprecated_failure: "This cookbook cannot be deprecated in favor of a deprecated cookbook."

--- a/spec/features/cookbook_deprecation_spec.rb
+++ b/spec/features/cookbook_deprecation_spec.rb
@@ -5,47 +5,66 @@ feature 'cookbook owners can deprecate a cookbook' do
   let(:replacement_cookbook) { create(:cookbook) }
   let(:user) { cookbook.owner }
 
-  before do
-    sign_in(user)
-    visit cookbook_path(cookbook)
-
-    follow_relation 'deprecate'
-
-    within '#deprecate' do
-      find('#cookbook_replacement').set(replacement_cookbook.name)
-      submit_form
-    end
-  end
-
-  it 'displays a success message' do
-    expect_to_see_success_message
-  end
-
-  it 'displays a deprecation notice on the cookbook show with the replacment' do
-    expect(page).to have_content(replacement_cookbook.name)
-  end
-
-  it 'displays a deprecation notice on the cookbook partial with link to replacement' do
-    visit user_path(cookbook.owner)
-
-    expect(page).to have_content(replacement_cookbook.name)
-  end
-
-  context 'when cookbook replacement is deleted' do
+  context 'to just say DO NOT USE THIS' do
     before do
-      replacement_cookbook.destroy
+      sign_in(user)
+      visit cookbook_path(cookbook)
+
+      follow_relation 'deprecate'
+
+      within '#deprecate' do
+        submit_form
+      end
     end
 
-    it 'displays a simple deprecation notice on the cookbook show' do
-      visit(current_path)
+    it 'displays a success message' do
+      expect_to_see_success_message
+    end
+  end
 
-      expect(page).to_not have_content(replacement_cookbook.name)
+  context 'with another cookbook to replace it' do
+    before do
+      sign_in(user)
+      visit cookbook_path(cookbook)
+
+      follow_relation 'deprecate'
+
+      within '#deprecate' do
+        find('#cookbook_replacement').set(replacement_cookbook.name)
+        submit_form
+      end
     end
 
-    it 'displays a simple deprecation notice on the cookbook partial' do
+    it 'displays a success message' do
+      expect_to_see_success_message
+    end
+
+    it 'displays a deprecation notice on the cookbook show with the replacment' do
+      expect(page).to have_content(replacement_cookbook.name)
+    end
+
+    it 'displays a deprecation notice on the cookbook partial with link to replacement' do
       visit user_path(cookbook.owner)
 
-      expect(page).to_not have_content(replacement_cookbook.name)
+      expect(page).to have_content(replacement_cookbook.name)
+    end
+
+    context 'when cookbook replacement is deleted' do
+      before do
+        replacement_cookbook.destroy
+      end
+
+      it 'displays a simple deprecation notice on the cookbook show' do
+        visit(current_path)
+
+        expect(page).to_not have_content(replacement_cookbook.name)
+      end
+
+      it 'displays a simple deprecation notice on the cookbook partial' do
+        visit user_path(cookbook.owner)
+
+        expect(page).to_not have_content(replacement_cookbook.name)
+      end
     end
   end
 end

--- a/spec/workers/cookbook_deprecated_notifier_spec.rb
+++ b/spec/workers/cookbook_deprecated_notifier_spec.rb
@@ -8,7 +8,7 @@ describe CookbookDeprecatedNotifier do
     disinterested_user = create(:user)
     disinterested_user.email_preference_for('Cookbook deprecated').destroy
     cookbook = create(:cookbook)
-    cookbook.deprecate(create(:cookbook))
+    cookbook.deprecate(create(:cookbook).name)
     cookbook_collaborator = create(:cookbook_collaborator, resourceable: cookbook)
     cookbook_followers = [
       create(:cookbook_follower, cookbook: cookbook),


### PR DESCRIPTION
* Turn off JS to allow form to be submitted without content in the text
  field
* Turn the requirement for a cookbook->replacement parameter into a permit
  so that form can be submitted without a name
* Move the replacement cookbook lookup into the Cookbook.deprecate method
* Update deprecation messaging to not assume there is a replacement
  cookbook

Closes #1223 