### PR TITLE
Untar all files in a cookbook artifact as binary to avoid encoding issues

### DIFF
--- a/src/fieri/app/models/cookbook_artifact.rb
+++ b/src/fieri/app/models/cookbook_artifact.rb
@@ -85,7 +85,7 @@ class CookbookArtifact
 
         FileUtils.mkdir_p destination_dir unless File.directory?(destination_dir)
 
-        file = File.open(destination_file, 'w+')
+        file = File.open(destination_file, 'wb+')
         file << entry.read
         file.close
       end


### PR DESCRIPTION
This should fix fieri's CookbookWorker failing with encoding errors when binary files (like other tarballs) are included in a cookbook artifact.