### PR TITLE
correct pluralization in guard around create

### DIFF
--- a/src/supermarket/db/seeds.rb
+++ b/src/supermarket/db/seeds.rb
@@ -31,7 +31,7 @@ unless(QualityMetric.where(name: 'License').any?)
   QualityMetric.create!(name: 'License', admin_only: true)
 end
 
-unless(QualityMetric.where(name: 'Supported Platform').any?)
+unless(QualityMetric.where(name: 'Supported Platforms').any?)
   QualityMetric.create!(name: 'Supported Platforms', admin_only: true)
 end
 


### PR DESCRIPTION
A very small fix to the `Supported Platforms` quality metric seed introduced in [#1513](https://github.com/chef/supermarket/pull/1513/files#diff-8166a7994124585a9e368c1ae6847e34R34). A future refinement might be to iterate over a list of quality metric names and admin_only flags to reduce the likelihood of name mismatches between the `unless` guard and the `create!`.