### PR TITLE
Allow omnibus test-kitchen tests to run in parallel

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
+++ b/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
@@ -2,7 +2,7 @@
 driver:
   name: vagrant
   network:
-    - ['private_network', { ip: '192.168.33.33' }]
+    - ['private_network', type: 'dhcp']
   synced_folders:
     - ['../../pkg', '/tmp/packages', 'create: true, type: :rsync']
 
@@ -26,6 +26,5 @@ suites:
     attributes:
       supermarket:
         test:
-          deb_package_path: <%= ENV['SUPERMARKET_DEB'] || false %>
-          rpm_package_path: <%= ENV['SUPERMARKET_RPM'] || false %>
+          version_to_install: <%= ENV['VERSION_TO_INSTALL'] || false %>
         ingredient_config:

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/cookbook_test.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/cookbook_test.rb
@@ -23,19 +23,17 @@
 # the cookbooks with integration tests.
 
 # If attributes are defined for packages, install them
-deb_package_path = node['supermarket']['test']['deb_package_path']
-rpm_package_path = node['supermarket']['test']['rpm_package_path']
+package_path = node['supermarket']['test']['package_path'] || '/tmp/packages'
+version_to_install = node['supermarket']['test']['version_to_install'] || 'nope_set_VERSION_TO_INSTALL'
 
 package 'supermarket' do
   case node['platform_family']
   when 'debian'
     provider Chef::Provider::Package::Dpkg
-    source deb_package_path
-    only_if { deb_package_path }
+    source "#{package_path}/supermarket_#{version_to_install}-1_amd64.deb"
   when 'rhel'
     provider Chef::Provider::Package::Rpm
-    source rpm_package_path
-    only_if { rpm_package_path }
+    source "#{package_path}/supermarket-#{version_to_install}-1.el#{node['platform_version'].to_i}.x86_64.rpm"
   end
 end
 


### PR DESCRIPTION
Previously, the exact file path to a package file had to be set
for a version. Sadly, for RHEL, that file path includes the platform
version (e.g. el6 vs el7). This updates the kitchen config and test
recipe to only require a version number for the package to be tested
and computes the file path.

package_path's default is based on the kitchen config's
synced_folders.

Note, you'll still need to have a build for a particular platform
stowed in omnibus/pkg prior to running kitchen for the package to
be available within the TK machine.

Signed-off-by: Robb Kidd <rkidd@chef.io>