### PR TITLE
make quality metrics appear in a consistent order

### DIFF
--- a/src/fieri/config/locales/en.yml
+++ b/src/fieri/config/locales/en.yml
@@ -8,13 +8,13 @@ en:
       failure: '%{cookbook_name} should declare what platform(s) it supports.'
     contributing_file:
       success: 'passed the CONTRIBUTING.md file metric.'
-      failure: 'Failure: To pass this metric, your cookbook metadata must include a source url, the source url must be in the form of http://github.com/user/repo, and your repo must contain a CONTRIBUTING.md file'
+      failure: 'Failure: To pass this metric, your cookbook metadata must include a source url, the source url must be in the form of https://github.com/user/repo, and your repo must contain a CONTRIBUTING.md file'
     testing_file:
       success: 'passed the TESTING.md file metric.'
-      failure: 'Failure: To pass this metric, your cookbook metadata must include a source url, the source url must be in the form of http://github.com/user/repo, and your repo must contain a TESTING.md file'
+      failure: 'Failure: To pass this metric, your cookbook metadata must include a source url, the source url must be in the form of https://github.com/user/repo, and your repo must contain a TESTING.md file'
     version_tag:
       success: 'passed the version tag metric.'
-      failure: 'Failure: To pass this metric, your cookbook metadata must include a source url, the source url must be in the form of http://github.com/user/repo, and your repo must include a tag that matches this cookbook version number'
+      failure: 'Failure: To pass this metric, your cookbook metadata must include a source url, the source url must be in the form of https://github.com/user/repo, and your repo must include a tag that matches this cookbook version number'
     no_binaries:
       success: 'passed the No Binaries metric. Contains no obvious binaries.'
       failure: 'Failure: Cookbook should not contain binaries. Found:'

--- a/src/supermarket/app/controllers/cookbook_versions_controller.rb
+++ b/src/supermarket/app/controllers/cookbook_versions_controller.rb
@@ -26,8 +26,8 @@ class CookbookVersionsController < ApplicationController
     @supported_platforms = @version.supported_platforms
     @owner_collaborator = Collaborator.new resourceable: @cookbook, user: @owner
 
-    @public_metric_results = @version.metric_results.open
-    @admin_metric_results = @version.metric_results.admin_only
+    @public_metric_results = @version.metric_results.open.sorted_by_name
+    @admin_metric_results = @version.metric_results.admin_only.sorted_by_name
   end
 
   private

--- a/src/supermarket/app/controllers/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/cookbooks_controller.rb
@@ -86,8 +86,8 @@ class CookbooksController < ApplicationController
     @collaborators = @cookbook.collaborators
     @supported_platforms = @cookbook.supported_platforms
 
-    @public_metric_results = @latest_version.metric_results.open
-    @admin_metric_results = @latest_version.metric_results.admin_only
+    @public_metric_results = @latest_version.metric_results.open.sorted_by_name
+    @admin_metric_results = @latest_version.metric_results.admin_only.sorted_by_name
 
     respond_to do |format|
       format.atom

--- a/src/supermarket/app/models/metric_result.rb
+++ b/src/supermarket/app/models/metric_result.rb
@@ -4,6 +4,7 @@ class MetricResult < ActiveRecord::Base
 
   scope :open, -> { joins(:quality_metric).merge(QualityMetric.open) }
   scope :admin_only, -> { joins(:quality_metric).merge(QualityMetric.admin_only) }
+  scope :sorted_by_name, -> { joins(:quality_metric).order('quality_metrics.name asc') }
 
   delegate :name, to: :quality_metric
   delegate :admin_only?, to: :quality_metric


### PR DESCRIPTION
For now, we'll go alphabetical by name. A future may have the QM### identifier included and maybe sort by that ... but that's The Future.

Bonus'd in a correction to the GitHub URLs mentioned in some of the QM failure messages.