### PR TITLE
really, really disable the datadog tracer

### DIFF
--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -48,7 +48,7 @@ gem 'chef', require: false
 gem 'mixlib-authentication'
 gem 'aws-sdk'
 gem 'newrelic_rpm'
-gem 'ddtrace'
+gem 'ddtrace', require: false
 gem 'semverse'
 gem 'sitemap_generator'
 gem 'redis-rails'

--- a/src/supermarket/config/initializers/datadog_tracer.rb
+++ b/src/supermarket/config/initializers/datadog_tracer.rb
@@ -1,16 +1,12 @@
 # Disable/Enable and configure the datadog application tracer
 # crf. http://www.rubydoc.info/gems/ddtrace/#Ruby_on_Rails
-Rails.configuration.datadog_trace =
-  if ENV['DATADOG_TRACER_ENABLED']
+
+if ENV['DATADOG_TRACER_ENABLED'] && ENV['DATADOG_TRACER_ENABLED'] == 'true'
+  require 'ddtrace'
+  Rails.configuration.datadog_trace =
     {
       auto_instrument: true,
       auto_instrument_redis: true,
       default_service: ENV['DATADOG_APP_NAME'] || 'rails_app'
     }
-  else
-    {
-      enabled: false,
-      auto_instrument: false,
-      auto_instrument_redis: false
-    }
-  end
+end


### PR DESCRIPTION
The tracer at the current version still tries to make connection attempts to the Datadog agent even when disabled. To disable those attempts and the log spam errors it generates, we'll only require the gem when we have enabled the tracer.

See datadog/dd-trace-rb#53 issue about the symptom.