### PR TITLE
Fix seeds with new location of README

### DIFF
--- a/src/supermarket/db/seeds.rb
+++ b/src/supermarket/db/seeds.rb
@@ -265,7 +265,7 @@ if Rails.env.development?
         description: Faker::Lorem.sentences(1).first,
         license: 'MIT',
         tarball: File.open('spec/support/cookbook_fixtures/redis-test-v1.tgz'),
-        readme: File.read('README.md'),
+        readme: File.read('../../README.md'),
         readme_extension: 'md'
       )
 


### PR DESCRIPTION
The README stayed at the root of the repo, so the seeds file needs the new path to it for faker cookbooks in development.