### PR TITLE
Add a helper that returns all platforms know to supermarket

### DIFF
--- a/src/supermarket/app/helpers/supported_platforms_helper.rb
+++ b/src/supermarket/app/helpers/supported_platforms_helper.rb
@@ -11,25 +11,44 @@ module SupportedPlatformsHelper
   #
   def known_platforms
     %(aix
+      alpine
       amazon
+      arch
       cento
+      cloudlinux
       debian
       fedora
       freebsd
       gentoo
+      hpux
+      ibm_powerkvm
+      ios_xr
+      linuxmint
       mac_os_x
+      netbsd
+      nexentacore
+      nexus
+      nexus_centos
       omnios
       openbsd
+      openindiana
+      opensolaris
       opensuse
       opensuseleap
       oracle
+      parallels
+      pidora
+      raspbian
       redhat
-      ubuntu
       scientific
+      slackware
       smartos
       solaris
       suse
+      ubuntu
       windows
+      wrlinux
+      xenserver
       zlinux)
   end
 

--- a/src/supermarket/app/helpers/supported_platforms_helper.rb
+++ b/src/supermarket/app/helpers/supported_platforms_helper.rb
@@ -1,4 +1,39 @@
 module SupportedPlatformsHelper
+
+  #
+  # Returns an array of all known platforms to Supermarket
+  #
+  # @example
+  #   puts known_platforms.join(',')
+  #
+  #
+  # @return [Array] platforms
+  #
+  def known_platforms
+    %(aix
+      amazon
+      cento
+      debian
+      fedora
+      freebsd
+      gentoo
+      mac_os_x
+      omnios
+      openbsd
+      opensuse
+      opensuseleap
+      oracle
+      redhat
+      ubuntu
+      scientific
+      smartos
+      solaris
+      suse
+      windows
+      zlinux)
+  end
+
+
   #
   # Determines the correct icon to use for a given platform
   #

--- a/src/supermarket/app/views/application/_search.html.erb
+++ b/src/supermarket/app/views/application/_search.html.erb
@@ -46,7 +46,7 @@
     <h4> Select Supported Platforms </h4>
     <div class = "advanced_search_platforms" >
 
-      <% %w(aix amazon centos debian fedora freebsd gentoo mac_os_x omnios openbsd opensuse opensuseleap oracle redhat ubuntu scientific smartos solaris suse windows zlinux).each do |platform| %>
+      <% known_platforms.each do |platform| %>
         <div class="advanced_search_platform">
             <label>
               <%=check_box_tag 'platforms[]', platform, params[:platforms] ? params[:platforms].include?(platform) : false %>


### PR DESCRIPTION
Creates a single place for us to add new platforms. This will be used by the "any" concept in a bit

Signed-off-by: Tim Smith <tsmith@chef.io>