### PR TITLE
stop displaying JIRA username

### DIFF
--- a/src/supermarket/app/views/api/v1/users/show.json.jbuilder
+++ b/src/supermarket/app/views/api/v1/users/show.json.jbuilder
@@ -4,7 +4,6 @@ json.company @user.company
 json.github Array(@github_usernames)
 json.twitter @user.twitter_username
 json.irc @user.irc_nickname
-json.jira @user.jira_username
 json.authorized_to_contribute @user.authorized_to_contribute?
 json.cookbooks do
   json.set! :owns do

--- a/src/supermarket/app/views/ccla_signatures/contributors.html.erb
+++ b/src/supermarket/app/views/ccla_signatures/contributors.html.erb
@@ -45,7 +45,6 @@
                   <%= link_to account.username, "https://www.github.com/#{account.username}", target: :blank %>
                 <% end %>
               </td>
-              <td><%= contributor.user.jira_username %></td>
             </tr>
           <% end %>
         </tbody>

--- a/src/supermarket/app/views/icla_signatures/index.html.erb
+++ b/src/supermarket/app/views/icla_signatures/index.html.erb
@@ -25,7 +25,6 @@
                     <%= link_to account.username, "https://www.github.com/#{account.username}", target: :blank %>
                   <% end %>
                 </td>
-                <td><%= icla_signature.user.jira_username %></td>
               </tr>
             <% end %>
           </tbody>

--- a/src/supermarket/app/views/profile/edit.html.erb
+++ b/src/supermarket/app/views/profile/edit.html.erb
@@ -32,9 +32,6 @@
             <div class="ircnickname-field">
               <%= f.text_field :irc_nickname, placeholder: 'IRC Nickname', title: 'irc nickname' %>
             </div>
-            <div class="jirausername-field">
-              <%= f.text_field :jira_username, placeholder: 'JIRA Username', title: 'jira username' %>
-            </div>
           </fieldset>
           <fieldset>
             Email Preferences<br><br>

--- a/src/supermarket/app/views/users/_sidebar.html.erb
+++ b/src/supermarket/app/views/users/_sidebar.html.erb
@@ -41,12 +41,6 @@
       </li>
     <% end %>
 
-    <% if @user.jira_username.present? %>
-      <li class="has-tip" title="<%= posessivize(@user.name) %> Jira Username">
-        <i class="fa fa-ticket"></i> <%= @user.jira_username %>
-      </li>
-    <% end %>
-
     <li class="has-tip" title="When <%= @user.name %> joined the Chef Community site">
       <i class="fa fa-clock-o"></i> Joined <%= time_ago_in_words(@user.created_at) %> ago.
     </li>

--- a/src/supermarket/spec/api/user_show_spec.rb
+++ b/src/supermarket/spec/api/user_show_spec.rb
@@ -10,7 +10,6 @@ describe 'GET /api/v1/users/:user' do
         company: 'Fanny Pack',
         twitter_username: 'fanny',
         irc_nickname: 'fanny',
-        jira_username: 'fanny',
         chef_account: create(
           :account,
           provider: 'chef_oauth2',
@@ -27,7 +26,6 @@ describe 'GET /api/v1/users/:user' do
         'company' => 'Fanny Pack',
         'twitter' => 'fanny',
         'irc' => 'fanny',
-        'jira' => 'fanny',
         'github' => ['fanny'],
         'authorized_to_contribute' => true,
         'cookbooks' => {

--- a/src/supermarket/spec/features/edit_profile_spec.rb
+++ b/src/supermarket/spec/features/edit_profile_spec.rb
@@ -8,7 +8,7 @@ describe 'editing the current user profile' do
     within '.edit_user' do
       fill_in 'user_irc_nickname', with: 'eddardstark'
       fill_in 'user_company', with: 'Winterfell'
-      fill_in 'user_jira_username', with: 'eddardstark'
+      fill_in 'user_twitter_username', with: 'eddardstark'
       submit_form
     end
 

--- a/src/supermarket/spec/views/api/v1/users/show.json.jbuilder_spec.rb
+++ b/src/supermarket/spec/views/api/v1/users/show.json.jbuilder_spec.rb
@@ -9,8 +9,7 @@ describe 'api/v1/users/show' do
       company: 'FannyInternational',
       twitter_username: 'fannyfannyfanny',
       email: 'fanny@fanny.com',
-      irc_nickname: 'fannyfunnyfanny',
-      jira_username: 'funnyfannyfunny'
+      irc_nickname: 'fannyfunnyfanny'
     )
   end
 
@@ -96,11 +95,6 @@ describe 'api/v1/users/show' do
   it "displays the user's irc handle" do
     irc = json_body['irc']
     expect(irc).to eql(user.irc_nickname)
-  end
-
-  it "displays the user's jira username" do
-    jira = json_body['jira']
-    expect(jira).to eql(user.jira_username)
   end
 
   it "displays the user's authorized_to_contribute status" do


### PR DESCRIPTION
The Chef community does not use JIRA to track issues anymore, so asking
for and displaying a JIRA username is confusing.

Edit profile feature test changed to set the previously-untested Twitter
username which is still a field on the form.

Fixes #1484 