### PR TITLE
Move the cache_path into the omnibus var dir to avoid warnings

### DIFF
--- a/omnibus/config/software/supermarket-cookbooks.rb
+++ b/omnibus/config/software/supermarket-cookbooks.rb
@@ -41,7 +41,7 @@ build do
     open("#{cookbooks_path}/solo.rb", "w") do |file|
       file.write <<-EOH.gsub(/^ {8}/, '')
         cookbook_path   "#{cookbooks_path}"
-        file_cache_path "#{cookbooks_path}/cache"
+        cache_path "/var/opt/supermarket/cache"
         verbose_logging true
         ssl_verify_mode :verify_peer
       EOH

--- a/omnibus/cookbooks/omnibus-supermarket/test/integration/default/serverspec/recipes/default_spec.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/test/integration/default/serverspec/recipes/default_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'omnibus-supermarket::default' do
+  describe file(property['supermarket']['var_directory'] + '/cache') do
+    it { should be_directory }
+  end
+
+  describe file(property['supermarket']['install_directory'] + '/embedded/cookbooks/local-mode-cache') do
+    it { should_not exist }
+  end
+end


### PR DESCRIPTION
Previously running reconfigure would yield many WARN-level messages
because the cache was embedded in the cookbook directory.  This moves
the cache to a more appropriate directory and cleans up the old cache
dir.

Sample warnings:
```
[2016-05-12T14:02:32+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/supermarket/embedded/cookbooks/local-mode-cache
[2016-05-12T14:02:32+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/supermarket/embedded/cookbooks/local-mode-cache
[2016-05-12T14:02:32+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/supermarket/embedded/cookbooks/local-mode-cache
[2016-05-12T14:02:32+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/supermarket/embedded/cookbooks/local-mode-cache
[2016-05-12T14:02:32+00:00] WARN: Cookbook 'local-mode-cache' is empty or entirely chefignored at /opt/supermarket/embedded/cookbooks/local-mode-cache
...
```

Lifted from chef/chef-server#168

TODO:
- ~~Is there a `var_dir` or similar variable available in an omnibus software definition so that the path does not need to be hard coded?~~ No.
- ~~Consider replicating [chef-server's upgrade "migrations"](https://github.com/chef/chef-server/blob/master/omnibus/files/private-chef-upgrades/001/024_cleanup_local_cache_path.rb) to handle cleanup of previous version cruft~~ Not necessary at this time.