### PR TITLE
allow env: tag in DD agent to be customized

### DIFF
--- a/src/supermarket/config/initializers/datadog_tracer.rb
+++ b/src/supermarket/config/initializers/datadog_tracer.rb
@@ -7,6 +7,7 @@ if ENV['DATADOG_TRACER_ENABLED'] && ENV['DATADOG_TRACER_ENABLED'] == 'true'
     {
       auto_instrument: true,
       auto_instrument_redis: true,
-      default_service: ENV['DATADOG_APP_NAME'] || 'rails_app'
+      default_service: ENV['DATADOG_APP_NAME'] || 'rails_app',
+      env: ENV['DATADOG_ENVIRONMENT'] || nil
     }
 end


### PR DESCRIPTION
By default, leave `nil` which will allow the `env:` tag to be set by the Datadog agent configuration for the host. (crf. [new default in dd-trace-rb](https://github.com/DataDog/dd-trace-rb/pull/92/files#r110255719))