### PR TITLE
Updates for publishing licensing information

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,18 +1,19 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: e8124b356fed937a6e646cdd194f9eaa06f325e6
+  revision: c9df1d71eb8c70010d27a121c9021988b8886e9d
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.2.0)
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 961695bbc1b29a4d006a2ddae93ad48b9827f074
+  revision: a83ee04eff7f9d6b609d1ac9c300d3c714513a43
   specs:
-    omnibus (5.3.0)
+    omnibus (5.4.0)
       aws-sdk (~> 2)
       chef-sugar (~> 3.3)
       cleanroom (~> 1.0)
+      ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.0)
       mixlib-versioning
       ohai (~> 8.0)
@@ -23,12 +24,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    aws-sdk (2.2.31)
-      aws-sdk-resources (= 2.2.31)
-    aws-sdk-core (2.2.31)
+    aws-sdk (2.2.34)
+      aws-sdk-resources (= 2.2.34)
+    aws-sdk-core (2.2.34)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.31)
-      aws-sdk-core (= 2.2.31)
+    aws-sdk-resources (2.2.34)
+      aws-sdk-core (= 2.2.34)
     berkshelf (3.3.0)
       addressable (~> 2.3.4)
       berkshelf-api-client (~> 1.2)
@@ -62,7 +63,8 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.8.1)
+    chef-config (12.9.38)
+      fuzzyurl (~> 0.8.0)
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
     chef-sugar (3.3.0)
@@ -77,12 +79,15 @@ GEM
     ffi (1.9.10)
     ffi-yajl (2.2.3)
       libyajl2 (~> 1.2)
+    fuzzyurl (0.8.0)
     hashie (3.4.3)
     hitimes (1.2.3)
     httpclient (2.6.0.1)
     ipaddress (0.8.3)
-    jmespath (1.1.3)
+    jmespath (1.2.4)
+      json_pure (>= 1.8.1)
     json (1.8.3)
+    json_pure (1.8.3)
     kitchen-vagrant (0.19.0)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
@@ -101,7 +106,7 @@ GEM
     nio4r (1.2.0)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    ohai (8.13.0)
+    ohai (8.15.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -165,3 +170,6 @@ DEPENDENCIES
   omnibus!
   omnibus-software!
   test-kitchen (~> 1.2)
+
+BUNDLED WITH
+   1.11.2

--- a/omnibus/config/software/supermarket-cookbooks.rb
+++ b/omnibus/config/software/supermarket-cookbooks.rb
@@ -29,11 +29,11 @@ build do
 
   block do
     open("#{cookbooks_path}/dna.json", "w") do |file|
-      file.write JSON.fast_generate(run_list: ['recipe[omnibus-supermarket::default]'])
+      file.write FFI_Yajl::Encoder.encode(run_list: ['recipe[omnibus-supermarket::default]'])
     end
 
     open("#{cookbooks_path}/show-config.json", "w") do |file|
-      file.write JSON.fast_generate(
+      file.write FFI_Yajl::Encoder.encode(
         run_list: ['recipe[omnibus-supermarket::show_config]']
       )
     end


### PR DESCRIPTION
This PR picks up the latest version of omnibus and omnibus-software which contains the required license information and the logic to publish this information to artifactory. After this change our download pages will be able to be updated to display the project specific license for supermarket.

/cc: @chef/engineering-services @chef/supermarket