### PR TITLE
Use rb-readline gem to fix the Rails console

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/console.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/console.rb
@@ -1,5 +1,5 @@
 add_command 'console', 'Enter the rails console for Supermarket', 1 do
-  cmd = "cd /opt/supermarket/embedded/service/supermarket && sudo -u supermarket env PATH=/opt/supermarket/embedded/bin bin/rails console production"
+  cmd = "cd /opt/supermarket/embedded/service/supermarket && sudo -u supermarket env PATH=/opt/supermarket/embedded/bin:$PATH bin/rails console production"
   exec cmd
   true
 end

--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -19,6 +19,7 @@ gem 'dotenv'
 gem 'octokit', require: false
 gem 'sidekiq', '= 3.4.2' # pinned to version prior to celluloid upgrade that breaks sidetiq
 gem 'tomlrb'
+gem 'rb-readline'
 
 # Pin sprockets to ensure we get the latest security patches. Not pinning this
 # meant that the gem that depended on sprockets was pulling in an old

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -336,6 +336,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    rb-readline (0.5.3)
     redcarpet (3.3.2)
     redis (3.2.1)
     redis-actionpack (4.0.0)
@@ -525,6 +526,7 @@ DEPENDENCIES
   pundit
   quiet_assets
   rails (~> 4.1.14)
+  rb-readline
   redcarpet
   redis-rails
   rinku


### PR DESCRIPTION
We upgraded omnibus-software to a version whose Ruby no longer had readline
compiled within. This adds the rb-readline gem to provide the same functionality
with only Ruby and UNIX commands.

Needed to update the PATH in the -ctl console command so that utilities like
stty required by rb-readline would be available.

Fixes #1271