### PR TITLE
Adoption Email Notice to Followers

### DIFF
--- a/src/supermarket/app/controllers/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/cookbooks_controller.rb
@@ -116,6 +116,12 @@ class CookbooksController < ApplicationController
 
     @cookbook.update_attributes(cookbook_urls_params)
 
+    if cookbook_urls_params.key?(:up_for_adoption)
+      if cookbook_urls_params[:up_for_adoption] == 'true'
+        AdoptionMailer.delay.follower_email(@cookbook)
+      end
+    end
+
     key = if cookbook_urls_params.key?(:up_for_adoption)
             if cookbook_urls_params[:up_for_adoption] == 'true'
               'adoption.up'

--- a/src/supermarket/app/mailers/adoption_mailer.rb
+++ b/src/supermarket/app/mailers/adoption_mailer.rb
@@ -17,4 +17,14 @@ class AdoptionMailer < ActionMailer::Base
 
     mail(to: @to, subject: "Interest in adopting your #{@name} #{@thing}")
   end
+
+  def follower_email(cookbook_or_tool)
+    @name = cookbook_or_tool.name
+    @thing = cookbook_or_tool.class.name.downcase
+    @emails = cookbook_or_tool.followers.pluck(:email)
+
+    @emails.each do |email|
+      mail(to: email, subject: "#{@name} #{@thing} up for adoption")
+    end
+  end
 end

--- a/src/supermarket/app/views/adoption_mailer/follower_email.html.erb
+++ b/src/supermarket/app/views/adoption_mailer/follower_email.html.erb
@@ -1,0 +1,5 @@
+Your <%= @thing %>, <%= @name %>, which is currently up for adoption, got some interest today.<br />
+<%= link_to(@name, "#{root_url}#{cookbook_path(@name)}") %>
+<br />
+<br />
+If you are interested in adopting <%= @name %>, please either contact Chef or visit the <%= @thing %> page in order to learn more. You can select the "Adopt Me" button in the sidebar from the show page for the <%= @thing %>

--- a/src/supermarket/app/views/adoption_mailer/follower_email.text.erb
+++ b/src/supermarket/app/views/adoption_mailer/follower_email.text.erb
@@ -1,0 +1,5 @@
+Your <%= @thing %>, <%= @name %>, which is currently up for adoption, got some interest today.<br />
+<%= link_to(@name, "#{root_url}#{cookbook_path(@name)}") %>
+<br />
+<br />
+If you are interested in adopting <%= @name %>, please either contact Chef or visit the <%= @thing %> page in order to learn more. You can select the "Adopt Me" button in the sidebar from the show page for the <%= @thing %>

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -254,11 +254,11 @@ describe CookbooksController do
         email: 'jane@example.com'
       )
     end
-    let(:cookbook_follower) do
+    let!(:cookbook_follower) do
       create(
         :cookbook_follower,
-        user_id: another_user.id,
-        cookbook_id: cookbook.id
+        user: another_user,
+        cookbook: cookbook
       )
     end
     before { sign_in user }
@@ -279,11 +279,12 @@ describe CookbooksController do
       end
 
       it 'sends an adoption email to cookbook followers' do
+        cookbook.reload
         Sidekiq::Testing.inline! do
           patch :update, id: cookbook, cookbook: {
             source_url: 'http://example.com/cookbook',
             issues_url: 'http://example.com/cookbook/issues',
-            up_for_adoption: true
+            up_for_adoption: 'true'
           }
           expect(ActionMailer::Base.deliveries.map(&:to).flatten).to include(cookbook_follower.user.email)
         end


### PR DESCRIPTION
Partially fixes #1184. This is a checked out branch separate from `master/adoption_process` for clarity of purpose. Another pull request will address the visibility of adoption on timelines. This is separate because the second part of the issue requires more attention and possible database migration. 