### PR TITLE
Use remote_file instead of execute-n-curl

### DIFF
--- a/.delivery/build_cookbook/recipes/_install_docker.rb
+++ b/.delivery/build_cookbook/recipes/_install_docker.rb
@@ -5,7 +5,7 @@ include_recipe 'chef-apt-docker::default'
 
 package "docker-engine"
 
-remote_file '/usr/local/bin/docker-compose' do
+remote_file "#{delivery_workspace_cache}/docker-compose" do
   source 'https://github.com/docker/compose/releases/download/1.8.0/docker-compose-Linux-x86_64'
   checksum 'ebc6ab9ed9c971af7efec074cff7752593559496d0d5f7afb6bfd0e0310961ff'
   owner 'root'

--- a/.delivery/build_cookbook/recipes/_install_docker.rb
+++ b/.delivery/build_cookbook/recipes/_install_docker.rb
@@ -5,14 +5,14 @@ include_recipe 'chef-apt-docker::default'
 
 package "docker-engine"
 
-execute 'install docker-compose' do
-  command <<-EOH
-curl -L https://github.com/docker/compose/releases/download/1.8.0/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-EOH
+remote_file '/usr/local/bin/docker-compose' do
+  source 'https://github.com/docker/compose/releases/download/1.8.0/docker-compose-Linux-x86_64'
+  checksum 'ebc6ab9ed9c971af7efec074cff7752593559496d0d5f7afb6bfd0e0310961ff'
+  owner 'root'
+  group 'docker'
+  mode  '0755'
 end
 
 # Ensure the `dbuild` user is part of the `docker` group so they can
 # connect to the Docker daemon
 execute "usermod -aG docker #{node['delivery_builder']['build_user']}"
-

--- a/.delivery/build_cookbook/recipes/unit.rb
+++ b/.delivery/build_cookbook/recipes/unit.rb
@@ -21,7 +21,7 @@ class DockerComposeKiller < Chef::Handler
 
   def report
     Chef::Log.info("Tearing down docker-composed dependency services.")
-    cmd = "docker-compose down"
+    cmd = "#{delivery_workspace_cache}/docker-compose down"
     so = Mixlib::ShellOut.new(cmd, cwd: cwd)
     so.run_command
     if so.error?
@@ -36,7 +36,7 @@ Chef::Config.exception_handlers << ishmael
 Chef::Config.report_handlers << ishmael
 
 execute 'Startup dependency services in Docker' do
-  command 'docker-compose up -d'
+  command "#{delivery_workspace_cache}/docker-compose up -d"
   cwd "#{delivery_workspace_repo}/src/supermarket"
   environment('USER' => node['delivery_builder']['build_user'])
   live_stream true


### PR DESCRIPTION
Check that the docker-compose we download is the one we expect with a checksum.

Also don't need to `uname` things because we only use 64-bit Linux builders for this pipeline.