### PR TITLE
include the published_at in API info for cookbook version

### DIFF
--- a/src/supermarket/app/views/api/v1/cookbook_versions/_cookbook_version.json.jbuilder
+++ b/src/supermarket/app/views/api/v1/cookbook_versions/_cookbook_version.json.jbuilder
@@ -1,6 +1,7 @@
 json.license cookbook_version.license
 json.tarball_file_size cookbook_version.tarball_file_size
 json.version cookbook_version.version
+json.published_at cookbook_version.created_at.iso8601
 json.average_rating nil
 json.cookbook api_v1_cookbook_url(cookbook)
 json.file api_v1_cookbook_version_download_url(cookbook_version.cookbook, cookbook_version)

--- a/src/supermarket/spec/api/cookbook_version_spec.rb
+++ b/src/supermarket/spec/api/cookbook_version_spec.rb
@@ -101,6 +101,12 @@ describe 'GET /api/v1/cookbooks/:cookbook/versions/:version' do
         expect(signature(json_body)).to include(cookbook_version_signature)
       end
 
+      it 'returns the date the version was published' do
+        get json_body['versions'].find { |v| v =~ /0.1.0/ }
+
+        expect(signature(json_body)).to include("published_at" => cookbook_version.created_at.iso8601)
+      end
+
       context 'when the fieri feature is active' do
         before do
           allow(ROLLOUT).to receive(:active?).with(:fieri).and_return(true)


### PR DESCRIPTION
Went with "published_at" based on created_at time.

Looks a bit like:

```json
{
  "license": "blargle",
  "tarball_file_size": 1698,
  "version": "0.1.0",
  "published_at": "2017-01-06T19:05:51Z",
  "average_rating": null,
  "cookbook": "http://localhost:3000/api/v1/cookbooks/blargle",
  "file": "http://localhost:3000/api/v1/cookbooks/blargle/versions/0.1.0/download",
  "quality_metrics": []
}
```

Closes #1515