### PR TITLE
Include short versions of the open source license strings

### DIFF
--- a/src/fieri/app/models/license_worker.rb
+++ b/src/fieri/app/models/license_worker.rb
@@ -6,7 +6,10 @@ class LicenseWorker
 
   # Acceptable licenses were determined and documented in
   # https://github.com/chef-cookbooks/cookbook-quality-metrics/blob/master/quality-metrics/qm-003-license.md
-  ACCEPTABLE_LICENSES = ['Apache 2.0', 'MIT', 'GNU Public License 2.0', 'GNU Public License 3.0'].freeze
+  ACCEPTABLE_LICENSES = ['Apache 2.0', 'apachev2',
+                         'MIT', 'mit',
+                         'GNU Public License 2.0', 'gplv2',
+                         'GNU Public License 3.0', 'gplv3'].freeze
 
   def perform(version_json, cookbook_name)
     version_info = JSON.parse(version_json)


### PR DESCRIPTION
These are the strings that are accepted as license options in `chef generate cookbook -I <license>`. These short versions are also the strings that appear in the metadata of `chef generate`'d cookbooks. (See discussion on [1477](https://github.com/chef/supermarket/pull/1477#discussion_r90479895) about licenses in the generators.)

TODO/CONSIDER:
- [x] ~explicit fixtures and tests for these short version strings?~
- [x] ~any adjustments to the failure feedback in displaying a now-longer list?~