### PR TITLE
Check gem versions for known vulnerabilities during security phase.

### DIFF
--- a/.delivery/build_cookbook/recipes/security.rb
+++ b/.delivery/build_cookbook/recipes/security.rb
@@ -3,3 +3,15 @@
 # Recipe:: security
 #
 # Copyright (c) 2016 The Authors, All Rights Reserved.
+
+gem_cache = File.join(node['delivery']['workspace']['root'], "../../../project_gem_cache")
+
+ruby_execute "Audit our gems for known vulnerabilities" do
+  version node['build_cookbook']['ruby_version']
+  command <<-CMD
+bundle install && \
+bundle exec bundle exec bundle-audit check --update
+CMD
+  cwd "#{delivery_workspace_repo}/src/supermarket"
+  environment('BUNDLE_PATH' => gem_cache)
+end

--- a/.delivery/config.json
+++ b/.delivery/config.json
@@ -6,7 +6,6 @@
   },
   "skip_phases": [
     "syntax",
-    "security",
     "quality",
     "provision",
     "deploy",


### PR DESCRIPTION
This is run during the Security phase of the Build stage because the team concluded that in general, the findings of gems that need to be updated is not a failure directly attributable the changes in a changeset. As such, the change to update gem versions should come in to the pipeline as a new change.