### PR TITLE
Update omnibus & omnibus-software for new version of OpenSSL

### DIFF
--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -12,8 +12,6 @@ provisioner:
   require_chef_omnibus: 12.4.1
 
 platforms:
-  - name: ubuntu-10.04
-    run_list: apt::default
   - name: ubuntu-12.04
     run_list: apt::default
   - name: centos-5.11

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: c9df1d71eb8c70010d27a121c9021988b8886e9d
+  revision: d6c10d3f94e368bc358b1ca0f1520642372910fd
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.2.0)
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: a83ee04eff7f9d6b609d1ac9c300d3c714513a43
+  revision: 56b8e507df41bc6fa6e452441dc9df5744892e34
   specs:
     omnibus (5.4.0)
       aws-sdk (~> 2)
@@ -24,12 +24,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    aws-sdk (2.2.34)
-      aws-sdk-resources (= 2.2.34)
-    aws-sdk-core (2.2.34)
+    artifactory (2.3.2)
+    aws-sdk (2.3.16)
+      aws-sdk-resources (= 2.3.16)
+    aws-sdk-core (2.3.16)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.2.34)
-      aws-sdk-core (= 2.2.34)
+    aws-sdk-resources (2.3.16)
+      aws-sdk-core (= 2.3.16)
     berkshelf (3.3.0)
       addressable (~> 2.3.4)
       berkshelf-api-client (~> 1.2)
@@ -63,13 +64,13 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.9.38)
+    chef-config (12.11.18)
       fuzzyurl (~> 0.8.0)
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
     chef-sugar (3.3.0)
     cleanroom (1.0.0)
-    dep-selector-libgecode (1.0.2)
+    dep-selector-libgecode (1.2.0)
     dep_selector (1.0.3)
       dep-selector-libgecode (~> 1.0)
       ffi (~> 1.9)
@@ -80,33 +81,37 @@ GEM
     ffi-yajl (2.2.3)
       libyajl2 (~> 1.2)
     fuzzyurl (0.8.0)
-    hashie (3.4.3)
-    hitimes (1.2.3)
+    hashie (3.4.4)
+    hitimes (1.2.4)
     httpclient (2.6.0.1)
     ipaddress (0.8.3)
     jmespath (1.2.4)
       json_pure (>= 1.8.1)
     json (1.8.3)
     json_pure (1.8.3)
-    kitchen-vagrant (0.19.0)
+    kitchen-vagrant (0.20.0)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
     minitar (0.5.4)
-    mixlib-authentication (1.3.0)
+    mixlib-authentication (1.4.1)
       mixlib-log
-    mixlib-cli (1.5.0)
+    mixlib-cli (1.6.0)
     mixlib-config (2.2.1)
+    mixlib-install (1.1.0)
+      artifactory
+      mixlib-shellout
+      mixlib-versioning
     mixlib-log (1.6.0)
     mixlib-shellout (2.2.6)
     mixlib-versioning (1.1.0)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
-    nio4r (1.2.0)
+    net-ssh (3.2.0)
+    nio4r (1.2.1)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    ohai (8.15.0)
+    ohai (8.17.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -120,7 +125,7 @@ GEM
       wmi-lite (~> 1.0)
     plist (3.2.0)
     retryable (2.0.3)
-    ridley (4.3.2)
+    ridley (4.4.2)
       addressable
       buff-config (~> 1.0)
       buff-extensions (~> 1.0)
@@ -128,6 +133,7 @@ GEM
       buff-shell_out (~> 0.1)
       celluloid (~> 0.16.0)
       celluloid-io (~> 0.16.1)
+      chef-config
       erubis
       faraday (~> 0.9.0)
       hashie (>= 2.0.2, < 4.0.0)
@@ -137,7 +143,7 @@ GEM
       retryable (~> 2.0)
       semverse (~> 1.1)
       varia_model (~> 0.4.0)
-    ruby-progressbar (1.7.5)
+    ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
@@ -147,10 +153,11 @@ GEM
       dep_selector (~> 1.0)
       semverse (~> 1.1)
     systemu (2.6.5)
-    test-kitchen (1.4.2)
+    test-kitchen (1.10.2)
+      mixlib-install (~> 1.0, >= 1.0.4)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
-      net-ssh (~> 2.7, < 2.10)
+      net-ssh (>= 2.9, < 4.0)
       safe_yaml (~> 1.0)
       thor (~> 0.18)
     thor (0.19.1)
@@ -170,6 +177,3 @@ DEPENDENCIES
   omnibus!
   omnibus-software!
   test-kitchen (~> 1.2)
-
-BUNDLED WITH
-   1.11.2

--- a/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
+++ b/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
@@ -12,7 +12,6 @@ provisioner:
     ssl_verify_mode: verify_peer
 
 platforms:
-  - name: ubuntu-10.04
   - name: ubuntu-12.04
   - name: ubuntu-14.04
   - name: centos-5.11

--- a/omnibus/cookbooks/omnibus-supermarket/templates/default/sv-rails-run.erb
+++ b/omnibus/cookbooks/omnibus-supermarket/templates/default/sv-rails-run.erb
@@ -3,7 +3,10 @@ exec 2>&1
 
 export PATH=<%= node['supermarket']['install_directory'] %>/embedded/bin:$PATH
 export LD_LIBRARY_PATH=<%= node['supermarket']['install_directory'] %>/embedded/lib
-cd <%= node['supermarket']['install_directory'] %>/embedded/service/supermarket
+export DIR=<%= node['supermarket']['app_directory'] %>
+export HOME=$DIR
+
+cd $DIR
 
 exec <%= node['runit']['chpst_bin'] %> \
   -P \

--- a/omnibus/cookbooks/omnibus-supermarket/templates/default/sv-sidekiq-run.erb
+++ b/omnibus/cookbooks/omnibus-supermarket/templates/default/sv-sidekiq-run.erb
@@ -1,6 +1,11 @@
 #!/bin/sh
 exec 2>&1
-cd <%= node['supermarket']['app_directory'] %>
+
+export DIR=<%= node['supermarket']['app_directory'] %>
+export HOME=$DIR
+
+cd $DIR
+
 exec chpst \
        -u <%= node['supermarket']['user'] %> \
        -P \


### PR DESCRIPTION
Closes #1351 

Also:

* removes Ubuntu 10.04 from kitchen configs now that it is unsupported
* needed to include `HOME` environment variable in startup scripts for Ruby services to make rbreadline happy.