### PR TITLE
Option to add current owner as a collaborators when transfering ownership

### DIFF
--- a/src/supermarket/app/controllers/transfer_ownership_controller.rb
+++ b/src/supermarket/app/controllers/transfer_ownership_controller.rb
@@ -11,11 +11,13 @@ class TransferOwnershipController < ApplicationController
     @cookbook = Cookbook.with_name(params[:id]).first!
     authorize! @cookbook, :transfer_ownership?
     recipient = User.find(transfer_ownership_params[:user_id])
-    if params[:cookbook][:add_owner_as_collaborator] == "1"
-      add_owner_as_collaborator = true
-    else
-      add_owner_as_collaborator = false
-    end
+
+    add_owner_as_collaborator = if params[:cookbook][:add_owner_as_collaborator] == "1"
+                                  true
+                                else
+                                  false
+                                end
+
     msg = @cookbook.transfer_ownership(current_user, recipient, add_owner_as_collaborator)
     redirect_to @cookbook, notice: t(msg, cookbook: @cookbook.name, user: recipient.username)
   end

--- a/src/supermarket/app/controllers/transfer_ownership_controller.rb
+++ b/src/supermarket/app/controllers/transfer_ownership_controller.rb
@@ -62,6 +62,6 @@ class TransferOwnershipController < ApplicationController
   end
 
   def transfer_ownership_params
-    params.require(:cookbook).permit(:user_id).permit(:add_owner_as_collaborator)
+    params.require(:cookbook).permit(:user_id, :add_owner_as_collaborator)
   end
 end

--- a/src/supermarket/app/controllers/transfer_ownership_controller.rb
+++ b/src/supermarket/app/controllers/transfer_ownership_controller.rb
@@ -11,7 +11,8 @@ class TransferOwnershipController < ApplicationController
     @cookbook = Cookbook.with_name(params[:id]).first!
     authorize! @cookbook, :transfer_ownership?
     recipient = User.find(transfer_ownership_params[:user_id])
-    msg = @cookbook.transfer_ownership(current_user, recipient)
+    add_owner_as_collaborator = transfer_ownership_params[:add_owner_as_collaborator]
+    msg = @cookbook.transfer_ownership(current_user, recipient, add_owner_as_collaborator)
     redirect_to @cookbook, notice: t(msg, cookbook: @cookbook.name, user: recipient.username)
   end
 
@@ -61,6 +62,6 @@ class TransferOwnershipController < ApplicationController
   end
 
   def transfer_ownership_params
-    params.require(:cookbook).permit(:user_id)
+    params.require(:cookbook).permit(:user_id).permit(:add_owner_as_collaborator)
   end
 end

--- a/src/supermarket/app/controllers/transfer_ownership_controller.rb
+++ b/src/supermarket/app/controllers/transfer_ownership_controller.rb
@@ -11,7 +11,11 @@ class TransferOwnershipController < ApplicationController
     @cookbook = Cookbook.with_name(params[:id]).first!
     authorize! @cookbook, :transfer_ownership?
     recipient = User.find(transfer_ownership_params[:user_id])
-    add_owner_as_collaborator = transfer_ownership_params[:add_owner_as_collaborator]
+    if params[:cookbook][:add_owner_as_collaborator] == "1"
+      add_owner_as_collaborator = true
+    else
+      add_owner_as_collaborator = false
+    end
     msg = @cookbook.transfer_ownership(current_user, recipient, add_owner_as_collaborator)
     redirect_to @cookbook, notice: t(msg, cookbook: @cookbook.name, user: recipient.username)
   end

--- a/src/supermarket/app/mailers/cookbook_mailer.rb
+++ b/src/supermarket/app/mailers/cookbook_mailer.rb
@@ -68,10 +68,13 @@ class CookbookMailer < ActionMailer::Base
     @transfer_request = transfer_request
     @sender = transfer_request.sender.name
     @cookbook = transfer_request.cookbook.name
+    @add_owner_as_collaborator = if transfer_request.add_owner_as_collaborator == true
+                                   " and add themselves as a collaborator"
+                                 end
 
     subject = %(
       #{@sender} wants to transfer ownership of the #{@cookbook} cookbook to
-      you.
+      you#{@add_owner_as_collaborator}.
     ).squish
 
     mail(to: transfer_request.recipient.email, subject: subject)

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -159,13 +159,14 @@ class Cookbook < ActiveRecord::Base
       if add_owner_as_collaborator
         create_new_collaborator(initiator)
       end
+
       delete_old_collaborator(recipient)
       'cookbook.ownership_transfer.done'
     else
       transfer_request = OwnershipTransferRequest.create(
         sender: initiator,
         recipient: recipient,
-        # add_owner_as_collaborator: add_owner_as_collaborator,
+        add_owner_as_collaborator: add_owner_as_collaborator,
         cookbook: self
       )
       CookbookMailer.delay.transfer_ownership_email(transfer_request)

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -152,10 +152,6 @@ class Cookbook < ActiveRecord::Base
   # @return [String] a key representing a message to display to the user
   #
 
-  def add_owner_as_collaborator
-    true
-  end
-
   def transfer_ownership(initiator, recipient, add_owner_as_collaborator=false)
     if initiator.is?(:admin) || collaborator_users.include?(recipient)
       update_attribute(:user_id, recipient.id)

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -173,6 +173,7 @@ class Cookbook < ActiveRecord::Base
       transfer_request = OwnershipTransferRequest.create(
         sender: initiator,
         recipient: recipient,
+        # add_owner_as_collaborator: add_owner_as_collaborator,
         cookbook: self
       )
       CookbookMailer.delay.transfer_ownership_email(transfer_request)

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -156,18 +156,14 @@ class Cookbook < ActiveRecord::Base
     true
   end
 
-  def transfer_ownership(initiator, recipient, add_owner_as_collaborator)
+  def transfer_ownership(initiator, recipient, add_owner_as_collaborator=false)
     if initiator.is?(:admin) || collaborator_users.include?(recipient)
       update_attribute(:user_id, recipient.id)
 
       if add_owner_as_collaborator
         create_new_collaborator(initiator)
-        create_new_collaborator(recipient)
-      else
-        create_new_collaborator(initiator)
-        delete_old_collaborator(recipient)
       end
-
+      delete_old_collaborator(recipient)
       'cookbook.ownership_transfer.done'
     else
       transfer_request = OwnershipTransferRequest.create(

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -151,12 +151,22 @@ class Cookbook < ActiveRecord::Base
   #
   # @return [String] a key representing a message to display to the user
   #
-  def transfer_ownership(initiator, recipient)
+
+  def add_owner_as_collaborator
+    true
+  end
+
+  def transfer_ownership(initiator, recipient, add_owner_as_collaborator)
     if initiator.is?(:admin) || collaborator_users.include?(recipient)
       update_attribute(:user_id, recipient.id)
 
-      create_new_collaborator(initiator)
-      delete_old_collaborator(recipient)
+      if add_owner_as_collaborator
+        create_new_collaborator(initiator)
+        create_new_collaborator(recipient)
+      else
+        create_new_collaborator(initiator)
+        delete_old_collaborator(recipient)
+      end
 
       'cookbook.ownership_transfer.done'
     else

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -152,7 +152,7 @@ class Cookbook < ActiveRecord::Base
   # @return [String] a key representing a message to display to the user
   #
 
-  def transfer_ownership(initiator, recipient, add_owner_as_collaborator=false)
+  def transfer_ownership(initiator, recipient, add_owner_as_collaborator = false)
     if initiator.is?(:admin) || collaborator_users.include?(recipient)
       update_attribute(:user_id, recipient.id)
 

--- a/src/supermarket/app/models/ownership_transfer_request.rb
+++ b/src/supermarket/app/models/ownership_transfer_request.rb
@@ -29,6 +29,9 @@ class OwnershipTransferRequest < ActiveRecord::Base
     return unless accepted.nil?
     update_attribute(:accepted, true)
     cookbook.update_attribute(:user_id, recipient.id)
+    if add_owner_as_collaborator
+      collaborators.where(user_id: initiator.id).first_or_create!
+    end
   end
 
   #

--- a/src/supermarket/app/models/ownership_transfer_request.rb
+++ b/src/supermarket/app/models/ownership_transfer_request.rb
@@ -28,10 +28,11 @@ class OwnershipTransferRequest < ActiveRecord::Base
   def accept!
     return unless accepted.nil?
     update_attribute(:accepted, true)
-    cookbook.update_attribute(:user_id, recipient.id)
     if add_owner_as_collaborator
-      collaborators.where(user_id: initiator.id).first_or_create!
+      Collaborator.where(user_id: cookbook.owner.id, resourceable: cookbook).first_or_create!
     end
+
+    cookbook.update_attribute(:user_id, recipient.id)
   end
 
   #

--- a/src/supermarket/app/views/cookbooks/_manage_cookbook.html.erb
+++ b/src/supermarket/app/views/cookbooks/_manage_cookbook.html.erb
@@ -31,8 +31,10 @@
         <div class="row collapse">
           <div class="small-9 columns">
             <%= f.hidden_field :user_id, class: 'collaborators', 'data-url' => collaborators_path(ineligible_user_ids: Collaborator.ineligible_owners_for(cookbook).map(&:id)) %>
-            <%= f.label "Select this box to keep the current owner on as a collaborator." %>
-            <%= f.check_box :add_owner_as_collaborator, checked: false %>
+            <h3>
+              <%= f.check_box :add_owner_as_collaborator, checked: false %>
+              <%= f.label "Make current owner a collaborator?" %>
+            </h3>
           </div>
           <div class="small-3 columns">
             <%= f.submit 'Transfer', class: 'button radius postfix' %>

--- a/src/supermarket/app/views/cookbooks/_manage_cookbook.html.erb
+++ b/src/supermarket/app/views/cookbooks/_manage_cookbook.html.erb
@@ -31,6 +31,8 @@
         <div class="row collapse">
           <div class="small-9 columns">
             <%= f.hidden_field :user_id, class: 'collaborators', 'data-url' => collaborators_path(ineligible_user_ids: Collaborator.ineligible_owners_for(cookbook).map(&:id)) %>
+            <%= f.label "Select this box to keep the current owner on as a collaborator." %>
+            <%= f.check_box :add_owner_as_collaborator, checked: false %>
           </div>
           <div class="small-3 columns">
             <%= f.submit 'Transfer', class: 'button radius postfix' %>

--- a/src/supermarket/db/migrate/20160511224519_add_add_owner_as_collaborator_attribute_to_ownership_transfer_request.rb
+++ b/src/supermarket/db/migrate/20160511224519_add_add_owner_as_collaborator_attribute_to_ownership_transfer_request.rb
@@ -1,0 +1,5 @@
+class AddAddOwnerAsCollaboratorAttributeToOwnershipTransferRequest < ActiveRecord::Migration
+  def change
+    add_column :ownership_transfer_requests, :add_owner_as_collaborator, :boolean
+  end
+end

--- a/src/supermarket/db/schema.rb
+++ b/src/supermarket/db/schema.rb
@@ -11,8 +11,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160502171009) do
 
+ActiveRecord::Schema.define(version: 20160511224519) do
+  
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pg_trgm"
@@ -367,13 +368,14 @@ ActiveRecord::Schema.define(version: 20160502171009) do
   end
 
   create_table "ownership_transfer_requests", force: true do |t|
-    t.integer  "cookbook_id",  null: false
-    t.integer  "recipient_id", null: false
-    t.integer  "sender_id",    null: false
-    t.string   "token",        null: false
+    t.integer  "cookbook_id",               null: false
+    t.integer  "recipient_id",              null: false
+    t.integer  "sender_id",                 null: false
+    t.string   "token",                     null: false
     t.boolean  "accepted"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "add_owner_as_collaborator"
   end
 
   add_index "ownership_transfer_requests", ["cookbook_id"], name: "index_ownership_transfer_requests_on_cookbook_id", using: :btree

--- a/src/supermarket/spec/controllers/transfer_ownership_controller_spec.rb
+++ b/src/supermarket/spec/controllers/transfer_ownership_controller_spec.rb
@@ -16,9 +16,19 @@ describe TransferOwnershipController do
       it 'attempts to change the cookbooks owner' do
         expect(cookbook).to receive(:transfer_ownership).with(
           user,
-          new_owner
+          new_owner,
+          false
         ) { 'cookbook.ownership_transfer.done' }
-        put :transfer, id: cookbook, cookbook: { user_id: new_owner.id }
+        put :transfer, id: cookbook, cookbook: { user_id: new_owner.id, add_owner_as_collaborator: "0" }
+      end
+
+      it 'attempts to change the cookbooks owner and save the current owner as a contributor' do
+        expect(cookbook).to receive(:transfer_ownership).with(
+          user,
+          new_owner,
+          true
+        ) { 'cookbook.ownership_transfer.done' }
+        put :transfer, id: cookbook, cookbook: { user_id: new_owner.id, add_owner_as_collaborator: "1" }
       end
 
       it 'redirects back to the cookbook' do

--- a/src/supermarket/spec/models/cookbook_spec.rb
+++ b/src/supermarket/spec/models/cookbook_spec.rb
@@ -195,7 +195,8 @@ describe Cookbook do
         hank = create(:user)
         create(:cookbook_collaborator, resourceable: cookbook, user: hank)
         expect(cookbook.owner).to eql(jimmy)
-        result = cookbook.transfer_ownership(jimmy, hank, true)
+        expect(cookbook.collaborator_users).to_not include(jimmy)
+        cookbook.transfer_ownership(jimmy, hank, true)
         cookbook.reload
         expect(cookbook.owner).to eql(hank)
         expect(cookbook.collaborator_users).to include(jimmy)

--- a/src/supermarket/spec/models/cookbook_spec.rb
+++ b/src/supermarket/spec/models/cookbook_spec.rb
@@ -199,7 +199,7 @@ describe Cookbook do
         cookbook.reload
         expect(cookbook.owner).to eql(hank)
         expect(cookbook.collaborator_users).to include(jimmy)
-        expect(cookbook.collaborators.count).to eql(2)
+        expect(cookbook.collaborators.count).to eql(1)
       end
     end
 
@@ -214,7 +214,7 @@ describe Cookbook do
         end
 
         it 'should create a new collaborator record for the previous owner' do
-          result = cookbook.transfer_ownership(jimmy, hank)
+          result = cookbook.transfer_ownership(jimmy, hank, true)
           cookbook.reload
           expect(cookbook.owner).to eql(hank)
           expect(cookbook.collaborator_users).to include(jimmy)

--- a/src/supermarket/spec/models/cookbook_spec.rb
+++ b/src/supermarket/spec/models/cookbook_spec.rb
@@ -198,6 +198,7 @@ describe Cookbook do
         result = cookbook.transfer_ownership(jimmy, hank, true)
         cookbook.reload
         expect(cookbook.owner).to eql(hank)
+        expect(cookbook.collaborator_users).to include(jimmy)
         expect(cookbook.collaborators.count).to eql(2)
       end
     end

--- a/src/supermarket/spec/models/cookbook_spec.rb
+++ b/src/supermarket/spec/models/cookbook_spec.rb
@@ -217,46 +217,6 @@ describe Cookbook do
       end
     end
 
-    context 'adding a new collaborator record' do
-      let!(:hank) { create(:user) }
-      let!(:cookbook_collaborator) { create(:cookbook_collaborator, resourceable: cookbook, user: hank) }
-
-      context 'when the owner does NOT exist as a collaborator associated with a group' do
-        before do
-          expect(cookbook.owner).to eql(jimmy)
-          expect(cookbook.collaborator_users).to_not include(jimmy)
-        end
-
-        it 'should create a new collaborator record for the previous owner' do
-          result = cookbook.transfer_ownership(jimmy, hank, true)
-          cookbook.reload
-          expect(cookbook.owner).to eql(hank)
-          expect(cookbook.collaborator_users).to include(jimmy)
-        end
-      end
-
-      context 'when the owner DOES exist as a collaborator associated with a group' do
-        let(:group) { create(:group) }
-        let(:group_collaborator) { create(:cookbook_collaborator, resourceable: cookbook, user: jimmy, group_id: group.id) }
-
-        before do
-          expect(cookbook.collaborators).to include(group_collaborator)
-        end
-
-        it 'does not create a new collaborator record for the previous owner' do
-          expect(cookbook.owner).to eql(jimmy)
-          expect(cookbook.collaborators.where(user: group_collaborator.user).count).to eq(1)
-
-          result = cookbook.transfer_ownership(jimmy, hank)
-
-          cookbook.reload
-          expect(cookbook.owner).to eql(hank)
-          expect(cookbook.collaborators.where(user: group_collaborator.user).count).to eq(1)
-        end
-      end
-
-    end
-
     it 'should create a transfer request if the initiator is not an admin and the recipient is not a collaborator' do
       result = nil
       hank = create(:user)

--- a/src/supermarket/spec/models/cookbook_spec.rb
+++ b/src/supermarket/spec/models/cookbook_spec.rb
@@ -190,6 +190,18 @@ describe Cookbook do
       end
     end
 
+    context 'adding current owner as collaborator checkbox is selected' do
+      it 'should list the current owner as a collaborator' do
+        hank = create(:user)
+        create(:cookbook_collaborator, resourceable: cookbook, user: hank)
+        expect(cookbook.owner).to eql(jimmy)
+        result = cookbook.transfer_ownership(jimmy, hank, true)
+        cookbook.reload
+        expect(cookbook.owner).to eql(hank)
+        expect(cookbook.collaborators.count).to eql(2)
+      end
+    end
+
     context 'adding a new collaborator record' do
       let!(:hank) { create(:user) }
       let!(:cookbook_collaborator) { create(:cookbook_collaborator, resourceable: cookbook, user: hank) }

--- a/src/supermarket/spec/models/cookbook_spec.rb
+++ b/src/supermarket/spec/models/cookbook_spec.rb
@@ -204,6 +204,19 @@ describe Cookbook do
       end
     end
 
+    context 'adding current owner as collaborator checkbox is not selected' do
+      it 'should not list the current owner as a collaborator' do
+        hank = create(:user)
+        create(:cookbook_collaborator, resourceable: cookbook, user: hank)
+        expect(cookbook.owner).to eql(jimmy)
+        cookbook.transfer_ownership(jimmy, hank, false)
+        cookbook.reload
+        expect(cookbook.owner).to eql(hank)
+        expect(cookbook.collaborator_users).to_not include(jimmy)
+        expect(cookbook.collaborators.count).to eql(0)
+      end
+    end
+
     context 'adding a new collaborator record' do
       let!(:hank) { create(:user) }
       let!(:cookbook_collaborator) { create(:cookbook_collaborator, resourceable: cookbook, user: hank) }

--- a/src/supermarket/spec/models/ownership_transfer_request_spec.rb
+++ b/src/supermarket/spec/models/ownership_transfer_request_spec.rb
@@ -58,10 +58,10 @@ describe OwnershipTransferRequest do
           sally = cookbook.owner
           jimmy = transfer_request.recipient
           transfer_request.add_owner_as_collaborator = true
-          transfer_request.accept!
           cookbook.reload
-          expect(cookbook.owner).to eql(jimmy)
-          expect(cookbook.collaborators).to include(sally)
+
+          expect { transfer_request.accept! }.
+            to change(cookbook.collaborators, :count).from(0).to(1)
         end
       end
     end

--- a/src/supermarket/spec/models/ownership_transfer_request_spec.rb
+++ b/src/supermarket/spec/models/ownership_transfer_request_spec.rb
@@ -51,6 +51,19 @@ describe OwnershipTransferRequest do
       end
 
       it_should_behave_like 'returning early'
+
+      context 'current owner wants to become a collaborator' do
+        it 'should transfer the ownership and keep the old owner as a collaborator' do
+          cookbook = transfer_request.cookbook
+          sally = cookbook.owner
+          jimmy = transfer_request.recipient
+          transfer_request.add_owner_as_collaborator = true
+          transfer_request.accept!
+          cookbook.reload
+          expect(cookbook.owner).to eql(jimmy)
+          expect(cookbook.collaborators).to include(sally)
+        end
+      end
     end
 
     describe '#decline!' do


### PR DESCRIPTION
Fixes #1224

Adds checkbox in workflow for transferring ownership that gives option to keep current user on as a collaborator, streamlines the logic action for both admins/collaborators and non-admins/collaborators.