### PR TITLE
Add license info to project and software definitions

### DIFF
--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -18,6 +18,9 @@ name "supermarket"
 maintainer "Chef Supermarket Team <supermarket@getchef.com>"
 homepage "https://supermarket.getchef.com"
 
+license "Apache-2.0"
+license_file "../LICENSE"
+
 # Defaults to C:/supermarket on Windows
 # and /opt/supermarket on all other platforms
 install_dir "#{default_root}/#{name}"

--- a/omnibus/config/software/supermarket-cookbooks.rb
+++ b/omnibus/config/software/supermarket-cookbooks.rb
@@ -15,6 +15,7 @@
 #
 
 name "supermarket-cookbooks"
+license :project_license
 
 dependency "berkshelf"
 

--- a/omnibus/config/software/supermarket-ctl.rb
+++ b/omnibus/config/software/supermarket-ctl.rb
@@ -15,6 +15,7 @@
 #
 
 name "supermarket-ctl"
+license :project_license
 
 dependency "omnibus-ctl"
 dependency "chef-gem"

--- a/omnibus/config/software/supermarket.rb
+++ b/omnibus/config/software/supermarket.rb
@@ -15,6 +15,7 @@
 #
 
 name "supermarket"
+license :project_license
 
 source path: File.expand_path('../../../../src/supermarket', project.filepath)
 


### PR DESCRIPTION
Makes the omnibus packager happier to have licensing info for the project.