### PR TITLE
Upgrade PostgreSQL to 9.3.14

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 09cf045c2e7622b05348855d7495470777f95df2
+  revision: 8eeb0bb45b01b833389c662932c9fab9042f328b
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 9f8d05967531c93973c0406a0c68171fd52f238a
+  revision: 3eefb1cd8de69b1d97de2962f779512892e9296d
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -27,12 +27,12 @@ GEM
   specs:
     addressable (2.3.8)
     artifactory (2.3.3)
-    aws-sdk (2.5.10)
-      aws-sdk-resources (= 2.5.10)
-    aws-sdk-core (2.5.10)
+    aws-sdk (2.5.11)
+      aws-sdk-resources (= 2.5.11)
+    aws-sdk-core (2.5.11)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.5.10)
-      aws-sdk-core (= 2.5.10)
+    aws-sdk-resources (2.5.11)
+      aws-sdk-core (= 2.5.11)
     berkshelf (3.3.0)
       addressable (~> 2.3.4)
       berkshelf-api-client (~> 1.2)

--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -28,7 +28,7 @@ install_dir "#{default_root}/#{name}"
 build_version Omnibus::BuildVersion.semver
 build_iteration 1
 
-override :postgresql, version: '9.3.6'
+override :postgresql, version: '9.3.14'
 override :ruby, version: "2.3.0"
 override :rubygems, version: "2.4.8"
 override :git, version: "2.2.1"


### PR DESCRIPTION
[9.3.7](https://www.postgresql.org/docs/current/static/release-9-3-7.html):

* CVE-2015-3165: Avoid possible crash when client disconnects just
  before the authentication timeout expires
* CVE-2015-3166: Improve detection of system-call failures and
  information disclosure with out-of-memory situations and buffer
  overflows.
* CVE-2015-3167: uniformly report decryption failures as "Wrong key or
  corrupt data" to avoid the risk of aiding attackers in recovering keys
  from other systems

[9.3.10](https://www.postgresql.org/docs/current/static/release-9-3-10.html):

* CVE-2015-5289: Guard against stack overflows in json parsing
* CVE-2015-5288: Fix contrib/pgcrypto to detect and report too-short
  crypt() salts

[9.3.11](https://www.postgresql.org/docs/current/static/release-9-3-11.html):

* CVE-2016-0773: Very large character ranges in bracket expressions
  could cause infinite loops in some cases, and memory overwrites in
  other cases.
* CVE-2007-4772: A more complete fix for an old fix to regex compiler
  handling loops.
* CVE-2016-0766: Mitigate a PL/Java bug.

[9.3.14](https://www.postgresql.org/docs/current/static/release-9-3-14.html):

* CVE-2016-5423: possible mis-evaluation of nested CASE-WHEN expressions
* CVE-2016-5424: Fix client programs' handling of special characters in
  database and role names. ... considered security fixes because crafted
  object names containing special characters could have been used to
  execute commands with superuser privileges the next time a superuser
  executes pg_dumpall or other routine maintenance operations.
