### PR TITLE
adds temporary handling for a single depth array as a chef_versions o…

### DIFF
--- a/src/supermarket/app/helpers/cookbook_versions_helper.rb
+++ b/src/supermarket/app/helpers/cookbook_versions_helper.rb
@@ -70,9 +70,17 @@ module CookbookVersionsHelper
   def versions_string(versions)
     versions_string = ''
 
-    versions.each do |version_set|
-      versions_string += "(#{combined_set(version_set)})"
-      versions_string += ' OR ' unless version_set == versions.last
+    if versions.first.class == Array
+      versions.each do |version_set|
+        versions_string += "(#{combined_set(version_set)})"
+        versions_string += ' OR ' unless version_set == versions.last
+      end
+    elsif versions.first.class == String
+      # This is a bandaid until https://github.com/chef/supermarket/issues/1505
+      versions.each do |version|
+        versions_string += version
+        versions_string += ' AND ' unless version == versions.last
+      end
     end
 
     versions_string

--- a/src/supermarket/spec/helpers/cookbook_versions_helper_spec.rb
+++ b/src/supermarket/spec/helpers/cookbook_versions_helper_spec.rb
@@ -45,5 +45,31 @@ describe CookbookVersionsHelper do
         expect(string).to_not include('<= 12.4.3) OR')
       end
     end
+
+    context 'with a single depth array' do
+      # This is a bandaid until https://github.com/chef/supermarket/issues/1505
+      context 'with one version' do
+        let(:chef_versions) { ['>= 12.4.1'] }
+        let(:string) { helper.versions_string(chef_versions) }
+
+        it 'returns the version value as a string' do
+          expect(string).to include('>= 12.4.1')
+          expect(string.class).to eq(String)
+        end
+      end
+
+      context 'with multiple versions' do
+        let(:chef_versions) { ['>= 12.4.1', '12.5.2'] }
+        let(:string) { helper.versions_string(chef_versions) }
+
+        it 'combines them with AND' do
+          expect(string).to include('>= 12.4.1 AND 12.5.2')
+        end
+
+        it 'does not include the AND at the end of the string' do
+          expect(string).to_not include('12.5.2 AND')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
…r ohai_versions attribute on a CookbookVersion

This is a temporary fix until we address #1505 

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>