### PR TITLE
Consistent naming

### DIFF
--- a/src/fieri/config/locales/en.yml
+++ b/src/fieri/config/locales/en.yml
@@ -1,5 +1,5 @@
 en:
   quality_metrics:
     collaborator:
-      success: 'passed the Collaborator Metric with %{num_collaborators} collaborators.'
+      success: 'passed the Collaborators Metric with %{num_collaborators} collaborators.'
       failure: 'Failure: Cookbook has %{num_collaborators} collaborators. A cookbook must have at least %{passing_number} collaborators to pass this metric.'

--- a/src/fieri/spec/models/collaborator_worker_spec.rb
+++ b/src/fieri/spec/models/collaborator_worker_spec.rb
@@ -21,7 +21,7 @@ describe CollaboratorWorker do
     expect(cw.get_collaborator_count(json_response)).to eq 2
   end
 
-  it 'checks whether coookbook version passes collaborator metrics' do
+  it 'checks whether coookbook version passes collaborators metrics' do
     expect(cw.sufficient_collaborators?(2)).to eql(true)
     expect(cw.sufficient_collaborators?(1)).to eql(false)
   end


### PR DESCRIPTION
We're mixing up plural vs. singular in the wording

Signed-off-by: Tim Smith <tsmith@chef.io>