### PR TITLE
Revised the copy of deprecation form and display banners

### DIFF
--- a/app/assets/stylesheets/cookbooks/show.scss
+++ b/app/assets/stylesheets/cookbooks/show.scss
@@ -11,7 +11,10 @@
     border: 4px solid $secondary_yellow;
     display: block;
     margin: rem-calc(0 0 18 0);
-    text-align: center;
+
+    h2 {
+      text-align: center;
+    }
 
     .deprecation-copy {
       color: $secondary-yellow;

--- a/app/views/cookbooks/_main.html.erb
+++ b/app/views/cookbooks/_main.html.erb
@@ -2,12 +2,18 @@
   <% if cookbook.deprecated? %>
     <div class="deprecation-notice">
       <h2 class="deprecation-copy">
-        <% if cookbook.replacement.present? %>
-          <i class="fa fa-exclamation-triangle"></i> <%= cookbook.name %> has been deprecated in favor of <%= link_to cookbook.replacement.name, cookbook.replacement %>
-        <% else %>
-          <i class="fa fa-exclamation-triangle"></i> <%= cookbook.name %> has been deprecated
-        <% end %>
+          <i class="fa fa-exclamation-triangle"></i> The <%= cookbook.name %>
+          cookbook has been deprecated
       </h2>
+      <p class="deprecation-copy">
+        The <%= cookbook.name %> cookbook has been deprecated and is no longer
+        being maintained by its authors.  Use of the <%= cookbook.name %>
+        cookbook is no longer recommended.
+        <% if cookbook.replacement.present? %>
+          You may find that the <%= link_to cookbook.replacement.name, cookbook.replacement %>
+          cookbook is a suitable alternative.
+        <% end %>
+      </p>
     </div>
   <% end %>
 

--- a/app/views/cookbooks/_manage_cookbook.html.erb
+++ b/app/views/cookbooks/_manage_cookbook.html.erb
@@ -51,7 +51,10 @@
     <div id="deprecate" class="reveal-modal small" data-reveal>
       <h1>Deprecate Cookbook</h1>
 
-      <p>You can deprecate your cookbook if you are no longer maintaining it. You are highly encouraged to select a replacement cookbook to recommend a solution you deem more appropriate.</p>
+      <p>Deprecating <%= cookbook.name %> will add a notice to the page letting
+         visitors know <%= cookbook.name %> has been deprecated and its use is no
+         longer recommended.  Optionally, select a cookbook that should be used
+         instead of this one.</p>
 
       <a class="close-reveal-modal">&#215;</a>
 

--- a/app/views/cookbooks/_manage_cookbook.html.erb
+++ b/app/views/cookbooks/_manage_cookbook.html.erb
@@ -51,10 +51,10 @@
     <div id="deprecate" class="reveal-modal small" data-reveal>
       <h1>Deprecate Cookbook</h1>
 
-      <p>Deprecating <%= cookbook.name %> will add a notice to the page letting
-         visitors know <%= cookbook.name %> has been deprecated and its use is no
-         longer recommended.  Optionally, select a cookbook that should be used
-         instead of this one.</p>
+      <p>Deprecating the <%= cookbook.name %> cookbook will add a notice to the
+      page letting visitors know the cookbook has been deprecated and its use is
+      no longer recommended.  Optionally, select a cookbook that should be used
+      instead of this one.</p>
 
       <a class="close-reveal-modal">&#215;</a>
 

--- a/spec/features/cookbook_undeprecation_spec.rb
+++ b/spec/features/cookbook_undeprecation_spec.rb
@@ -15,6 +15,6 @@ feature 'cookbook owners can undeprecate a cookbook' do
   end
 
   it 'it no longer displays a deprecation notice' do
-    expect(page).to have_no_content("#{cookbook.name} has been deprecated")
+    expect(page).to have_no_content("#{cookbook.name} cookbook has been deprecated")
   end
 end


### PR DESCRIPTION
Reads better and doesn't require the cookbook author to say all this in a
README update in a new cookbook release (even though that's still a good
thing to do.)

### modal form for declaring a cookbook is deprecated
<img width="467" alt="screen shot 2016-03-25 at 3 46 08 pm" src="https://cloud.githubusercontent.com/assets/517302/14052441/bb5ff894-f2a0-11e5-9d90-78d8d6fd30ea.png">

### banner for deprecated cookbook without a replacement
<img width="734" alt="screen shot 2016-03-25 at 3 16 46 pm" src="https://cloud.githubusercontent.com/assets/517302/14051924/a8d57c8e-f29c-11e5-9ce0-74400d207291.png">

### banner for deprecated cookbook with a recommended replacement
<img width="736" alt="screen shot 2016-03-25 at 3 10 05 pm" src="https://cloud.githubusercontent.com/assets/517302/14051930/ad319876-f29c-11e5-89d6-c62e32644e79.png">

:wink: