### PR TITLE
add an exception handler for not finding a repo

### DIFF
--- a/src/fieri/app/models/version_tag_worker.rb
+++ b/src/fieri/app/models/version_tag_worker.rb
@@ -42,6 +42,8 @@ class VersionTagWorker < SourceRepoWorker
 
   def tag_names(repo)
     octokit_client.tags(repo).map { |tag| tag['name'] }
+  rescue Octokit::NotFound
+    []
   end
 
   def give_feedback(failure_result)


### PR DESCRIPTION
Sometimes metadata declares a repo that doesn't exist anymore. Catch that and return an empty list of tags to fail the version tag check.