### PR TITLE
Remove as-supermarket-user guard from `-ctl test` command

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/test.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/test.rb
@@ -1,18 +1,7 @@
 require 'mixlib/shellout'
 require 'optparse'
-# due to how things are being exec'ed, the CWD will be all wrong,
-# so we want to use the full path when loaded from omnibus-ctl,
-# but we need the local relative path for it to work with rspec
-begin
-  require 'helpers/ctl_command_helper'
-rescue LoadError
-  require '/opt/supermarket/embedded/service/omnibus-ctl/helpers/ctl_command_helper'
-end
 
 add_command 'test', 'Run the Supermarket installation test suite', 2 do
-  cmd_helper = CtlCommandHelper.new('test')
-  cmd_helper.must_run_as 'supermarket'
-
   options = {}
   OptionParser.new do |opts|
     opts.on '-J', '--junit-xml PATH' do |junit_xml|

--- a/omnibus/cookbooks/omnibus-supermarket/test/integration/default/serverspec/ctl-commands/test_spec.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/test/integration/default/serverspec/ctl-commands/test_spec.rb
@@ -1,8 +1,0 @@
-require 'spec_helper'
-
-describe 'supermarket-ctl test' do
-  # run as someone other that the supermarket OS user
-  describe command("supermarket-ctl test") do
-    its(:stderr) { should match /supermarket-ctl test should be run as the supermarket OS user./ }
-  end
-end


### PR DESCRIPTION
It can run as root. And currently does in the CI pipeline, so let's let it.

Makes the CI tests happier.