### PR TITLE
make the API item limit configurable

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -332,6 +332,7 @@ default['supermarket']['pubsubhubbub_callback_url'] = nil
 default['supermarket']['pubsubhubbub_secret'] = nil
 default['supermarket']['redis_url'] = "redis://#{node['supermarket']['redis']['bind']}:#{node['supermarket']['redis']['port']}/0/supermarket"
 default['supermarket']['sentry_url'] = nil
+default['supermarket']['api_item_limit'] = 100
 
 # ### Chef URL Settings
 #

--- a/src/supermarket/app/controllers/api/v1/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/api/v1/cookbooks_controller.rb
@@ -7,7 +7,8 @@ class Api::V1::CookbooksController < Api::V1Controller
   #
   # Return all Cookbooks. Defaults to 10 at a time, starting at the first
   # Cookbook when sorted alphabetically. The max number of Cookbooks that can be
-  # returned is 100.
+  # returned is set by an environment variable API_ITEM_LIMIT. If the limit is
+  # not set or set to an non-integer value, the default is 100.
   #
   # Pass in the start and items params to specify the index at which to start
   # and how many to return. You can pass in an order param to specify how
@@ -55,7 +56,8 @@ class Api::V1::CookbooksController < Api::V1Controller
   # Return cookbooks with a name that contains the specified query. Takes the
   # +q+ parameter for the query. It also handles the start and items parameters
   # for specify where to start the search and how many items to return. Start
-  # defaults to 0. Items defaults to 10. Items has an upper limit of 100.
+  # defaults to 0. Items defaults to 10. Items has an upper limit default of 100
+  # which can be changed by setting an environment variable API_ITEM_LIMIT.
   #
   # @example
   #   GET /api/v1/search?q=redis

--- a/src/supermarket/app/controllers/api/v1/tools_controller.rb
+++ b/src/supermarket/app/controllers/api/v1/tools_controller.rb
@@ -6,7 +6,8 @@ class Api::V1::ToolsController < Api::V1Controller
   #
   # Return all Tools. Defaults to 10 at a time, starting at the first
   # Tool when sorted alphabetically. The max number of Tools that can be
-  # returned is 100.
+  # returned is set by an environment variable API_ITEM_LIMIT. If the limit is
+  # not set or set to an non-integer value, the default is 100.
   #
   # Pass in the start and items params to specify the index at which to start
   # and how many to return. You can pass in an order param to specify how
@@ -46,7 +47,9 @@ class Api::V1::ToolsController < Api::V1Controller
   # - +order+ order of the results, defaults to alphabetically by name
   #           options: recently_added (reverse chronological)
   # - +start+ what index to start the results list, defaults to 0
-  # - +items+ how many items to return from the +start+ index, defaults to 10
+  # - +items+ how many items to return from the +start+ index, defaults to 10,
+  #           with an upper limit default of 100, to change upper limit on items
+  #           set API_ITEM_LIMIT environment variable.
   #
   # @example
   #   GET /api/v1/tools-search?q=berkshelf

--- a/src/supermarket/app/controllers/api/v1_controller.rb
+++ b/src/supermarket/app/controllers/api/v1_controller.rb
@@ -46,7 +46,7 @@ class Api::V1Controller < ApplicationController
   #
   def init_params
     @start = params.fetch(:start, 0).to_i
-    @items = [params.fetch(:items, 10).to_i, 100].min
+    @items = [params.fetch(:items, 10).to_i, item_limit].min
 
     if @start < 0 || @items < 0
       return error(
@@ -58,5 +58,18 @@ class Api::V1Controller < ApplicationController
     end
 
     @order = params.fetch(:order, 'name ASC').to_s
+  end
+
+  #
+  # Returns the configured limit for number of items in an API request
+  # Inteded to wrap the mechanism by which the limit is configured
+  #
+  def item_limit
+    configured_limit = ENV['API_ITEM_LIMIT'].to_i
+    if configured_limit > 0
+      configured_limit
+    else
+      100
+    end
   end
 end

--- a/src/supermarket/spec/controllers/api/v1/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/api/v1/cookbooks_controller_spec.rb
@@ -10,6 +10,8 @@ describe Api::V1::CookbooksController do
     create(:cookbook, name: 'sashimi', web_download_count: 11, api_download_count: 14, owner: clive)
   end
 
+  it_behaves_like 'an API v1 controller'
+
   describe '#index' do
     it 'orders the cookbooks by their name by default' do
       get :index, format: :json
@@ -102,7 +104,8 @@ describe Api::V1::CookbooksController do
       expect(assigns[:items]).to eql(10)
     end
 
-    it 'limits the number of items to 100' do
+    it 'limits the number of items to the configured limit' do
+      allow(subject).to receive(:item_limit).and_return(100)
       get :index, items: 101, format: :json
 
       expect(assigns[:items]).to eql(100)

--- a/src/supermarket/spec/controllers/api/v1/tools_controller_spec.rb
+++ b/src/supermarket/spec/controllers/api/v1/tools_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe Api::V1::ToolsController do
+  it_behaves_like 'an API v1 controller'
+
   describe '#index' do
     let!(:metal) do
       create(:tool, name: 'metal')
@@ -97,7 +99,8 @@ describe Api::V1::ToolsController do
       expect(assigns[:start]).to eql(0)
     end
 
-    it 'limits the number of items to 100' do
+    it 'limits the number of items to the configured limit' do
+      allow(subject).to receive(:item_limit).and_return(100)
       get :index, items: 101, format: :json
 
       expect(assigns[:items]).to eql(100)

--- a/src/supermarket/spec/controllers/api/v1_controller_spec.rb
+++ b/src/supermarket/spec/controllers/api/v1_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+class SomeV1Controller < Api::V1Controller; end
+
+describe Api::V1Controller::SomeV1Controller do
+  it_behaves_like 'an API v1 controller'
+end

--- a/src/supermarket/spec/support/shared_examples/v1_controller_shared.rb
+++ b/src/supermarket/spec/support/shared_examples/v1_controller_shared.rb
@@ -1,0 +1,22 @@
+shared_examples 'an API v1 controller' do
+  context '#item_limit' do
+    it 'knows the API item limit' do
+      subject.respond_to?(:item_limit)
+    end
+
+    it 'determines the API item limit from an environment variable' do
+      expect(ENV).to receive(:[]).with('API_ITEM_LIMIT').and_return(9999)
+      expect(subject.send(:item_limit)).to eql(9999)
+    end
+
+    it 'defaults to 100 if there is no environment variable set' do
+      expect(ENV).to receive(:[]).with('API_ITEM_LIMIT').and_return(nil)
+      expect(subject.send(:item_limit)).to eql(100)
+    end
+
+    it 'defaults to 100 if set to something other than a positive integer' do
+      expect(ENV).to receive(:[]).with('API_ITEM_LIMIT').and_return('nope, not an integer')
+      expect(subject.send(:item_limit)).to eql(100)
+    end
+  end
+end


### PR DESCRIPTION
Use `API_ITEM_LIMIT` environment variable to set the upper limit on the number of items to return for API requests to a Supermarket instance.

Defaults to the previously hard-coded value of 100 if the env var is not present. Also, the cookbook internal to the omnibus package has the same default set in the section of the attributes that get set as env vars.

Closes #1542 