### PR TITLE
Add a HOME to db migrate command in omnibus

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/recipes/database.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/database.rb
@@ -80,6 +80,9 @@ end
 execute 'database schema' do
   command 'bundle exec rake db:migrate db:seed'
   cwd node['supermarket']['app_directory']
-  env 'RAILS_ENV' => 'production'
+  environment({
+    'RAILS_ENV' => 'production',
+    'HOME' => node['supermarket']['app_directory']
+  })
   user node['supermarket']['user']
 end


### PR DESCRIPTION
Our calls to `bundle exec` in the omnibus install need to have a HOME set because of an updated [rb-readline that requires an `ENV['HOME']` to be present](https://github.com/ConnorAtherton/rb-readline/issues/8). This is related to 28344e92c243974c991093474d90b64a7fe37b72, where a HOME was added to the runit startup scripts for rails and sidekiq. This is the only other `bundle exec` in the omnibus cookbook and so it needs a HOME, too.

Presumably fixes chef-cookbooks/supermarket-omnibus-cookbook#41, but we're currently lacking an automated reproduction of the problem and test of the fix.