### PR TITLE
Making error handling in Fieri more verbose

### DIFF
--- a/src/fieri/.env
+++ b/src/fieri/.env
@@ -2,3 +2,4 @@ FIERI_FOODCRITIC_FAIL_TAGS=any
 FIERI_FOODCRITIC_TAGS=~FC031 ~FC045
 FIERI_RESULTS_ENDPOINT=http://supermarket.getchef.com/api/v1/cookbook-verisons/evaluation
 FIERI_KEY=YOUR_FIERI_KEY
+FIERI_LOG_PATH='./log/fieri.log'

--- a/src/fieri/.env.test
+++ b/src/fieri/.env.test
@@ -1,1 +1,2 @@
 REDIS_URL='redis://localhost:6379/2/fieri'
+FIERI_LOG_PATH='./spec/fixtures/fieri_test_log.log'

--- a/src/fieri/app/models/cookbook_worker.rb
+++ b/src/fieri/app/models/cookbook_worker.rb
@@ -12,16 +12,19 @@ class CookbookWorker
       logger.error e
     else
       feedback, status = cookbook.criticize
-
-      Net::HTTP.post_form(
-        URI.parse(ENV['FIERI_RESULTS_ENDPOINT']),
-        fieri_key: ENV['FIERI_KEY'],
-        cookbook_name: params['cookbook_name'],
-        cookbook_version: params['cookbook_version'],
-        foodcritic_feedback: feedback,
-        foodcritic_failure: status
-      )
-
+      begin
+        Net::HTTP.post_form(
+          URI.parse(ENV['FIERI_RESULTS_ENDPOINT']),
+          fieri_key: ENV['FIERI_KEY'],
+          cookbook_name: params['cookbook_name'],
+          cookbook_version: params['cookbook_version'],
+          foodcritic_feedback: feedback,
+          foodcritic_failure: status
+        )
+      rescue
+        logger = Logger.new File.new(File.expand_path(ENV['FIERI_LOG_PATH']))
+        logger.error e
+      end
       cookbook.cleanup
     end
   end

--- a/src/fieri/app/models/cookbook_worker.rb
+++ b/src/fieri/app/models/cookbook_worker.rb
@@ -8,24 +8,31 @@ class CookbookWorker
     begin
       cookbook = CookbookArtifact.new(params['cookbook_artifact_url'], jid)
     rescue Zlib::GzipFile::Error => e
-      logger = Logger.new File.new(File.expand_path('./log/fieri.log'))
-      logger.error e
-    else
-      feedback, status = cookbook.criticize
-      begin
-        Net::HTTP.post_form(
-          URI.parse(ENV['FIERI_RESULTS_ENDPOINT']),
-          fieri_key: ENV['FIERI_KEY'],
-          cookbook_name: params['cookbook_name'],
-          cookbook_version: params['cookbook_version'],
-          foodcritic_feedback: feedback,
-          foodcritic_failure: status
-        )
-      rescue
-        logger = Logger.new File.new(File.expand_path(ENV['FIERI_LOG_PATH']))
-        logger.error e
-      end
-      cookbook.cleanup
+      format_log_message(e)
     end
+    feedback, status = cookbook.criticize
+
+    begin
+      make_post(params, feedback, status)
+    rescue
+      format_log_message(e)
+    end
+    cookbook.cleanup
+  end
+
+  def format_log_message(e)
+    logger = Logger.new File.new(File.expand_path(ENV['FIERI_LOG_PATH']))
+    logger.error e
+  end
+
+  def make_post(params, feedback, status)
+    Net::HTTP.post_form(
+      URI.parse(ENV['FIERI_RESULTS_ENDPOINT']),
+      fieri_key: ENV['FIERI_KEY'],
+      cookbook_name: params['cookbook_name'],
+      cookbook_version: params['cookbook_version'],
+      foodcritic_feedback: feedback,
+      foodcritic_failure: status
+    )
   end
 end

--- a/src/fieri/spec/requests/fieri/fieri_jobs_spec.rb
+++ b/src/fieri/spec/requests/fieri/fieri_jobs_spec.rb
@@ -50,10 +50,8 @@ RSpec.describe 'Jobs', type: :request do
         ENV['FIERI_LOG_PATH'] = './spec/fixtures/fieri_test_log.log'
         logger = double('logger')
         allow(Logger).to receive(:new).and_return(logger)
+        allow(logger).to receive_messages(:level= => 1, :formatter= => Sidekiq::Logging::Pretty, :debug => "Sidekiq client with redis options {:url=>nil}")
 
-        allow(logger).to receive(:level=) { 1 }
-        allow(logger).to receive(:formatter=) { Sidekiq::Logging::Pretty }
-        allow(logger).to receive(:debug) { "Sidekiq client with redis options {:url=>nil}"}
         Sidekiq::Testing.inline! do
           allow(Net::HTTP).to receive(:post_form).and_raise("errors")
           expect(logger).to receive(:error)

--- a/src/fieri/spec/requests/fieri/fieri_jobs_spec.rb
+++ b/src/fieri/spec/requests/fieri/fieri_jobs_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sidekiq/testing'
 
 RSpec.describe 'Jobs', type: :request do
   describe 'POST /fieri_jobs' do
@@ -8,6 +9,7 @@ RSpec.describe 'Jobs', type: :request do
           cookbook_version: '1.2.0',
           cookbook_artifact_url: 'http://example.com/apache.tar.gz' }
       end
+
       it 'should return a 200' do
         post fieri.jobs_path valid_params
         expect(response).to have_http_status(200)
@@ -24,6 +26,39 @@ RSpec.describe 'Jobs', type: :request do
       it 'should return a 400' do
         post fieri.jobs_path(cookbook_name: 'redis')
         expect(response).to have_http_status(400)
+      end
+    end
+
+    describe 'when a job is redirected' do
+      let(:artifact) { CookbookArtifact.new('http://example.com/apache.tar.gz', 'somejobid2') }
+      let(:valid_params) do
+        { cookbook_name: 'redis',
+          cookbook_version: '1.2.0',
+          cookbook_artifact_url: 'http://example.com/apache.tar.gz' }
+      end
+
+      before do
+        stub_request(:get, 'http://example.com/apache.tar.gz').
+          to_return(
+            body: File.open(File.expand_path('./spec/fixtures/apache-no-metadata.rb.tar.gz')),
+            status: 200
+        )
+        allow_any_instance_of(CookbookArtifact).to receive(:criticize).and_return(['FC023: Prefer conditional attributes: /var/folders/m3/r80gybns1v357ff8q40pxw980000gn/T/e8f370c280fb21201b8d491d/apache2/definitions/apache_conf.rb:38', true])
+      end
+
+      it 'should be rescued' do
+        ENV['FIERI_LOG_PATH'] = './spec/fixtures/fieri_test_log.log'
+        logger = double('logger')
+        allow(Logger).to receive(:new).and_return(logger)
+
+        allow(logger).to receive(:level=) { 1 }
+        allow(logger).to receive(:formatter=) { Sidekiq::Logging::Pretty }
+        allow(logger).to receive(:debug) { "Sidekiq client with redis options {:url=>nil}"}
+        Sidekiq::Testing.inline! do
+          allow(Net::HTTP).to receive(:post_form).and_raise("errors")
+          expect(logger).to receive(:error)
+          CookbookWorker.perform_async(valid_params)
+        end
       end
     end
   end

--- a/src/fieri/spec/requests/fieri/fieri_jobs_spec.rb
+++ b/src/fieri/spec/requests/fieri/fieri_jobs_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Jobs', type: :request do
           to_return(
             body: File.open(File.expand_path('./spec/fixtures/apache-no-metadata.rb.tar.gz')),
             status: 200
-        )
+          )
         allow_any_instance_of(CookbookArtifact).to receive(:criticize).and_return(['FC023: Prefer conditional attributes: /var/folders/m3/r80gybns1v357ff8q40pxw980000gn/T/e8f370c280fb21201b8d491d/apache2/definitions/apache_conf.rb:38', true])
       end
 
@@ -50,10 +50,10 @@ RSpec.describe 'Jobs', type: :request do
         ENV['FIERI_LOG_PATH'] = './spec/fixtures/fieri_test_log.log'
         logger = double('logger')
         allow(Logger).to receive(:new).and_return(logger)
-        allow(logger).to receive_messages(:level= => 1, :formatter= => Sidekiq::Logging::Pretty, :debug => "Sidekiq client with redis options {:url=>nil}")
+        allow(logger).to receive_messages(:level= => 1, :formatter= => Sidekiq::Logging::Pretty, :debug => 'Sidekiq client with redis options {:url=>nil}')
 
         Sidekiq::Testing.inline! do
-          allow(Net::HTTP).to receive(:post_form).and_raise("errors")
+          allow(Net::HTTP).to receive(:post_form).and_raise('errors')
           expect(logger).to receive(:error)
           CookbookWorker.perform_async(valid_params)
         end

--- a/src/fieri/spec/requests/fieri/fieri_status_spec.rb
+++ b/src/fieri/spec/requests/fieri/fieri_status_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'sidekiq/api'
 
 RSpec.describe 'Jobs', type: :request do
   describe 'GET /status' do


### PR DESCRIPTION
Fixes #1327. Adds tests and logic for capturing standard errors and logging them in Fieri.