### PR TITLE
upgrade foodcritic to 10.3.1

### DIFF
--- a/src/fieri/Gemfile.lock
+++ b/src/fieri/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
   specs:
     fieri (0.0.1)
       dotenv-rails
-      foodcritic (~> 10.2)
+      foodcritic (~> 10.3)
       mixlib-archive (~> 0.4)
       octokit (~> 4.0)
       rails (~> 4.2)
@@ -60,7 +60,7 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     arel (6.0.4)
     ast (2.3.0)
-    backports (3.6.8)
+    backports (3.7.0)
     builder (3.2.3)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -77,7 +77,7 @@ GEM
     erubis (2.7.0)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    foodcritic (10.2.2)
+    foodcritic (10.3.1)
       cucumber-core (>= 1.3)
       erubis
       nokogiri (>= 1.5, < 2.0)
@@ -85,7 +85,7 @@ GEM
       rufus-lru (~> 1.0)
       treetop (~> 1.4)
       yajl-ruby (~> 1.1)
-    gherkin (4.0.0)
+    gherkin (4.1.1)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashdiff (0.3.0)

--- a/src/fieri/fieri.gemspec
+++ b/src/fieri/fieri.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 4.2'
   s.add_dependency 'sidekiq'
   s.add_dependency 'dotenv-rails'
-  s.add_dependency 'foodcritic', '~> 10.2'
+  s.add_dependency 'foodcritic', '~> 10.3'
   s.add_dependency 'mixlib-archive', '~> 0.4'
   s.add_dependency 'octokit', '~> 4.0'
   s.add_dependency 'ruby-filemagic'

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -25,7 +25,7 @@ PATH
   specs:
     fieri (0.0.1)
       dotenv-rails
-      foodcritic (~> 10.2)
+      foodcritic (~> 10.3)
       mixlib-archive (~> 0.4)
       octokit (~> 4.0)
       rails (~> 4.2)
@@ -195,7 +195,7 @@ GEM
     ffi-yajl (1.4.0)
       ffi (~> 1.5)
       libyajl2 (~> 1.2)
-    foodcritic (10.2.2)
+    foodcritic (10.3.1)
       cucumber-core (>= 1.3)
       erubis
       nokogiri (>= 1.5, < 2.0)
@@ -557,7 +557,7 @@ GEM
     xml-simple (1.1.4)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    yajl-ruby (1.2.1)
+    yajl-ruby (1.3.0)
     yard (0.8.7.6)
 
 PLATFORMS


### PR DESCRIPTION
Includes new critiques:

- Added FC069 to ensure standardized licenses are defined in metadata
- Added FC070 to detect invalid platform supports in metadata
- Added FC071 to ensure a LICENSE file is included with the cookbook
