### PR TITLE
Generally simplify the advanced search toggle styles and make cute

### DIFF
--- a/src/supermarket/app/assets/stylesheets/cookbooks/search.scss
+++ b/src/supermarket/app/assets/stylesheets/cookbooks/search.scss
@@ -200,15 +200,12 @@ input[type="search"].cookbook_search_textfield {
 
 .advanced_search_toggle {
   @include grid-column($columns: 12, $collapse: true);
-  margin-bottom: rem-calc(-21);
-  padding-right: rem-calc(2);
-  margin-top: rem-calc(10);
   cursor: pointer;
+  text-align: right;
+  margin-top: rem-calc(15);
 
   span {
     color: lighten($primary_gray, 20%);
-    float: right;
-    margin-right: rem-calc(10);
     font: rem-calc(14) $accent_font;
     &:hover{
       color: white;


### PR DESCRIPTION
The toggle was butting up against the bottom of the search bar on mobile, this fixes that.

**Before:**

<img width="444" alt="screen shot 2016-10-28 at 7 46 14 pm" src="https://cloud.githubusercontent.com/assets/316507/19825496/d2ba74a4-9d47-11e6-9a3a-09c40e732b11.png">

**After:** ✨ 

<img width="434" alt="screen shot 2016-10-28 at 7 46 30 pm" src="https://cloud.githubusercontent.com/assets/316507/19825498/d84fd92c-9d47-11e6-8a7e-d5fc2f4d79a9.png">