### PR TITLE
Use chef_nginx instead of nginx

### DIFF
--- a/omnibus/Berksfile
+++ b/omnibus/Berksfile
@@ -1,5 +1,6 @@
 source 'https://supermarket.chef.io'
 
+cookbook 'apt'
 cookbook 'enterprise', git: 'https://github.com/chef-cookbooks/enterprise-chef-common'
 cookbook 'omnibus-supermarket',
          path: File.expand_path("cookbooks/omnibus-supermarket", File.dirname(__FILE__))

--- a/omnibus/cookbooks/omnibus-supermarket/metadata.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/metadata.rb
@@ -7,7 +7,7 @@ long_description 'Installs/Configures supermarket in an Omnibus installation'
 version          '1.1.0'
 
 depends          'enterprise'
-depends          'nginx'
+depends          'chef_nginx'
 depends          'omnibus'
 depends          'runit', '>= 3.0.3'
 depends          'sysctl'

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/nginx.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/nginx.rb
@@ -38,7 +38,7 @@ link "#{node['supermarket']['nginx']['directory']}/mime.types" do
 end
 
 template "#{node['supermarket']['nginx']['directory']}/nginx.conf" do
-  cookbook 'nginx'
+  cookbook 'chef_nginx'
   source 'nginx.conf.erb'
   owner node['supermarket']['user']
   group node['supermarket']['group']


### PR DESCRIPTION
Nginx is no longer being maintained. Depend on the nginx cookbook instead.
Signed-off-by: Tim Smith <tsmith@chef.io>