### PR TITLE
makes s3 bucket domain name style configurable

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -436,6 +436,18 @@ default['supermarket']['s3_bucket'] = nil
 default['supermarket']['s3_secret_access_key'] = nil
 default['supermarket']['cdn_url'] = nil
 
+
+# ### Additional S3 Settings
+# By default, Supermarket will use domain style S3 urls that look like this
+# bucketname.s3.amazonaws.com
+# This style of url will work across all regions
+# If this is set as ':s3_path_url', the S3 urls will look like this
+# s3.amazonaws.com/bucketname.
+# This will only work if the S3 bucket is in N. Virginia.
+# If your S3 bucket name as had "." in it - i.e. "my.bucket.name",
+# you must use the path style url and your S3 bucket must be in N. Virginia
+default['supermarket']['s3_domain_style'] = ':s3_domain_url'
+
 # ### SMTP Settings
 #
 # If none of these are set, the :sendmail delivery method will be used. Using

--- a/src/supermarket/config/initializers/paperclip.rb
+++ b/src/supermarket/config/initializers/paperclip.rb
@@ -37,7 +37,7 @@ end
       )
     else
       options = options.merge(
-        url: ':s3_path_url'
+        url: ENV['S3_DOMAIN_STYLE']
       )
     end
 

--- a/src/supermarket/docs/CONFIGURING.md
+++ b/src/supermarket/docs/CONFIGURING.md
@@ -105,6 +105,9 @@ the test suite.
   cookbook object itself, which may conflict with a bucket policy if you use one
   on your bucket.  If you wish to use a bucket policy, rather than an object policy,
   leave this variable as nil.
+* `S3_DOMAIN_STYLE` is used to specify what type of URL is used to access your s3 bucket.
+  The default is ':s3_domain_url', it will use domains that look like this: bucketname.s3.amazonaws.com.  This works across regions.
+  The alternative is ':s3_path_url', which will use this style s3.amazonaws.com/bucketname.  Unfortunately, this will only work if your S3 bucket is in N. Virginia.  If your s3 bucket name has dots in it (i.e. my.bucket.name), you must use ':s3_path_url' for your S3_DOMAIN_STYLE
 * `CDN_URL` Used to configure a CDN URL for use with Paperclip. Downloads
   will be aliased with this URL, something like `static.chef.io`.
 * `FIERI_URL` is the URL Supermarket will `POST` to for Cookbook evaluation when


### PR DESCRIPTION
Fixes #1301 

Before this is deployed, we will need to add this value to the supermarket vault
s3_domain_style: ':s3_path_url'