### PR TITLE
omit the foodcritic working directory from metric feedback

### DIFF
--- a/src/fieri/app/models/cookbook_artifact.rb
+++ b/src/fieri/app/models/cookbook_artifact.rb
@@ -49,7 +49,8 @@ class CookbookArtifact
     end
     cmd = FoodCritic::CommandLine.new(args)
     result, _status = FoodCritic::Linter.run(cmd)
-    [result.to_s, result.failed?]
+    feedback = result.to_s.gsub("#{work_dir}/", '')
+    [feedback, result.failed?]
   end
 
   #

--- a/src/fieri/spec/models/cookbook_artifact_spec.rb
+++ b/src/fieri/spec/models/cookbook_artifact_spec.rb
@@ -34,8 +34,8 @@ describe CookbookArtifact do
       it 'returns the feedback and status from the FoodCritic run' do
         feedback, status = artifact.criticize
 
-        assert_match(/FC064/, feedback)
-        assert_equal true, status
+        expect(feedback).to match(/FC064/)
+        expect(status).to be true
       end
 
       it 'does not include the working directory of the foodcritic run' do
@@ -69,8 +69,8 @@ describe CookbookArtifact do
     describe '#criticize' do
       it 'disables ~FC031 and ~FC045 by default' do
         feedback, _status = artifact.criticize
-        refute_match(/FC031/, feedback)
-        refute_match(/FC045/, feedback)
+        expect(feedback).to_not match(/FC031/)
+        expect(feedback).to_not match(/FC045/)
       end
     end
   end
@@ -90,8 +90,8 @@ describe CookbookArtifact do
       it 'disables ~FC031 and ~FC045 by default' do
         feedback, status = artifact.criticize
 
-        assert_match(/FC064/, feedback)
-        assert_equal true, status
+        expect(feedback).to match(/FC064/)
+        expect(status).to be true
       end
     end
   end

--- a/src/fieri/spec/models/cookbook_artifact_spec.rb
+++ b/src/fieri/spec/models/cookbook_artifact_spec.rb
@@ -37,6 +37,12 @@ describe CookbookArtifact do
         assert_match(/FC064/, feedback)
         assert_equal true, status
       end
+
+      it 'does not include the working directory of the foodcritic run' do
+        feedback, _status = artifact.criticize
+
+        expect(feedback).to_not include(artifact.work_dir)
+      end
     end
 
     describe '#clean' do


### PR DESCRIPTION
Fixes #1348

Based on the work of Logan McDonald in #1349

TODO Reach Goals:
- [x] change all assertions over to rspec-style expectations
- [ ] speed up the tests somehow, maybe by not running foodcritic because we're not testing foodcritic itself