### PR TITLE
update to omnibus-software with nokogiri license check fix

### DIFF
--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -16,9 +16,9 @@ platforms:
     run_list: apt::default
   - name: centos-5.11
     run_list: yum-epel::default
-  - name: centos-6.7
+  - name: centos-6.8
     run_list: yum-epel::default
-  - name: centos-7.1
+  - name: centos-7.3
     run_list: yum-epel::default
 
 suites:

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 2352f3e0c6326e05befda4d97f12a07de27c575c
+  revision: 5aaeccbc70f08237086609858b82730a47b96efd
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: e4068402d4a5023c419ecbaae66b8f651349163f
+  revision: 67964d9d3a5879940a22af81f2c89afe17e7182b
   specs:
     omnibus (5.5.0)
       aws-sdk (~> 2)
@@ -25,14 +25,17 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
-    artifactory (2.5.0)
-    aws-sdk (2.6.17)
-      aws-sdk-resources (= 2.6.17)
-    aws-sdk-core (2.6.17)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    artifactory (2.6.0)
+    aws-sdk (2.7.9)
+      aws-sdk-resources (= 2.7.9)
+    aws-sdk-core (2.7.9)
+      aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.17)
-      aws-sdk-core (= 2.6.17)
+    aws-sdk-resources (2.7.9)
+      aws-sdk-core (= 2.7.9)
+    aws-sigv4 (1.0.0)
     berkshelf (4.3.5)
       addressable (~> 2.3, >= 2.3.4)
       berkshelf-api-client (~> 2.0, >= 2.0.2)
@@ -68,7 +71,7 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (12.15.19)
+    chef-config (12.18.31)
       addressable
       fuzzyurl
       mixlib-config (~> 2.0)
@@ -78,30 +81,30 @@ GEM
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.14)
+    ffi (1.9.17)
     ffi-yajl (2.3.0)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
-    hashie (3.4.6)
+    hashie (3.5.3)
     hitimes (1.2.4)
     httpclient (2.7.2)
     ipaddress (0.8.3)
     jmespath (1.3.1)
-    json (2.0.2)
-    kitchen-vagrant (0.20.0)
+    json (2.0.3)
+    kitchen-vagrant (0.21.1)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
     license_scout (0.1.3)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
-    minitar (0.5.4)
-    mixlib-archive (0.2.0)
+    minitar (0.6.1)
+    mixlib-archive (0.4.1)
       mixlib-log
     mixlib-authentication (1.4.1)
       mixlib-log
     mixlib-cli (1.7.0)
     mixlib-config (2.2.4)
-    mixlib-install (2.1.5)
+    mixlib-install (2.1.12)
       artifactory
       mixlib-shellout
       mixlib-versioning
@@ -113,13 +116,13 @@ GEM
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (3.2.0)
-    net-ssh-gateway (1.2.0)
+    net-ssh (4.0.1)
+    net-ssh-gateway (1.3.0)
       net-ssh (>= 2.6.5)
-    nio4r (1.2.1)
-    octokit (4.4.1)
-      sawyer (~> 0.7.0, >= 0.5.3)
-    ohai (8.21.0)
+    nio4r (2.0.0)
+    octokit (4.6.2)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    ohai (8.23.0)
       chef-config (>= 12.5.0.alpha.1, < 13)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -132,6 +135,7 @@ GEM
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
     plist (3.2.0)
+    public_suffix (2.0.5)
     retryable (2.0.4)
     ridley (4.6.1)
       addressable
@@ -153,23 +157,23 @@ GEM
       varia_model (~> 0.4.0)
     ruby-progressbar (1.8.1)
     safe_yaml (1.0.4)
-    sawyer (0.7.0)
-      addressable (>= 2.3.5, < 2.5)
-      faraday (~> 0.8, < 0.10)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     semverse (1.2.1)
     solve (2.0.3)
       molinillo (~> 0.4.2)
       semverse (~> 1.1)
     systemu (2.6.5)
-    test-kitchen (1.13.2)
+    test-kitchen (1.15.0)
       mixlib-install (>= 1.2, < 3.0)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
-      net-ssh (>= 2.9, < 4.0)
-      net-ssh-gateway (~> 1.2.0)
+      net-ssh (>= 2.9, < 5.0)
+      net-ssh-gateway (~> 1.2)
       safe_yaml (~> 1.0)
       thor (~> 0.18)
-    thor (0.19.1)
+    thor (0.19.4)
     timers (4.0.4)
       hitimes
     varia_model (0.4.1)
@@ -188,4 +192,4 @@ DEPENDENCIES
   test-kitchen (~> 1.2)
 
 BUNDLED WITH
-   1.12.5
+   1.14.3

--- a/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
+++ b/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
@@ -16,8 +16,8 @@ platforms:
   - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: centos-5.11
-  - name: centos-6.7
-  - name: centos-7.1
+  - name: centos-6.8
+  - name: centos-7.3
 
 suites:
   - name: default


### PR DESCRIPTION
Omnibus builds were failing looking for the wrong license file within the nokogiri repo. Fix was in chef/omnibus-software#795 so updating our dependency to a version that includes that fix.

Also updates the CentOS boxes used in the omnibus kitchens to latest minor versions.