### PR TITLE
WIP: Add a guard to Supermarket-specific ctl commands to require being run as supermarket service user

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/console.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/console.rb
@@ -1,5 +1,17 @@
+# due to how things are being exec'ed, the CWD will be all wrong,
+# so we want to use the full path when loaded from omnibus-ctl,
+# but we need the local relative path for it to work with rspec
+begin
+  require 'helpers/user_check_helper'
+rescue LoadError
+  require '/opt/supermarket/embedded/service/omnibus-ctl/helpers/user_check_helper'
+end
+
 add_command 'console', 'Enter the rails console for Supermarket', 1 do
-  cmd = "cd /opt/supermarket/embedded/service/supermarket && sudo -u supermarket env PATH=/opt/supermarket/embedded/bin:$PATH bin/rails console production"
+  user_check = UserCheckHelper.new('console')
+  user_check.must_run_as 'supermarket'
+
+  cmd = "cd /opt/supermarket/embedded/service/supermarket && env PATH=/opt/supermarket/embedded/bin:$PATH bin/rails console production"
   exec cmd
   true
 end

--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/console.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/console.rb
@@ -2,14 +2,14 @@
 # so we want to use the full path when loaded from omnibus-ctl,
 # but we need the local relative path for it to work with rspec
 begin
-  require 'helpers/user_check_helper'
+  require 'helpers/ctl_command_helper'
 rescue LoadError
-  require '/opt/supermarket/embedded/service/omnibus-ctl/helpers/user_check_helper'
+  require '/opt/supermarket/embedded/service/omnibus-ctl/helpers/ctl_command_helper'
 end
 
 add_command 'console', 'Enter the rails console for Supermarket', 1 do
-  user_check = UserCheckHelper.new('console')
-  user_check.must_run_as 'supermarket'
+  cmd_helper = CtlCommandHelper.new('console')
+  cmd_helper.must_run_as 'supermarket'
 
   cmd = "cd /opt/supermarket/embedded/service/supermarket && env PATH=/opt/supermarket/embedded/bin:$PATH bin/rails console production"
   exec cmd

--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/helpers/ctl_command_helper.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/helpers/ctl_command_helper.rb
@@ -1,4 +1,4 @@
-class UserCheckHelper
+class CtlCommandHelper
   attr_accessor :command_name
 
   def initialize(command_name)
@@ -17,6 +17,6 @@ class UserCheckHelper
 
   def exit_failure(msg)
     STDERR.puts msg
-    raise SystemExit.new(1, msg)
+    exit 1
   end
 end

--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/helpers/user_check_helper.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/helpers/user_check_helper.rb
@@ -1,0 +1,22 @@
+class UserCheckHelper
+  attr_accessor :command_name
+
+  def initialize(command_name)
+    @command_name = command_name
+  end
+
+  def must_run_as(user)
+    if Process.uid != Etc.getpwnam(user).uid
+      exit_failure "supermarket-ctl #{command_name} should be run as the #{user} OS user."
+    end
+  rescue ArgumentError => e
+    exit_failure "supermarket-ctl requires that a #{user} OS user exist"
+  end
+
+  private
+
+  def exit_failure(msg)
+    STDERR.puts msg
+    raise SystemExit.new(1, msg)
+  end
+end

--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/make-admin.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/make-admin.rb
@@ -1,13 +1,23 @@
 require 'mixlib/shellout'
+# due to how things are being exec'ed, the CWD will be all wrong,
+# so we want to use the full path when loaded from omnibus-ctl,
+# but we need the local relative path for it to work with rspec
+begin
+  require 'helpers/user_check_helper'
+rescue LoadError
+  require '/opt/supermarket/embedded/service/omnibus-ctl/helpers/user_check_helper'
+end
 
 # supermarket-ctl make_admin username
 add_command 'make-admin', 'Make a Supermarket user an admin', 2 do
+  user_check = UserCheckHelper.new('make-admin')
+  user_check.must_run_as 'supermarket'
 
   # Find username arg
   username = ARGV[3]
 
   # Run rake task
-  command_text = "cd /opt/supermarket/embedded/service/supermarket && sudo RAILS_ENV=\"production\" env PATH=/opt/supermarket/embedded/bin bin/rake user:make_admin user=\"#{username}\""
+  command_text = "cd /opt/supermarket/embedded/service/supermarket && RAILS_ENV=\"production\" env PATH=/opt/supermarket/embedded/bin bin/rake user:make_admin user=\"#{username}\""
 
   # Return output to user
   shell_out = Mixlib::ShellOut.new(command_text)

--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/make-admin.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/make-admin.rb
@@ -3,15 +3,15 @@ require 'mixlib/shellout'
 # so we want to use the full path when loaded from omnibus-ctl,
 # but we need the local relative path for it to work with rspec
 begin
-  require 'helpers/user_check_helper'
+  require 'helpers/ctl_command_helper'
 rescue LoadError
-  require '/opt/supermarket/embedded/service/omnibus-ctl/helpers/user_check_helper'
+  require '/opt/supermarket/embedded/service/omnibus-ctl/helpers/ctl_command_helper'
 end
 
 # supermarket-ctl make_admin username
 add_command 'make-admin', 'Make a Supermarket user an admin', 2 do
-  user_check = UserCheckHelper.new('make-admin')
-  user_check.must_run_as 'supermarket'
+  cmd_helper = CtlCommandHelper.new('make-admin')
+  cmd_helper.must_run_as 'supermarket'
 
   # Find username arg
   username = ARGV[3]

--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/test.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/test.rb
@@ -4,14 +4,14 @@ require 'optparse'
 # so we want to use the full path when loaded from omnibus-ctl,
 # but we need the local relative path for it to work with rspec
 begin
-  require 'helpers/user_check_helper'
+  require 'helpers/ctl_command_helper'
 rescue LoadError
-  require '/opt/supermarket/embedded/service/omnibus-ctl/helpers/user_check_helper'
+  require '/opt/supermarket/embedded/service/omnibus-ctl/helpers/ctl_command_helper'
 end
 
 add_command 'test', 'Run the Supermarket installation test suite', 2 do
-  user_check = UserCheckHelper.new('test')
-  user_check.must_run_as 'supermarket'
+  cmd_helper = CtlCommandHelper.new('test')
+  cmd_helper.must_run_as 'supermarket'
 
   options = {}
   OptionParser.new do |opts|

--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/test.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/test.rb
@@ -1,7 +1,18 @@
 require 'mixlib/shellout'
 require 'optparse'
+# due to how things are being exec'ed, the CWD will be all wrong,
+# so we want to use the full path when loaded from omnibus-ctl,
+# but we need the local relative path for it to work with rspec
+begin
+  require 'helpers/user_check_helper'
+rescue LoadError
+  require '/opt/supermarket/embedded/service/omnibus-ctl/helpers/user_check_helper'
+end
 
 add_command 'test', 'Run the Supermarket installation test suite', 2 do
+  user_check = UserCheckHelper.new('test')
+  user_check.must_run_as 'supermarket'
+
   options = {}
   OptionParser.new do |opts|
     opts.on '-J', '--junit-xml PATH' do |junit_xml|

--- a/omnibus/cookbooks/omnibus-supermarket/test/integration/default/serverspec/ctl-commands/console_spec.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/test/integration/default/serverspec/ctl-commands/console_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'supermarket-ctl console' do
+  # run as someone other that the supermarket OS user
+  describe command("supermarket-ctl console") do
+    its(:stderr) { should match /supermarket-ctl console should be run as the supermarket OS user./ }
+  end
+end

--- a/omnibus/cookbooks/omnibus-supermarket/test/integration/default/serverspec/ctl-commands/make_admin_spec.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/test/integration/default/serverspec/ctl-commands/make_admin_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'supermarket-ctl make-admin' do
+  # run as someone other that the supermarket OS user
+  describe command("supermarket-ctl make-admin") do
+    its(:stderr) { should match /supermarket-ctl make-admin should be run as the supermarket OS user./ }
+  end
+
+  # run as supermarket user, but with a user that doesn't exist
+  describe command("sudo -u supermarket supermarket-ctl make-admin user=nope") do
+    its(:stdout) { should match /nope was not found in Supermarket./ }
+  end
+end

--- a/omnibus/cookbooks/omnibus-supermarket/test/integration/default/serverspec/ctl-commands/test_spec.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/test/integration/default/serverspec/ctl-commands/test_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'supermarket-ctl test' do
+  # run as someone other that the supermarket OS user
+  describe command("supermarket-ctl test") do
+    its(:stderr) { should match /supermarket-ctl test should be run as the supermarket OS user./ }
+  end
+end


### PR DESCRIPTION
Fixes #1314

Calling sudo within the ctl command conflicts with a host configuration whose sudoers requires a TTY.
This removes the call to sudo from within the command and displays an error to the user if the ctl
command is being run as an OS user other than the 'supermarket' service user.