### PR TITLE
Add chef ohai

### DIFF
--- a/src/supermarket/app/helpers/cookbook_versions_helper.rb
+++ b/src/supermarket/app/helpers/cookbook_versions_helper.rb
@@ -66,4 +66,21 @@ module CookbookVersionsHelper
       content
     end
   end
+
+  def versions_string(versions)
+    versions_string = ''
+
+    versions.each do |version_set|
+      versions_string += "(#{combined_set(version_set)})"
+      versions_string += ' OR ' unless version_set == versions.last
+    end
+
+    versions_string
+  end
+
+  private
+
+  def combined_set(set)
+    set.join(' AND ')
+  end
 end

--- a/src/supermarket/app/views/cookbooks/_sidebar.html.erb
+++ b/src/supermarket/app/views/cookbooks/_sidebar.html.erb
@@ -90,6 +90,16 @@
     <h4><i class="fa fa-key"></i> License</h4>
     <p><%= version.license %></p>
 
+    <% if version.chef_versions.present? %>
+      <h4><i class="fa fa-key"></i> Chef Versions</h4>
+      <p><%= versions_string(version.chef_versions) %></p>
+    <% end %>
+
+    <% if version.ohai_versions.present? %>
+      <h4><i class="fa fa-key"></i> Ohai Versions</h4>
+      <p><%= versions_string(version.ohai_versions) %></p>
+    <% end %>
+
     <%= link_to "Download Cookbook", { action: 'download' }, class: 'button secondary radius expand button_download_cookbook' %>
   </div>
 </div>

--- a/src/supermarket/spec/helpers/cookbook_versions_helper_spec.rb
+++ b/src/supermarket/spec/helpers/cookbook_versions_helper_spec.rb
@@ -24,4 +24,26 @@ describe CookbookVersionsHelper do
       expect(helper.safe_updated_at(nil)).to be <= Time.zone.now
     end
   end
+
+  describe 'versions_string' do
+    let(:chef_versions) { [['>= 12.4.1', '< 12.4.2'], ['> 11.2.3', '<= 12.4.3']] }
+    let(:string) { helper.versions_string(chef_versions) }
+
+    context 'combining the inner array elements' do
+      it 'combines them with AND' do
+        expect(string).to include('(>= 12.4.1 AND < 12.4.2)')
+        expect(string).to include('(> 11.2.3 AND <= 12.4.3)')
+      end
+    end
+
+    context 'combining the outer array elements' do
+      it 'combines them with OR' do
+        expect(string).to include('< 12.4.2) OR (> 11.2.3')
+      end
+
+      it 'does not include OR at the end of the string' do
+        expect(string).to_not include('<= 12.4.3) OR')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1379 

Here is what I have come up with for displaying the versions of Chef and Ohai that a cookbook version supports.  I welcome any input on the view, etc.

<img width="458" alt="screen shot 2016-12-21 at 4 39 41 pm" src="https://cloud.githubusercontent.com/assets/813007/21411273/1b86bdea-c79c-11e6-83ee-d71aef19e838.png">

(I will squash the commits when this is finalized)