### PR TITLE
Fix for disappearing browser when clicking a cookbook's CHANGELOG tab

### DIFF
--- a/src/supermarket/app/views/cookbooks/_main.html.erb
+++ b/src/supermarket/app/views/cookbooks/_main.html.erb
@@ -1,4 +1,4 @@
-<div class="main" data-equalizer-watch>
+<div class="main">
   <% if cookbook.deprecated? %>
     <div class="deprecation-notice">
       <h2 class="deprecation-copy">


### PR DESCRIPTION
Fixes #1026

Note: I was able to replicate part of the problem locally and believe the issue was with the `data-equalizer-watch` foundation class, documented [here](http://foundation.zurb.com/sites/docs/v/5.5.3/components/equalizer.html). I removed the class and the problem went away locally. 