### PR TITLE
Switch to using with_name scope to handle downcasing incoming cookbook names

### DIFF
--- a/src/supermarket/app/controllers/api/v1/cookbook_versions_controller.rb
+++ b/src/supermarket/app/controllers/api/v1/cookbook_versions_controller.rb
@@ -78,7 +78,7 @@ class Api::V1::CookbookVersionsController < Api::V1Controller
     require_collaborator_params
 
     if ENV['FIERI_KEY'] == params['fieri_key']
-      cookbook_version = Cookbook.where(lowercase_name: params[:cookbook_name]).first.cookbook_versions.last
+      cookbook_version = Cookbook.with_name(params[:cookbook_name]).first.cookbook_versions.last
 
       cookbook_version.update(
         collaborator_failure: params[:collaborator_failure],


### PR DESCRIPTION
Use the [`Cookbook.with_name`](https://github.com/chef/supermarket/blob/master/src/supermarket/app/models/cookbook.rb#L20-L24) scope to handle downcasing the cookbook name to find. Otherwise, the chained methods fail for cookbooks whose names contain capitals
when fieri posts results.

```
NoMethodError: undefined method `cookbook_versions' for nil:NilClass
```