### PR TITLE
Use the new Foodcritic URL

### DIFF
--- a/src/supermarket/app/views/cookbooks/_main.html.erb
+++ b/src/supermarket/app/views/cookbooks/_main.html.erb
@@ -119,7 +119,7 @@
           <% if version.foodcritic_feedback.present? %>
             <pre><%= version.foodcritic_feedback.gsub(/\n/, '<br />').html_safe %></pre>
           <% else %>
-            <p><%= version.version %> passed <%= link_to 'Foodcritic', 'http://acrmp.github.io/foodcritic', target: '_blank' %>.
+            <p><%= version.version %> passed <%= link_to 'Foodcritic', 'http://www.foodcritic.io/', target: '_blank' %>.
           <% end %>
 
           <br />


### PR DESCRIPTION
Avoid a redirect and help the right URL get to the top in Google search results

Signed-off-by: Tim Smith <tsmith@chef.io>