### PR TITLE
reverts changing paperclip to use path urls

### DIFF
--- a/src/supermarket/config/initializers/paperclip.rb
+++ b/src/supermarket/config/initializers/paperclip.rb
@@ -37,7 +37,7 @@ end
       )
     else
       options = options.merge(
-        url: ':s3_domain_url'
+        url: ':s3_path_url'
       )
     end
 


### PR DESCRIPTION
This temporarily fixes #1301

What happened was, when we deployed #1281, we started seeing errors from berks.  This was due to the fact that our prod S3 bucket has "." in the name, which cannot be used with the path style.  #1307 begins to address this, but that PR needs some additional work.  In order to make this shippable for now, I am reversing the s3 url style change.