### PR TITLE
"Recently Updated" cookbooks list now refers to list of recently shipped new versions

### DIFF
--- a/src/supermarket/app/controllers/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/cookbooks_controller.rb
@@ -54,9 +54,8 @@ class CookbooksController < ApplicationController
   # Return the three most recently updated and created cookbooks.
   #
   def directory
-    @recently_updated_cookbook_versions = Cookbook.
-      includes(:cookbook_versions).
-      ordered_by('recently_updated').
+    @recently_updated_cookbook_versions = CookbookVersion.
+      order('created_at DESC').
       limit(5)
     @most_downloaded_cookbooks = Cookbook.
       includes(:cookbook_versions).

--- a/src/supermarket/app/controllers/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/cookbooks_controller.rb
@@ -55,7 +55,8 @@ class CookbooksController < ApplicationController
   #
   def directory
     @recently_updated_cookbooks = Cookbook.
-      order_by_latest_upload_date(limit: 5)
+      order_by_latest_upload_date.
+      limit(5)
     @most_downloaded_cookbooks = Cookbook.
       includes(:cookbook_versions).
       ordered_by('most_downloaded').

--- a/src/supermarket/app/controllers/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/cookbooks_controller.rb
@@ -54,17 +54,10 @@ class CookbooksController < ApplicationController
   # Return the three most recently updated and created cookbooks.
   #
   def directory
-    recently_updated_cookbook_ids = CookbookVersion.
-      order('created_at DESC').
-      pluck(:cookbook_id).
-      uniq.
-      take(5)
-
-    @recently_updated_cookbooks = []
-
-    recently_updated_cookbook_ids.each do |id|
-      @recently_updated_cookbooks << Cookbook.find(id)
-    end
+    @recently_updated_cookbooks = Cookbook.
+      includes(:cookbook_versions).
+      order('cookbook_versions.created_at DESC').
+      limit(10)
 
     @most_downloaded_cookbooks = Cookbook.
       includes(:cookbook_versions).

--- a/src/supermarket/app/controllers/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/cookbooks_controller.rb
@@ -55,10 +55,7 @@ class CookbooksController < ApplicationController
   #
   def directory
     @recently_updated_cookbooks = Cookbook.
-      includes(:cookbook_versions).
-      order('cookbook_versions.created_at DESC').
-      limit(10)
-
+      order_by_latest_upload_date(limit: 5)
     @most_downloaded_cookbooks = Cookbook.
       includes(:cookbook_versions).
       ordered_by('most_downloaded').

--- a/src/supermarket/app/controllers/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/cookbooks_controller.rb
@@ -54,7 +54,7 @@ class CookbooksController < ApplicationController
   # Return the three most recently updated and created cookbooks.
   #
   def directory
-    @recently_updated_cookbooks = Cookbook.
+    @recently_updated_cookbook_versions = Cookbook.
       includes(:cookbook_versions).
       ordered_by('recently_updated').
       limit(5)

--- a/src/supermarket/app/controllers/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/cookbooks_controller.rb
@@ -54,9 +54,18 @@ class CookbooksController < ApplicationController
   # Return the three most recently updated and created cookbooks.
   #
   def directory
-    @recently_updated_cookbook_versions = CookbookVersion.
+    recently_updated_cookbook_ids = CookbookVersion.
       order('created_at DESC').
-      limit(5)
+      pluck(:cookbook_id).
+      uniq.
+      take(5)
+
+    @recently_updated_cookbooks = []
+
+    recently_updated_cookbook_ids.each do |id|
+      @recently_updated_cookbooks << Cookbook.find(id)
+    end
+
     @most_downloaded_cookbooks = Cookbook.
       includes(:cookbook_versions).
       ordered_by('most_downloaded').

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -32,7 +32,7 @@ class Cookbook < ActiveRecord::Base
     }.fetch(ordering, 'name ASC'))
   }
 
-  scope :order_by_latest_upload_date, lambda { |opts = {}|
+  scope :order_by_latest_upload_date, -> {
     joins(:cookbook_versions)
     .select('cookbooks.*', 'MAX(cookbook_versions.created_at) AS latest_upload')
     .group('cookbooks.id')

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -32,7 +32,7 @@ class Cookbook < ActiveRecord::Base
     }.fetch(ordering, 'name ASC'))
   }
 
-  scope :order_by_latest_upload_date, -> {
+  scope :order_by_latest_upload_date, lambda {
     joins(:cookbook_versions)
     .select('cookbooks.*', 'MAX(cookbook_versions.created_at) AS latest_upload')
     .group('cookbooks.id')

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -32,6 +32,13 @@ class Cookbook < ActiveRecord::Base
     }.fetch(ordering, 'name ASC'))
   }
 
+  scope :order_by_latest_upload_date, lambda { |opts = {}|
+    joins(:cookbook_versions)
+    .select('cookbooks.*', 'MAX(cookbook_versions.created_at) AS latest_upload')
+    .group('cookbooks.id')
+    .order('latest_upload DESC')
+  }
+
   scope :owned_by, lambda { |username|
     joins(owner: :chef_account).where('accounts.username = ?', username)
   }

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -327,6 +327,14 @@ describe CookbooksController do
       )
     end
 
+    let(:cookbook2_versionB) do
+      create(
+        :cookbook_version,
+        cookbook: cookbook_2,
+        created_at: Time.now
+      )
+    end
+
     before do
       CookbookVersion.destroy_all
     end
@@ -343,6 +351,16 @@ describe CookbooksController do
 
       expect(assigns[:recently_updated_cookbook_versions].first).to eq(cookbook2_versionA)
       expect(assigns[:recently_updated_cookbook_versions].last).to eq(cookbook1_versionA)
+    end
+
+    it "returns unique cookbooks when ordered by @recently_updated_cookbook_versions" do 
+      cookbook1_versionA
+      cookbook2_versionA
+      cookbook2_versionB
+      get(:directory)
+      
+      expect(assigns[:recently_updated_cookbook_versions]).to include(cookbook1_versionA)
+      expect(assigns[:recently_updated_cookbook_versions].count).to eq 2
     end
 
     it 'assigns @most_downloaded_cookbooks' do

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -339,28 +339,28 @@ describe CookbooksController do
       CookbookVersion.destroy_all
     end
 
-    it 'assigns @recently_updated_cookbook_versions' do
+    it 'assigns @recently_updated_cookbook' do
       get(:directory)
-      expect(assigns[:recently_updated_cookbook_versions]).to_not be_nil
+      expect(assigns[:recently_updated_cookbooks]).to_not be_nil
     end
 
-    it 'orders cookbooks by @recently_updated_cookbook_versions' do 
+    it 'orders cookbooks by @recently_updated_cookbooks' do 
       cookbook1_versionA
       cookbook2_versionA
       get(:directory)
 
-      expect(assigns[:recently_updated_cookbook_versions].first).to eq(cookbook2_versionA)
-      expect(assigns[:recently_updated_cookbook_versions].last).to eq(cookbook1_versionA)
+      expect(assigns[:recently_updated_cookbooks].first).to eq(cookbook_2)
+      expect(assigns[:recently_updated_cookbooks].last).to eq(cookbook_1)
     end
 
-    it "returns unique cookbooks when ordered by @recently_updated_cookbook_versions" do 
+    it "returns unique cookbooks when ordered by @recently_updated_cookbooks" do 
       cookbook1_versionA
       cookbook2_versionA
       cookbook2_versionB
       get(:directory)
-      
-      expect(assigns[:recently_updated_cookbook_versions]).to include(cookbook1_versionA)
-      expect(assigns[:recently_updated_cookbook_versions].count).to eq 2
+
+      expect(assigns[:recently_updated_cookbooks]).to include(cookbook_1)
+      expect(assigns[:recently_updated_cookbooks].count).to eq 2
     end
 
     it 'assigns @most_downloaded_cookbooks' do

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -360,7 +360,7 @@ describe CookbooksController do
       get(:directory)
 
       expect(assigns[:recently_updated_cookbooks]).to include(cookbook_1)
-      expect(assigns[:recently_updated_cookbooks].count).to eq 2
+      expect(assigns[:recently_updated_cookbooks].length).to eq 2
     end
 
     it 'assigns @most_downloaded_cookbooks' do

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -311,7 +311,7 @@ describe CookbooksController do
       )
     end
 
-    let(:cookbook1_versionA) do 
+    let(:cookbook1_versionA) do
       create(
         :cookbook_version,
         cookbook: cookbook_1,

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -291,8 +291,8 @@ describe CookbooksController do
   describe 'GET #directory' do
     before { get :directory }
 
-    it 'assigns @recently_updated_cookbooks' do
-      expect(assigns[:recently_updated_cookbooks]).to_not be_nil
+    it 'assigns @recently_updated_cookbook_versions' do
+      expect(assigns[:recently_updated_cookbook_versions]).to_not be_nil
     end
 
     it 'assigns @most_downloaded_cookbooks' do

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -296,7 +296,7 @@ describe CookbooksController do
         web_download_count: 1,
         api_download_count: 100,
         cookbook_followers_count: 100,
-        updated_at: Time.now
+        updated_at: Time.zone.now
       )
     end
 
@@ -307,7 +307,7 @@ describe CookbooksController do
         web_download_count: 1,
         api_download_count: 50,
         cookbook_followers_count: 50,
-        updated_at: Time.now - 2.days
+        updated_at: Time.zone.now - 2.days
       )
     end
 
@@ -315,7 +315,7 @@ describe CookbooksController do
       create(
         :cookbook_version,
         cookbook: cookbook_1,
-        created_at: Time.now - 1.day
+        created_at: Time.zone.now - 1.day
       )
     end
 
@@ -323,7 +323,7 @@ describe CookbooksController do
       create(
         :cookbook_version,
         cookbook: cookbook_2,
-        created_at: Time.now
+        created_at: Time.zone.now
       )
     end
 
@@ -331,7 +331,7 @@ describe CookbooksController do
       create(
         :cookbook_version,
         cookbook: cookbook_2,
-        created_at: Time.now
+        created_at: Time.zone.now
       )
     end
 
@@ -344,7 +344,7 @@ describe CookbooksController do
       expect(assigns[:recently_updated_cookbooks]).to_not be_nil
     end
 
-    it 'orders cookbooks by @recently_updated_cookbooks' do 
+    it 'orders cookbooks by @recently_updated_cookbooks' do
       cookbook1_versionA
       cookbook2_versionA
       get(:directory)
@@ -353,7 +353,7 @@ describe CookbooksController do
       expect(assigns[:recently_updated_cookbooks].last).to eq(cookbook_1)
     end
 
-    it "returns unique cookbooks when ordered by @recently_updated_cookbooks" do 
+    it "returns unique cookbooks when ordered by @recently_updated_cookbooks" do
       cookbook1_versionA
       cookbook2_versionA
       cookbook2_versionB

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -311,7 +311,7 @@ describe CookbooksController do
       )
     end
 
-    let!(:cookbook1_versionA) do 
+    let(:cookbook1_versionA) do 
       create(
         :cookbook_version,
         cookbook: cookbook_1,
@@ -319,7 +319,7 @@ describe CookbooksController do
       )
     end
 
-    let!(:cookbook2_versionA) do
+    let(:cookbook2_versionA) do
       create(
         :cookbook_version,
         cookbook: cookbook_2,
@@ -327,34 +327,46 @@ describe CookbooksController do
       )
     end
 
-    before { get :directory }
+    before do
+      CookbookVersion.destroy_all
+    end
 
     it 'assigns @recently_updated_cookbook_versions' do
+      get(:directory)
       expect(assigns[:recently_updated_cookbook_versions]).to_not be_nil
     end
 
     it 'orders cookbooks by @recently_updated_cookbook_versions' do 
+      cookbook1_versionA
+      cookbook2_versionA
+      get(:directory)
+
       expect(assigns[:recently_updated_cookbook_versions].first).to eq(cookbook2_versionA)
       expect(assigns[:recently_updated_cookbook_versions].last).to eq(cookbook1_versionA)
     end
 
     it 'assigns @most_downloaded_cookbooks' do
+      get(:directory)
       expect(assigns[:most_downloaded_cookbooks]).to_not be_nil
     end
 
     it 'assigns @most_followed_cookbooks' do
+      get(:directory)
       expect(assigns[:most_followed_cookbooks]).to_not be_nil
     end
 
     it 'assigns @featured_cookbooks' do
+      get(:directory)
       expect(assigns[:featured_cookbooks]).to_not be_nil
     end
 
     it 'sends cookbook count to the view' do
+      get(:directory)
       expect(assigns[:cookbook_count]).to_not be_nil
     end
 
     it 'sends user count to the view' do
+      get(:directory)
       expect(assigns[:user_count]).to_not be_nil
     end
   end

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -289,10 +289,53 @@ describe CookbooksController do
   end
 
   describe 'GET #directory' do
+    let!(:cookbook_1) do
+      create(
+        :cookbook,
+        name: 'mysql',
+        web_download_count: 1,
+        api_download_count: 100,
+        cookbook_followers_count: 100,
+        updated_at: Time.now
+      )
+    end
+
+    let!(:cookbook_2) do
+      create(
+        :cookbook,
+        name: 'mysql-admin-tools',
+        web_download_count: 1,
+        api_download_count: 50,
+        cookbook_followers_count: 50,
+        updated_at: Time.now - 2.days
+      )
+    end
+
+    let!(:cookbook1_versionA) do 
+      create(
+        :cookbook_version,
+        cookbook: cookbook_1,
+        created_at: Time.now - 1.day
+      )
+    end
+
+    let!(:cookbook2_versionA) do
+      create(
+        :cookbook_version,
+        cookbook: cookbook_2,
+        created_at: Time.now
+      )
+    end
+
     before { get :directory }
 
     it 'assigns @recently_updated_cookbook_versions' do
       expect(assigns[:recently_updated_cookbook_versions]).to_not be_nil
+    end
+
+    it 'orders cookbooks by @recently_updated_cookbook_versions' do 
+      expect(assigns[:recently_updated_cookbook_versions].first).to eq(cookbook2_versionA)
+      expect(assigns[:recently_updated_cookbook_versions].last).to eq(cookbook1_versionA)
     end
 
     it 'assigns @most_downloaded_cookbooks' do


### PR DESCRIPTION
Rather than any change in the cookbook itself. 

Fixes #1244