### PR TITLE
Log foodcritic postback errors from fieri to supermarket

### DIFF
--- a/src/fieri/app/models/foodcritic_worker.rb
+++ b/src/fieri/app/models/foodcritic_worker.rb
@@ -5,24 +5,30 @@ class FoodcriticWorker
   include ::Sidekiq::Worker
 
   def perform(params)
-    begin
-      cookbook = CookbookArtifact.new(params['cookbook_artifact_url'], jid)
-    rescue Zlib::GzipFile::Error => e
-      logger = Logger.new File.new(File.expand_path('./log/fieri.log'))
-      logger.error e
-    else
-      feedback, status = cookbook.criticize
+    cookbook = CookbookArtifact.new(params['cookbook_artifact_url'], jid)
+    feedback, status = cookbook.criticize
+    make_post(params, feedback, status)
+    cookbook.cleanup
+  rescue => e
+    log_error(e)
+  end
 
-      Net::HTTP.post_form(
-        URI.parse("#{ENV['FIERI_SUPERMARKET_ENDPOINT']}/api/v1/cookbook-versions/foodcritic_evaluation"),
-        fieri_key: ENV['FIERI_KEY'],
-        cookbook_name: params['cookbook_name'],
-        cookbook_version: params['cookbook_version'],
-        foodcritic_feedback: feedback,
-        foodcritic_failure: status
-      )
+  def log_error(e)
+    logger.error e
+  end
 
-      cookbook.cleanup
+  def make_post(params, feedback, status)
+    response = Net::HTTP.post_form(
+      URI.parse("#{ENV['FIERI_SUPERMARKET_ENDPOINT']}/api/v1/cookbook-versions/foodcritic_evaluation"),
+      fieri_key: ENV['FIERI_KEY'],
+      cookbook_name: params['cookbook_name'],
+      cookbook_version: params['cookbook_version'],
+      foodcritic_feedback: feedback,
+      foodcritic_failure: status
+    )
+    unless response.is_a? Net::HTTPSuccess
+      error_msg = "Unable to POST Foodcritic Evaluation of #{params[cookbook_name]} " + response.message
+      raise error_msg
     end
   end
 end

--- a/src/fieri/spec/models/foodcritic_worker_spec.rb
+++ b/src/fieri/spec/models/foodcritic_worker_spec.rb
@@ -44,16 +44,6 @@ describe FoodcriticWorker do
     end
   end
 
-  it 'creates a unique directory for each job to work within' do
-    Sidekiq::Testing.inline! do
-      job_id_1 = FoodcriticWorker.perform_async(valid_params)
-      job_id_2 = FoodcriticWorker.perform_async(valid_params)
-
-      assert Dir.exist?(File.join(Dir.tmpdir, job_id_1))
-      assert Dir.exist?(File.join(Dir.tmpdir, job_id_2))
-    end
-  end
-
   describe 'when posting results back to Supermarket' do
     let(:not_gonna_work_params) do
       valid_params.merge('cookbook_name' => 'not_gonna_work')

--- a/src/fieri/spec/models/foodcritic_worker_spec.rb
+++ b/src/fieri/spec/models/foodcritic_worker_spec.rb
@@ -1,19 +1,29 @@
 require 'rails_helper'
 
 describe FoodcriticWorker do
+  let(:valid_params) do
+    { 'cookbook_artifact_url' => 'http://example.com/apache.tar.gz',
+      'cookbook_name' => 'apache2',
+      'cookbook_version' => '1.2.0' }
+  end
+
+  let(:test_evaluation_endpoint) do
+    "#{ENV['FIERI_SUPERMARKET_ENDPOINT']}/api/v1/cookbook-versions/foodcritic_evaluation"
+  end
+
   before do
     #
     # Stubs criticize for speed!
     #
-    CookbookArtifact.any_instance.stub(:criticize)
-                    .and_return('FC023', true)
+    allow_any_instance_of(CookbookArtifact).to receive(:criticize)
+      .and_return('FC023', true)
 
     #
     # Stubs cleanup so we can test the creation of unique
     # directories.
     #
-    CookbookArtifact.any_instance.stub(:cleanup)
-                    .and_return(0)
+    allow_any_instance_of(CookbookArtifact).to receive(:cleanup)
+      .and_return(0)
 
     stub_request(:get, 'http://example.com/apache.tar.gz').
       to_return(
@@ -21,19 +31,52 @@ describe FoodcriticWorker do
         status: 200
       )
 
-    stub_request(:post, "#{ENV['FIERI_SUPERMARKET_ENDPOINT']}/api/v1/cookbook-versions/foodcritic_evaluation")
+    stub_request(:post, test_evaluation_endpoint).
+      with(body: hash_including(cookbook_name: 'apache2'))
   end
 
   it 'sends a post request to the results endpoint' do
-    FoodcriticWorker.new.perform(
-      'cookbook_artifact_url' => 'http://example.com/apache.tar.gz',
-      'cookbook_name' => 'apache2',
-      'cookbook_version' => '1.2.0'
-    )
+    subject.perform(valid_params)
 
-    assert_requested(:post, "#{ENV['FIERI_SUPERMARKET_ENDPOINT']}/api/v1/cookbook-versions/foodcritic_evaluation", times: 1) do |req|
+    assert_requested(:post, test_evaluation_endpoint) do |req|
       req.body =~ /foodcritic_failure=true/
       req.body =~ /FC023/
+    end
+  end
+
+  it 'creates a unique directory for each job to work within' do
+    Sidekiq::Testing.inline! do
+      job_id_1 = FoodcriticWorker.perform_async(valid_params)
+      job_id_2 = FoodcriticWorker.perform_async(valid_params)
+
+      assert Dir.exist?(File.join(Dir.tmpdir, job_id_1))
+      assert Dir.exist?(File.join(Dir.tmpdir, job_id_2))
+    end
+  end
+
+  describe 'when posting results back to Supermarket' do
+    let(:not_gonna_work_params) do
+      valid_params.merge('cookbook_name' => 'not_gonna_work')
+    end
+
+    it 'rescues a POST error' do
+      stub_request(:post, test_evaluation_endpoint).
+        with(body: hash_including(cookbook_name: 'not_gonna_work')).
+        to_return(status: 502, body: '', headers: {})
+
+      expect(subject).to receive(:log_error)
+
+      subject.perform(not_gonna_work_params)
+    end
+
+    it 'rescues a timeout' do
+      stub_request(:post, test_evaluation_endpoint).
+        with(body: hash_including(cookbook_name: 'not_gonna_work')).
+        to_timeout
+
+      expect(subject).to receive(:log_error)
+
+      subject.perform(not_gonna_work_params)
     end
   end
 end


### PR DESCRIPTION
Added test to confirm POST response was successful. Logs the error if not.

Based on the work in #1377 

Fixes #1327 