### PR TITLE
contains calls to outside services - vendors one font, removes another

### DIFF
--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -61,6 +61,7 @@ gem 'sass-rails',   '~> 4.0.4'
 gem 'sass-globbing'
 gem 'compass-rails'
 gem 'uglifier',     '~> 2.7'
+gem 'font-awesome-rails'
 
 group :doc do
   gem 'yard', require: false

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
     ffi-yajl (1.4.0)
       ffi (~> 1.5)
       libyajl2 (~> 1.2)
+    font-awesome-rails (4.6.3.0)
+      railties (>= 3.2, < 5.1)
     foodcritic (6.2.0)
       cucumber-core (>= 1.3)
       erubis
@@ -529,6 +531,7 @@ DEPENDENCIES
   factory_girl
   faker
   fieri!
+  font-awesome-rails
   foreman
   guard
   guard-rspec
@@ -587,4 +590,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.12.3
+   1.12.4

--- a/src/supermarket/app/assets/stylesheets/appheader.scss
+++ b/src/supermarket/app/assets/stylesheets/appheader.scss
@@ -36,8 +36,6 @@
   width: rem-calc(55);
   z-index: 1;
 
-  &:before { display: block; margin-top: rem-calc(43); }
-
   &:visited { color: adjust-lightness($concrete, 10%); }
   &:hover { color: adjust-lightness($concrete, 20%); }
 }

--- a/src/supermarket/app/assets/stylesheets/application.css.scss
+++ b/src/supermarket/app/assets/stylesheets/application.css.scss
@@ -6,6 +6,7 @@
 *= require normalize
 *= require foundation
 *= require select2
+*= require font-awesome
 *
 * Supermarket Styles
 *

--- a/src/supermarket/app/assets/stylesheets/variables.scss
+++ b/src/supermarket/app/assets/stylesheets/variables.scss
@@ -85,6 +85,6 @@ $cookbook_partial_sidebar_footer: #dbe2e7;
 
 // Fonts
 $default_font: "helvetica neue", helvetica, arial, sans-serif;
-$accent_font: "Montserrat", $default_font;
+$accent_font: $default_font;
 $bold: 700;
 $normal: 400;

--- a/src/supermarket/app/views/layouts/application.html.erb
+++ b/src/supermarket/app/views/layouts/application.html.erb
@@ -15,7 +15,6 @@
     <link rel="apple-touch-icon" href="<%= image_url('apple-touch-icon.png') %>"/>
     <%= stylesheet_link_tag "application", media: "all" %>
     <% unless Rails.env == 'test' %>
-      <%= stylesheet_link_tag "//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" %>
       <%= stylesheet_link_tag "//fonts.googleapis.com/css?family=Montserrat:400,700" %>
     <% end %>
     <%= csrf_meta_tags %>


### PR DESCRIPTION
Fixes #1305 

1) Vendors one external font source
2) Removes the Montserrat font and uses the default font as an accent font (the default fault was already the fallback font for the accent font)
3) This does not alter Google Analytics - as Google Analytics will only work when the GOOGLE_ANALYTICS_ID environmental variable is set.