### PR TITLE
Fieri use with on disk cookbooks

### DIFF
--- a/src/supermarket/app/controllers/cookbook_versions_controller.rb
+++ b/src/supermarket/app/controllers/cookbook_versions_controller.rb
@@ -11,7 +11,7 @@ class CookbookVersionsController < ApplicationController
     Cookbook.increment_counter(:web_download_count, @cookbook.id)
     Supermarket::Metrics.increment('cookbook.downloads.web')
 
-    redirect_to cookbook_url
+    redirect_to @version.cookbook_artifact_url
   end
 
   #
@@ -32,13 +32,5 @@ class CookbookVersionsController < ApplicationController
   def set_cookbook_and_version
     @cookbook = Cookbook.with_name(params[:cookbook_id]).first!
     @version = @cookbook.get_version!(params[:version])
-  end
-
-  def cookbook_url
-    if ENV['S3_URLS_EXPIRE'].present?
-      @version.tarball.expiring_url(ENV['S3_URLS_EXPIRE'])
-    else
-      @version.tarball.url
-    end
   end
 end

--- a/src/supermarket/app/models/cookbook_version.rb
+++ b/src/supermarket/app/models/cookbook_version.rb
@@ -73,7 +73,7 @@ class CookbookVersion < ActiveRecord::Base
   end
 
   def cookbook_artifact_url
-    if s3_configured?
+    if Paperclip::Attachment.default_options[:storage] == 's3'
       tarball.url
     else
       "#{Supermarket::Host.full_url}#{tarball.url}"
@@ -91,12 +91,6 @@ class CookbookVersion < ActiveRecord::Base
       Semverse::Version.new(version)
     rescue Semverse::InvalidVersionFormat
       errors.add(:version, 'is formatted incorrectly')
-    end
-  end
-
-  def s3_configured?
-    %w(S3_BUCKET S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY).all? do |key|
-      ENV[key].present?
     end
   end
 end

--- a/src/supermarket/app/models/cookbook_version.rb
+++ b/src/supermarket/app/models/cookbook_version.rb
@@ -72,6 +72,14 @@ class CookbookVersion < ActiveRecord::Base
     CookbookVersionPlatform.create! supported_platform: platform, cookbook_version: self
   end
 
+  def cookbook_artifact_url
+    if s3_configured?
+      tarball.url
+    else
+      "#{Supermarket::Host.full_url}#{tarball.url}"
+    end
+  end
+
   private
 
   #
@@ -83,6 +91,12 @@ class CookbookVersion < ActiveRecord::Base
       Semverse::Version.new(version)
     rescue Semverse::InvalidVersionFormat
       errors.add(:version, 'is formatted incorrectly')
+    end
+  end
+
+  def s3_configured?
+    %w(S3_BUCKET S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY).all? do |key|
+      ENV[key].present?
     end
   end
 end

--- a/src/supermarket/app/models/cookbook_version.rb
+++ b/src/supermarket/app/models/cookbook_version.rb
@@ -74,7 +74,7 @@ class CookbookVersion < ActiveRecord::Base
 
   def cookbook_artifact_url
     if Paperclip::Attachment.default_options[:storage] == 's3'
-      tarball.url
+      ENV['S3_URLS_EXPIRE'].present? ? tarball.expiring_url(ENV['S3_URLS_EXPIRE']) : tarball.url
     else
       "#{Supermarket::Host.full_url}#{tarball.url}"
     end

--- a/src/supermarket/app/workers/fieri_notify_worker.rb
+++ b/src/supermarket/app/workers/fieri_notify_worker.rb
@@ -21,23 +21,9 @@ class FieriNotifyWorker
     data = {
       'cookbook_name' => cookbook_version.name,
       'cookbook_version' => cookbook_version.version,
-      'cookbook_artifact_url' => cookbook_artifact_url(cookbook_version)
+      'cookbook_artifact_url' => cookbook_version.cookbook_artifact_url
     }
 
     response = Net::HTTP.post_form(uri, data)
-  end
-
- def cookbook_artifact_url(cookbook_version)
-    if s3_configured?
-      cookbook_version.tarball.url
-    else
-      "#{Supermarket::Host.full_url}#{cookbook_version.tarball.url}"
-    end
-  end
-
-  def s3_configured?
-    %w(S3_BUCKET S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY).all? do |key|
-      ENV[key].present?
-    end
   end
 end

--- a/src/supermarket/app/workers/fieri_notify_worker.rb
+++ b/src/supermarket/app/workers/fieri_notify_worker.rb
@@ -21,9 +21,23 @@ class FieriNotifyWorker
     data = {
       'cookbook_name' => cookbook_version.name,
       'cookbook_version' => cookbook_version.version,
-      'cookbook_artifact_url' => cookbook_version.tarball.url
+      'cookbook_artifact_url' => cookbook_artifact_url(cookbook_version)
     }
 
     response = Net::HTTP.post_form(uri, data)
+  end
+
+ def cookbook_artifact_url(cookbook_version)
+    if s3_configured?
+      cookbook_version.tarball.url
+    else
+      "#{Supermarket::Host.full_url}#{cookbook_version.tarball.url}"
+    end
+  end
+
+  def s3_configured?
+    %w(S3_BUCKET S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY).all? do |key|
+      ENV[key].present?
+    end
   end
 end

--- a/src/supermarket/config/routes.rb
+++ b/src/supermarket/config/routes.rb
@@ -20,7 +20,12 @@ Supermarket::Application.routes.draw do
       delete 'cookbooks/:cookbook' => 'cookbook_uploads#destroy'
       delete 'cookbooks/:cookbook/versions/:version' => 'cookbook_uploads#destroy_version', constraints: { version: VERSION_PATTERN }
       get 'users/:user' => 'users#show', as: :user
-      post '/cookbook-verisons/evaluation' => 'cookbook_versions#evaluation', as: :cookbook_versions_evaluation, constraints: proc { ROLLOUT.active?(:fieri) }
+
+      # This was the original route, which has a misspelling (cookbook-verisons rather than cookbook-versions).  Keeping this here so as not to break anyone who is still depending on the original route.
+      post '/cookbook-verisons/evaluation' => 'cookbook_versions#evaluation', constraints: proc { ROLLOUT.active?(:fieri) }
+
+      # This route has the correct spelling of cookbook-versions
+      post '/cookbook-versions/evaluation' => 'cookbook_versions#evaluation', as: :cookbook_versions_evaluation, constraints: proc { ROLLOUT.active?(:fieri) }
 
       get 'tools/:tool' => 'tools#show', as: :tool
       get 'tools' => 'tools#index', as: :tools

--- a/src/supermarket/spec/api/cookbook_evaluation_results_spec.rb
+++ b/src/supermarket/spec/api/cookbook_evaluation_results_spec.rb
@@ -4,16 +4,34 @@ describe 'POST /api/v1/cookbook_evalution_results' do
   let(:cookbook) { create(:cookbook) }
   let(:cookbook_version) { create(:cookbook_version, cookbook: cookbook) }
 
-  it 'returns a 200' do
-    post(
-      '/api/v1/cookbook-verisons/evaluation',
-      cookbook_name: cookbook.name,
-      cookbook_version: cookbook_version.version,
-      foodcritic_failure: false,
-      foodcritic_feedback: nil,
-      fieri_key: 'YOUR_FIERI_KEY'
-    )
+  context 'with the original mispelling' do
+    # The original route was mispelled as cookbook-verisons, rather than cookbook-versions
+    it 'returns a 200' do
+      post(
+        '/api/v1/cookbook-verisons/evaluation',
+        cookbook_name: cookbook.name,
+        cookbook_version: cookbook_version.version,
+        foodcritic_failure: false,
+        foodcritic_feedback: nil,
+        fieri_key: 'YOUR_FIERI_KEY'
+      )
 
-    expect(response.status.to_i).to eql(200)
+      expect(response.status.to_i).to eql(200)
+    end
+  end
+
+  context 'with the correct spelling' do
+    it 'returns a 200' do
+      post(
+        '/api/v1/cookbook-versions/evaluation',
+        cookbook_name: cookbook.name,
+        cookbook_version: cookbook_version.version,
+        foodcritic_failure: false,
+        foodcritic_feedback: nil,
+        fieri_key: 'YOUR_FIERI_KEY'
+      )
+
+      expect(response.status.to_i).to eql(200)
+    end
   end
 end

--- a/src/supermarket/spec/controllers/cookbook_versions_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbook_versions_controller_spec.rb
@@ -10,7 +10,7 @@ describe CookbookVersionsController do
     it '302s to the latest cookbook version file' do
       get :download, cookbook_id: cookbook.name, version: version.to_param
 
-      expect(response).to redirect_to(version.tarball.url)
+      expect(response).to redirect_to(version.cookbook_artifact_url)
       expect(response.status.to_i).to eql(302)
     end
 
@@ -45,34 +45,11 @@ describe CookbookVersionsController do
         allow(Cookbook).to receive_message_chain(:with_name, :first!).and_return(cookbook)
         allow(cookbook).to receive(:get_version!).and_return(version)
         allow(version).to receive(:tarball).and_return(mock_tarball)
-
       end
 
-      context 'when using expiring urls' do
-        before do
-          ENV['S3_URLS_EXPIRE'] = '10'
-        end
-
-        it 'redirects to the expiring url' do
-          expect(version.tarball).to receive(:expiring_url)
-            .with(ENV['S3_URLS_EXPIRE'])
-            .and_return(version.tarball.expiring_url(ENV['S3_URLS_EXPIRE']))
-
-          get :download, cookbook_id: cookbook.name, version: version.to_param
-        end
-
-        after do
-          ENV['S3_URLS_EXPIRE'] = nil
-        end
-      end
-
-      context 'when not using expiring urls' do
-        it 'redirects to the regular url for the cookbook' do
-          expect(mock_tarball).to_not receive(:expiring_url)
-          expect(mock_tarball).to receive(:url).and_return(version.tarball.url)
-
-          get :download, cookbook_id: cookbook.name, version: version.to_param
-        end
+      it 'calls for the artifact url' do
+        expect(version).to receive(:cookbook_artifact_url).and_return(version.cookbook_artifact_url)
+        get :download, cookbook_id: cookbook.name, version: version.to_param
       end
     end
   end

--- a/src/supermarket/spec/models/cookbook_version_spec.rb
+++ b/src/supermarket/spec/models/cookbook_version_spec.rb
@@ -97,7 +97,11 @@ describe CookbookVersion do
       allow(CookbookVersion).to receive(:find).and_return(version)
     end
 
-    context 'when using S3 for cookbook storage' do
+    context 'when using the filesystem for cookbook storage' do
+      before do
+        expect(Paperclip::Attachment.default_options[:storage]).to eq(:filesystem)
+      end
+
       it 'includes the correct cookbook artifact url' do
         expect(version.cookbook_artifact_url).to eq("#{Supermarket::Host.full_url}#{version.tarball.url.to_s}")
       end
@@ -105,9 +109,7 @@ describe CookbookVersion do
 
     context 'when using S3 for cookbook storage' do
       before do
-        ENV['S3_BUCKET'] = 'mybucket'
-        ENV['S3_ACCESS_KEY_ID'] = '123'
-        ENV['S3_SECRET_ACCESS_KEY'] = '456'
+        Paperclip::Attachment.default_options[:storage] = 's3'
 
         # Paths for cookbooks are configured in config/initializers/paperclip.rb
         # These variables are set to simulate cookbooks which are configured to

--- a/src/supermarket/spec/models/cookbook_version_spec.rb
+++ b/src/supermarket/spec/models/cookbook_version_spec.rb
@@ -88,4 +88,42 @@ describe CookbookVersion do
       expect(cookbook_version.download_count).to eql(11)
     end
   end
+
+  context '#artifact_url' do
+    let(:cookbook) { create(:cookbook) }
+    let(:version) { create(:cookbook_version, cookbook: cookbook) }
+
+    before do
+      allow(CookbookVersion).to receive(:find).and_return(version)
+    end
+
+    context 'when using S3 for cookbook storage' do
+      it 'includes the correct cookbook artifact url' do
+        expect(version.cookbook_artifact_url).to eq("#{Supermarket::Host.full_url}#{version.tarball.url.to_s}")
+      end
+    end
+
+    context 'when using S3 for cookbook storage' do
+      before do
+        ENV['S3_BUCKET'] = 'mybucket'
+        ENV['S3_ACCESS_KEY_ID'] = '123'
+        ENV['S3_SECRET_ACCESS_KEY'] = '456'
+
+        # Paths for cookbooks are configured in config/initializers/paperclip.rb
+        # These variables are set to simulate cookbooks which are configured to
+        # be stored on S3
+        default_s3_url = "https://s3.amazonaws.com/"
+        s3_path = version.tarball.url.sub(%r{^/system}, '') # S3 cookbook paths do not have /system at the beginning of them
+
+        s3_tarball_url = "#{default_s3_url}#{ENV['S3_BUCKET']}#{s3_path}"
+
+        allow(version).to receive_message_chain(:tarball, :url).and_return(s3_tarball_url)
+      end
+
+      it 'includes the correct cookbook artifact url' do
+        expect(version.cookbook_artifact_url).to include('https://s3.amazonaws.com')
+        expect(version.cookbook_artifact_url).to eq(version.tarball.url.to_s)
+      end
+    end
+  end
 end

--- a/src/supermarket/spec/models/cookbook_version_spec.rb
+++ b/src/supermarket/spec/models/cookbook_version_spec.rb
@@ -109,7 +109,7 @@ describe CookbookVersion do
 
     context 'when using S3 for cookbook storage' do
       before do
-        Paperclip::Attachment.default_options[:storage] = 's3'
+        allow(Paperclip::Attachment).to receive(:default_options).and_return(storage: 's3')
 
         # Paths for cookbooks are configured in config/initializers/paperclip.rb
         # These variables are set to simulate cookbooks which are configured to

--- a/src/supermarket/spec/models/cookbook_version_spec.rb
+++ b/src/supermarket/spec/models/cookbook_version_spec.rb
@@ -126,6 +126,19 @@ describe CookbookVersion do
         expect(version.cookbook_artifact_url).to include('https://s3.amazonaws.com')
         expect(version.cookbook_artifact_url).to eq(version.tarball.url.to_s)
       end
+
+      context 'when the Supermarket is set to use expiring URLs' do
+        before do
+          ENV['S3_URLS_EXPIRE'] = '10'
+        end
+
+        it 'includes the expiration' do
+          expect(version.tarball).to receive(:expiring_url)
+            .with(ENV['S3_URLS_EXPIRE'])
+
+          version.cookbook_artifact_url
+        end
+      end
     end
   end
 end

--- a/src/supermarket/spec/models/cookbook_version_spec.rb
+++ b/src/supermarket/spec/models/cookbook_version_spec.rb
@@ -103,7 +103,7 @@ describe CookbookVersion do
       end
 
       it 'includes the correct cookbook artifact url' do
-        expect(version.cookbook_artifact_url).to eq("#{Supermarket::Host.full_url}#{version.tarball.url.to_s}")
+        expect(version.cookbook_artifact_url).to eq("#{Supermarket::Host.full_url}#{version.tarball.url}")
       end
     end
 

--- a/src/supermarket/spec/workers/fieri_notify_worker_spec.rb
+++ b/src/supermarket/spec/workers/fieri_notify_worker_spec.rb
@@ -13,7 +13,6 @@ describe FieriNotifyWorker do
     expect(result.class).to eql(Net::HTTPOK)
   end
 
-
   context 'setting the correct cookbook artifact url' do
     let(:version) { create(:cookbook_version, cookbook: cookbook) }
 

--- a/src/supermarket/spec/workers/fieri_notify_worker_spec.rb
+++ b/src/supermarket/spec/workers/fieri_notify_worker_spec.rb
@@ -12,4 +12,50 @@ describe FieriNotifyWorker do
 
     expect(result.class).to eql(Net::HTTPOK)
   end
+
+
+  context 'setting the correct cookbook artifact url' do
+    let(:version) { create(:cookbook_version, cookbook: cookbook) }
+
+    before do
+      allow(CookbookVersion).to receive(:find).and_return(version)
+    end
+
+    context 'when not using S3 for cookbook storage' do
+      before do
+        ENV['S3_BUCKET'] = nil
+      end
+
+      it 'includes the correct cookbook artifact url' do
+        expect(Net::HTTP).to receive(:post_form).with(anything, hash_including("cookbook_artifact_url" => "#{Supermarket::Host.full_url}#{version.tarball.url}"))
+
+        worker = FieriNotifyWorker.new
+        worker.perform(version.id)
+      end
+    end
+
+    context 'when using S3 for cookbook storage' do
+      before do
+        ENV['S3_BUCKET'] = 'mybucket'
+        ENV['S3_ACCESS_KEY_ID'] = '123'
+        ENV['S3_SECRET_ACCESS_KEY'] = '456'
+
+        # Paths for cookbooks are configured in config/initializers/paperclip.rb
+        # These variables are set to simulate cookbooks which are configured to
+        # be stored on S3
+        default_s3_url = "https://s3.amazonaws.com/"
+        s3_path = version.tarball.url.sub(%r{^/system}, '') # S3 cookbook paths do not have /system at the beginning of them
+
+        s3_tarball_url = "#{default_s3_url}#{ENV['S3_BUCKET']}#{s3_path}"
+
+        allow(version).to receive_message_chain(:tarball, :url).and_return(s3_tarball_url)
+      end
+
+      it 'includes the correct cookbook artifact url' do
+        expect(Net::HTTP).to receive(:post_form).with(anything, hash_including("cookbook_artifact_url" => version.tarball.url.to_s))
+        worker = FieriNotifyWorker.new
+        worker.perform(version.id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This alters the cookbook_version.tarball.url to point to the correct location when a Supermarket is storing its cookbook on disc.

This also corrects a typo in one of our routes "cookbook_verisons" (switched i and s) is now "cookbook_versions."  I have left the old route in with a note in case anyone is still using it.  I have verified that both urls work with a live Private Supermarket and Fieri instance.