### PR TITLE
make sidekiq optionally connect to an alternate redis

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -332,7 +332,8 @@ default['supermarket']['port'] = node['supermarket']['nginx']['force_ssl'] ? nod
 default['supermarket']['protocol'] = node['supermarket']['nginx']['force_ssl'] ? 'https' : 'http'
 default['supermarket']['pubsubhubbub_callback_url'] = nil
 default['supermarket']['pubsubhubbub_secret'] = nil
-default['supermarket']['redis_url'] = "redis://#{node['supermarket']['redis']['bind']}:#{node['supermarket']['redis']['port']}/0/supermarket"
+default['supermarket']['redis_url'] = 'redis://127.0.0.1:16379/0/supermarket'
+default['supermarket']['redis_jobq_url'] = nil
 default['supermarket']['sentry_url'] = nil
 default['supermarket']['api_item_limit'] = 100
 

--- a/src/supermarket/config/initializers/sidekiq.rb
+++ b/src/supermarket/config/initializers/sidekiq.rb
@@ -1,0 +1,11 @@
+redis_for_job_queue = ENV['REDIS_JOBQ_URL'].presence ||
+                      ENV['REDIS_URL'].presence ||
+                      'redis://localhost:6379/0/supermarket'
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: redis_for_job_queue }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: redis_for_job_queue }
+end


### PR DESCRIPTION
Adds an initializer for Sidekiq to configure which Redis instance to use for job queuing. Defaults to a common single `REDIS_URL` that will be shared with Rails caching and Rollout feature flag checking. Shared is less than ideal in high traffic production environments, so this adds the option to set a different Redis URL for Sidekiq.

https://github.com/mperham/sidekiq/wiki/Using-Redis#using-an-initializer

TODO:
- [x] decide if `REDIS_JOBQ_URL` is too silly a name and, if so, pick something else
- [x] set `default['supermarket']['redis_jobq_url']` to something sensible in the omnibus' cookbook (probably match `redis_url` but with a different Redis DB id)