### PR TITLE
Case insensitive hostname

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -61,7 +61,7 @@
 
 # The fully qualified domain name. Will use the node's fqdn if nothing is
 # specified.
-default['supermarket']['fqdn'] = node['fqdn']
+default['supermarket']['fqdn'] = node['fqdn'].downcase
 
 # The URL for the Chef server. Used with the "Chef OAuth2 Settings" and
 # "Chef URL Settings" below. If this is not set, authentication and some of the

--- a/omnibus/cookbooks/omnibus-supermarket/templates/default/rails.nginx.conf.erb
+++ b/omnibus/cookbooks/omnibus-supermarket/templates/default/rails.nginx.conf.erb
@@ -54,7 +54,7 @@ server {
 
   # Redirect anything that isn't an ip address (for ELB checks) or the
   # canonical server name to <%= node['supermarket']['fqdn'] %>
-  if ($host !~ "^(<%= node['supermarket']['fqdn'].gsub('.', '\.') %>|[0-9.]+)$") {
+  if ($host !~* "^(<%= node['supermarket']['fqdn'].gsub('.', '\.') %>|[0-9.]+)$") {
     set $redirect_to_canonical H;
   }
 


### PR DESCRIPTION
Right now if you have a uppercase character in the hostname of your supermarket server and you try to access it thru http instead of https, an endless loop will occur because the regexp code on site-enabled/rails doesn't match the uppercase name. A simple * will fix regexp.

Fixes #1412