### PR TITLE
use present? to fail on empty strings

### DIFF
--- a/.delivery/build_cookbook/recipes/unit.rb
+++ b/.delivery/build_cookbook/recipes/unit.rb
@@ -54,7 +54,7 @@ ruby_execute "Tests for Supermarket" do
   command <<-CMD
 bundle install && \
 bundle exec rake db:create db:schema:load db:test:prepare && \
-bundle exec rspec --color --format documentation
+bundle exec rspec --color
 CMD
   cwd "#{delivery_workspace_repo}/src/supermarket"
   environment('BUNDLE_PATH' => gem_cache)
@@ -64,7 +64,7 @@ ruby_execute "Tests for Fieri" do
   version node['build_cookbook']['ruby_version']
   command <<-CMD
 bundle install && \
-bundle exec rspec --color --format documentation
+bundle exec rspec --color
 CMD
   cwd "#{delivery_workspace_repo}/src/fieri"
   environment('BUNDLE_PATH' => gem_cache)

--- a/src/fieri/app/models/version_tag_worker.rb
+++ b/src/fieri/app/models/version_tag_worker.rb
@@ -23,10 +23,8 @@ class VersionTagWorker < SourceRepoWorker
   def evaluate(cookbook_json, cookbook_version)
     repo = source_repo(cookbook_json)
 
-    if repo.nil?
-      # if no match for repo from #source_user_repo, fails metric
-      return true
-    end
+    # if no match for repo from #source_user_repo, fails metric
+    return true unless repo.present?
 
     tags = tag_names(repo)
 


### PR DESCRIPTION
Sometimes the `source_url` for a cookbook is an empty string, not a null. The `source_repo` metric will then return the empty string. So check for presence instead of nilness.