### PR TITLE
Fix Quality tab not displaying successful foodcritic feedback.

### DIFF
--- a/src/supermarket/app/views/cookbooks/_main.html.erb
+++ b/src/supermarket/app/views/cookbooks/_main.html.erb
@@ -112,14 +112,14 @@
     <% end %>
     <% if ROLLOUT.active?(:fieri) %>
       <div class="content" id="quality">
-        <% if version.foodcritic_failure.present? %>
+        <% if version.foodcritic_failure.nil? %>
+          <h2>No quality metric results found.</h2>
+        <% else %>
           <% if version.foodcritic_feedback.present? %>
             <pre><%= version.foodcritic_feedback.gsub(/\n/, '<br />').html_safe %></pre>
           <% else %>
             <p><%= version.version %> passed <%= link_to 'Foodcritic', 'http://acrmp.github.io/foodcritic', target: '_blank' %>.
           <% end %>
-        <% else %>
-          <h2>No quality metric results found.</h2>
         <% end %>
       </div>
     <% end %>


### PR DESCRIPTION
Fixes #1336 

foodcritic_failure will be nil if fieri hasn't posted back results. If
fieri has posted results, foodcritic_failure will be true or false. false
means success (argh, double negatives!), but false is also not `present?`
and so the test for presence fails and the view thinks there are no
results.

This flips the test from `present?` to `nil?` and flips the if/else
clauses. This was the smallest change to fix the display of foodcritic
success.

Future TODOs:
- extract the quality section of this partial to its own partial for focused testing with a view spec
- remove the foodcritic_failure column altogether and have fieri post feedback—positive or negative—for this view to display more simply