### PR TITLE
adds ubuntu 12.04 to the list of kitchens

### DIFF
--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -14,6 +14,8 @@ provisioner:
 platforms:
   - name: ubuntu-10.04
     run_list: apt::default
+  - name: ubuntu-12.04
+    run_list: apt::default
   - name: centos-5.11
     run_list: yum-epel::default
   - name: centos-6.7


### PR DESCRIPTION
I've been manually adding Ubuntu 12.04 to the .kitchen.yml and see no reason not to include it in the .kitchen.yml stored in source code