### PR TITLE
Fix JS specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ notifications:
 rvm:
 - 2.1.8
 script:
-- cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake spec:all
+- cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake spec:travis
 services:
   - redis-server
   - postgresql

--- a/src/supermarket/lib/tasks/spec/all.rake
+++ b/src/supermarket/lib/tasks/spec/all.rake
@@ -7,6 +7,9 @@ namespace :spec do
     fail unless system 'bundle exec bundle-audit check --update'
   end
 
+  desc 'Tests to run in Travis'
+  task travis: [:spec, :rubocop, :bundle_audit]
+
   desc 'Run RSpec tests and rubocop'
   task all: [:spec, :javascripts, :rubocop, :bundle_audit]
 end

--- a/src/supermarket/package.json
+++ b/src/supermarket/package.json
@@ -2,11 +2,13 @@
   "name": "supermarket",
   "devDependencies": {
     "chai": "~1.8.1",
-    "karma": "~0.10.2",
+    "karma": "~0.12.1",
     "mocha": "~1.13.0",
-    "karma-mocha": "~0.1.0",
+    "karma-mocha": "~0.2.2",
     "karma-osx-reporter": "0.0.3",
     "karma-spec-reporter": "0.0.6",
+    "karma-phantomjs-launcher": "~1.0.0",
+    "phantomjs-prebuilt": "~2.1",
     "sprockets-chain": "0.0.9"
   }
 }


### PR DESCRIPTION
Upgrade some karma packages for running JS specs on Mac

New Travis-specific rake task for tests to run there.
* Removing `spec:javascripts` from the list to run at Travis as the one JS spec
  the project has tests a div flash fade which isn't worth all the chattiness
  of the npm module install.

Fixes #1282 