### PR TITLE
add type and order parameters to the tools API search endpoint

### DIFF
--- a/src/supermarket/spec/api/tools_search_spec.rb
+++ b/src/supermarket/spec/api/tools_search_spec.rb
@@ -22,6 +22,18 @@ describe 'GET /api/v1/tools/search' do
     expect(json_body).to eql(search_response)
   end
 
+  it 'returns tools ordered by recently_added' do
+    search_response = {
+      'items' => [search_signature(berkshelf_2), search_signature(berkshelf)],
+      'total' => 2,
+      'start' => 0
+    }
+
+    get '/api/v1/tools-search?q=berkshelf&order=recently_added'
+
+    expect(json_body).to eql(search_response)
+  end
+
   it 'handles the start and items params' do
     search_response = {
       'items' => [search_signature(berkshelf_2)],
@@ -32,6 +44,20 @@ describe 'GET /api/v1/tools/search' do
     get '/api/v1/tools-search?q=berkshelf&start=1&items=1'
 
     expect(json_body).to eql(search_response)
+  end
+
+  it 'returns tools filtered by tool type' do
+    policy = create(:tool, name: 'awesome_policy', type: 'compliance_profile')
+
+    search_response = {
+      'items' => [search_signature(policy)],
+      'total' => 1,
+      'start' => 0
+    }
+
+    get '/api/v1/tools-search?type=compliance_profile'
+
+    expect(json_body).to eq(search_response)
   end
 end
 


### PR DESCRIPTION
Updated the tools-search API endpoint to behave more like the UI search logic. 

* Adds a type parameter so that tool results can be filtered by tool type.
* Adds order parameter to specify ordering of results.

Fixes #1454 