### PR TITLE
upgrade to OpenSSL 1.0.2j

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 8eeb0bb45b01b833389c662932c9fab9042f328b
+  revision: 2186b5816b13c5712d17ffe66e7cab8cf28ca735
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 3eefb1cd8de69b1d97de2962f779512892e9296d
+  revision: ed8a050dc3df3fca242f068879cfc867762428d3
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -27,12 +27,12 @@ GEM
   specs:
     addressable (2.4.0)
     artifactory (2.3.3)
-    aws-sdk (2.5.11)
-      aws-sdk-resources (= 2.5.11)
-    aws-sdk-core (2.5.11)
+    aws-sdk (2.6.3)
+      aws-sdk-resources (= 2.6.3)
+    aws-sdk-core (2.6.3)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.5.11)
-      aws-sdk-core (= 2.5.11)
+    aws-sdk-resources (2.6.3)
+      aws-sdk-core (= 2.6.3)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -68,7 +68,8 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.13.37)
+    chef-config (12.14.89)
+      addressable
       fuzzyurl
       mixlib-config (~> 2.0)
       mixlib-shellout (~> 2.0)
@@ -90,7 +91,7 @@ GEM
     kitchen-vagrant (0.20.0)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (0.1.2)
+    license_scout (0.1.3)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
     minitar (0.5.4)

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 2186b5816b13c5712d17ffe66e7cab8cf28ca735
+  revision: 778b2bb20cb3f64207ad822c1277e6068be5bbfc
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)

--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -34,7 +34,7 @@ override :rubygems, version: "2.4.8"
 override :git, version: "2.2.1"
 override :'chef-gem', version: '12.13.37'
 override :redis, version: '2.8.21'
-override :openssl, version: '1.0.2h'
+override :openssl, version: '1.0.2i'
 
 # pin berks to keep net-ssh at 2.9.2 as expected by Supermarket
 # chef, net-ssh, berks and rspec have gotten tangled

--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -34,7 +34,7 @@ override :rubygems, version: "2.4.8"
 override :git, version: "2.2.1"
 override :'chef-gem', version: '12.13.37'
 override :redis, version: '2.8.21'
-override :openssl, version: '1.0.2i'
+override :openssl, version: '1.0.2j'
 
 # pin berks to keep net-ssh at 2.9.2 as expected by Supermarket
 # chef, net-ssh, berks and rspec have gotten tangled


### PR DESCRIPTION
## Severity: High

* OCSP Status Request extension unbounded memory growth (CVE-2016-6304)

## Severity: Medium

* SSL_peek() hang on empty record (CVE-2016-6305)
* Missing CRL sanity check (CVE-2016-7052)

## Severity: Low

* SWEET32 Mitigation (CVE-2016-2183)
* OOB write in MDC2_Update() (CVE-2016-6303)
* Malformed SHA512 ticket DoS (CVE-2016-6302)
* OOB write in BN_bn2dec() (CVE-2016-2182)
* OOB read in TS_OBJ_print_bio() (CVE-2016-2180)
* Pointer arithmetic undefined behaviour (CVE-2016-2177)
* Constant time flag not preserved in DSA signing (CVE-2016-2178)
* DTLS buffered message DoS (CVE-2016-2179)
* DTLS replay protection DoS (CVE-2016-2181)
* Certificate message OOB reads (CVE-2016-6306)
* Excessive allocation of memory in tls_get_message_header() (CVE-2016-6307)
* Excessive allocation of memory in dtls1_preprocess_fragment() (CVE-2016-6308)

https://www.openssl.org/news/secadv/20160922.txt

UPDATE: Now includes 1.0.2i and 1.0.2j.

Fixes #1435 