### PR TITLE
provide a fallback for when FQDN is indeterminate

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -61,7 +61,7 @@
 
 # The fully qualified domain name. Will use the node's fqdn if nothing is
 # specified.
-default['supermarket']['fqdn'] = node['fqdn'].downcase
+default['supermarket']['fqdn'] = (node['fqdn'] || node['hostname']).downcase
 
 # The URL for the Chef server. Used with the "Chef OAuth2 Settings" and
 # "Chef URL Settings" below. If this is not set, authentication and some of the


### PR DESCRIPTION
Occasionally ohai fails to figure out a host's FQDN (e.g. `hostname -f` fails). Calling `.downcase` on `nil` causes much woe and gnashing of teeth. Therefore, we'll fallback to a host's hostname for the FQDN, much like [the workaround](https://github.com/chef-cookbooks/supermarket-omnibus-cookbook/blob/d4b0fd8a0dcd5f01b89fab3140eb0f948a5d990c/resources/supermarket_server.rb#L26-L30) used in many wrapper cookbooks of making an entry in `/etc/hosts` for the hostname on the host's IP address if none is present.

Production Supermarkets are expected to provide an override for this value that matches a supplied SSL certificate. Defaults are mostly for development and test environments.

Fixes #1591 