### PR TITLE
Create the log directory to avoid failures which assume it's created

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
@@ -59,6 +59,14 @@ directory node['supermarket']['var_directory'] do
   owner node['supermarket']['user']
   group node['supermarket']['group']
   mode '0700'
+  recursive true
+end
+
+directory node['supermarket']['log_directory'] do
+  owner node['supermarket']['user']
+  group node['supermarket']['group']
+  mode '0700'
+  recursive true
 end
 
 directory "#{node['supermarket']['var_directory']}/etc" do


### PR DESCRIPTION
Create log and var directory recursively in case parent directories don't exist.

Without these options, setting the log and var directories to non-default locations will fail randomly due to missing parents. Furthermore, the cookbook will (try to) make subdirectories of these locations without having ensured they exist.

```
    [2016-07-01T20:22:58+00:00] INFO: Processing directory[/data/supermarket/log/sidekiq] action create (omnibus-supermarket::sidekiq line 20)

    ================================================================================
    Error executing action `create` on resource 'directory[/data/supermarket/log/sidekiq]'
    ================================================================================

    Chef::Exceptions::EnclosingDirectoryDoesNotExist
    ------------------------------------------------
    Parent directory /data/supermarket/log does not exist, cannot create /data/supermarket/log/sidekiq

    Resource Declaration:
    ---------------------
    # In /var/opt/supermarket/cache/cache/cookbooks/omnibus-supermarket/recipes/sidekiq.rb

     20: directory "#{node['supermarket']['log_directory']}/sidekiq" do
     21:   owner node['supermarket']['user']
     22:   group node['supermarket']['group']
     23:   mode '0700'
     24: end
     25:

    Compiled Resource:
    ------------------
    # Declared in /var/opt/supermarket/cache/cache/cookbooks/omnibus-supermarket/recipes/sidekiq.rb:20:in `from_file'

    directory("/data/supermarket/log/sidekiq") do
      action :create
      retries 0
      retry_delay 2
      default_guard_interpreter :default
      path "/data/supermarket/log/sidekiq"
      declared_type :directory
      cookbook_name "omnibus-supermarket"
      recipe_name "sidekiq"
      owner "supermarket"
      group "supermarket"
      mode "0700"
    end
```