### PR TITLE
fix seeds not knowing about a column we just added in a migration

### DIFF
--- a/src/supermarket/app/models/metric_result.rb
+++ b/src/supermarket/app/models/metric_result.rb
@@ -2,7 +2,7 @@ class MetricResult < ActiveRecord::Base
   belongs_to :cookbook_version
   belongs_to :quality_metric
 
-  scope :open, -> { joins(:quality_metric).where('quality_metrics.admin_only IS NULL') }
+  scope :open, -> { joins(:quality_metric).where('quality_metrics.admin_only = false') }
   scope :admin_only, -> { joins(:quality_metric).where('quality_metrics.admin_only = true') }
 
   delegate :name, to: :quality_metric

--- a/src/supermarket/app/models/metric_result.rb
+++ b/src/supermarket/app/models/metric_result.rb
@@ -2,8 +2,8 @@ class MetricResult < ActiveRecord::Base
   belongs_to :cookbook_version
   belongs_to :quality_metric
 
-  scope :open, -> { joins(:quality_metric).where('quality_metrics.admin_only = false') }
-  scope :admin_only, -> { joins(:quality_metric).where('quality_metrics.admin_only = true') }
+  scope :open, -> { joins(:quality_metric).merge(QualityMetric.open) }
+  scope :admin_only, -> { joins(:quality_metric).merge(QualityMetric.admin_only) }
 
   delegate :name, to: :quality_metric
   delegate :admin_only?, to: :quality_metric

--- a/src/supermarket/app/models/quality_metric.rb
+++ b/src/supermarket/app/models/quality_metric.rb
@@ -1,6 +1,9 @@
 class QualityMetric < ActiveRecord::Base
   has_many :metric_results
 
+  scope :open, -> { where(admin_only: false) }
+  scope :admin_only, -> { where(admin_only: true) }
+
   validates :name, uniqueness: true
 
   def self.foodcritic_metric

--- a/src/supermarket/db/migrate/20161116191103_add_admin_only_to_quality_metrics.rb
+++ b/src/supermarket/db/migrate/20161116191103_add_admin_only_to_quality_metrics.rb
@@ -1,5 +1,5 @@
 class AddAdminOnlyToQualityMetrics < ActiveRecord::Migration
   def change
-    add_column :quality_metrics, :admin_only, :boolean
+    add_column :quality_metrics, :admin_only, :boolean, default: false, null: false
   end
 end

--- a/src/supermarket/db/schema.rb
+++ b/src/supermarket/db/schema.rb
@@ -399,9 +399,9 @@ ActiveRecord::Schema.define(version: 20161116191103) do
 
   create_table "quality_metrics", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.boolean  "admin_only"
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.boolean  "admin_only", default: false, null: false
   end
 
   create_table "supported_platforms", force: :cascade do |t|

--- a/src/supermarket/db/seeds.rb
+++ b/src/supermarket/db/seeds.rb
@@ -13,6 +13,8 @@ attributes = {}
   ).read
 end
 
+QualityMetric.reset_column_information
+
 unless(QualityMetric.where(name: 'Foodcritic').any?)
   QualityMetric.create!(name: 'Foodcritic')
 end
@@ -257,6 +259,9 @@ if Rails.env.development?
     'apt' => %w(debian ubuntu),
     'postgres' => %w(fedora debian suse amazon centos redhat scientific oracle ubuntu)
   }
+
+  Cookbook.reset_column_information
+  CookbookVersion.reset_column_information
 
   %w(apt redis postgres node ruby haskell clojure java mysql apache2 nginx yum app).each do |name|
     cookbook = Cookbook.where(


### PR DESCRIPTION
I'm still confused about why when running `db:migrate db:seeds` together in a single rake command that the `QualityMetric` creation in seeds didn't know about the new column created by the migration. But `reset_column_information` forces a refresh from the schema in the database and gets us past the error.

As a bonus ...

Fixes #1471 by adding a default value of `false` to the `admin_only` column on `QualityMetric` and disallows NULL values. @nellshamrell and I agreed it was safe to modify this migration because it had not yet been included in release of Supermarket, so not production or staging systems would have seen and executed the migration's previous state.

Bonus bonus: learned about [ActiveRecord's `merge()`](http://api.rubyonrails.org/classes/ActiveRecord/SpawnMethods.html#method-i-merge) and applied it judiciously to our open/admin-only scopes.