### PR TITLE
Update postrm script to not rm symlinks during upgrade on RHELish systems

### DIFF
--- a/omnibus/package-scripts/supermarket/postrm
+++ b/omnibus/package-scripts/supermarket/postrm
@@ -1,4 +1,9 @@
 #!/bin/sh
+# WARNING: REQUIRES /bin/sh
+# - if you think you are a bash wizard, you probably do not understand
+#   this programming language.  do not touch.
+# - if you are under 40, get peer review from your elders.
+
 cleanup_symlinks() {
   binaries="supermarket-ctl"
   for binary in $binaries; do

--- a/omnibus/package-scripts/supermarket/postrm
+++ b/omnibus/package-scripts/supermarket/postrm
@@ -1,2 +1,18 @@
 #!/bin/sh
-rm -f /usr/bin/supermarket-ctl
+cleanup_symlinks() {
+  binaries="supermarket-ctl"
+  for binary in $binaries; do
+    rm -f /usr/bin/$binary
+  done
+}
+
+# Clean up binary symlinks if they exist
+# see: http://tickets.opscode.com/browse/CHEF-3022
+#    : https://github.com/chef/supermarket/issues/1265
+if [ ! -f /etc/redhat-release -a ! -f /etc/fedora-release -a ! -f /etc/system-release -a ! -f /etc/SuSE-release ]; then
+  # not a redhat-ish RPM-based system
+  cleanup_symlinks
+elif [ "x$1" = "x0" ]; then
+  # RPM-based system and we're deinstalling rather than upgrading
+  cleanup_symlinks
+fi


### PR DESCRIPTION
During an upgrade, RPM runs the old package's post-uninstall script as the
last step. Replicate the solution from the same problem with Chef and Chef
Server (https://tickets.opscode.com/browse/CHEF-3022).

Fixes #1265