### PR TITLE
add a reference to the Chef code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,20 @@
+This project's code of conduct is documented in the [Chef Community
+Guidelines](https://github.com/chef/chef-rfc/blob/master/rfc020-community-guidelines.md).
+
+Paraphrasing and excerpting from these guidelines, we would like to
+reaffirm some of those beliefs here:
+
+* Diversity is one of our biggest strengths.
+* We are welcoming, inclusive, friendly, and patient.
+* We are considerate.
+* We are respectful.
+* We are professional.
+* We are careful in the words that we choose.
+* When we disagree, we all work together to understand why.
+* YOU are welcome here!
+
+Borrowing from the ubuntu philosophy:
+
+> I am because you are.
+> When you suffer, I suffer.
+> When you thrive, I thrive.


### PR DESCRIPTION
Link to the Chef Community Guidelines.

Words lifted liberally from @nathenharvey's [reaffirmation of our beliefs](https://discourse.chef.io/t/reaffirming-the-chef-community-guidelines/9841).