### PR TITLE
prevent an exception if the user's public key is empty

### DIFF
--- a/src/supermarket/app/models/user.rb
+++ b/src/supermarket/app/models/user.rb
@@ -381,6 +381,7 @@ class User < ActiveRecord::Base
   end
 
   def public_key_signature
+    return nil unless public_key.present?
     # Inspired by https://stelfox.net/blog/2014/04/calculating-rsa-key-fingerprints-in-ruby/
     # Verifiable by an end-user either:
     #   with private key: openssl rsa -in private_key.pem -pubout -outform DER | openssl md5 -c

--- a/src/supermarket/app/views/profile/edit.html.erb
+++ b/src/supermarket/app/views/profile/edit.html.erb
@@ -86,15 +86,29 @@
         <p>Your Supermarket key is the same as your key on the associated Chef
            Server. You can change your credentials or keys by logging into
            <a href="<%= chef_oauth2_url %>">this Supermarket's Chef Server</a>.</p>
-        <p>Current key fingerprint for this Supermarket is:</p>
-        <p><pre class="install"><%= current_user.public_key_signature %></pre></p>
-        <p>This fingerprint should match the fingerprint of the private key you
-           have configured in knife. Check with:</p>
-        <p><pre class="install">openssl rsa -in your/private_key.pem -pubout -outform DER | openssl md5 -c</pre></p>
-        <p>If the signatures do not match, it could be that you have a newer key
-           on the Chef Server than the one known by Supermarket. Supermarket can
-           get the latest key if you log out of Supermarket and then log back in
-           to trigger an account refresh between the systems.</p>
+        <% if current_user.public_key_signature -%>
+          <p>Current key fingerprint for this Supermarket is:</p>
+          <p><pre class="install"><%= current_user.public_key_signature %></pre></p>
+          <p>This fingerprint should match the fingerprint of the private key you
+             have configured in knife. Check with:</p>
+          <p><pre class="install">openssl rsa -in your/private_key.pem -pubout -outform DER | openssl md5 -c</pre></p>
+          <p>If the signatures do not match, it could be that you have a newer key
+             on the Chef Server than the one known by Supermarket. Supermarket can
+             get the latest key if you log out of Supermarket and then log back in
+             to trigger an account refresh between the systems.</p>
+        <% else -%>
+          <p><i class="fa fa-warning"></i> The account information from
+             <a href="<%= chef_oauth2_url %>">the associated Chef Server</a>
+             does not appear to contain a public key. Try logging out of
+             Supermarket and logging back in. If your key still does not appear
+             here, there is probably an issue with the authentication services
+             between Supermarket and the Chef Server. Check
+             <a href="http://status.chef.io/">status.chef.io</a> for service
+             alerts or for private Supermarkets contact support. You will not be
+             able to use Supermarket clients (e.g. knife supermarket or stove)
+             to publish cookbooks until a public key is associated with your
+             account.</p>
+        <% end -%>
       </div>
     </div>
   </div>

--- a/src/supermarket/spec/models/user_spec.rb
+++ b/src/supermarket/spec/models/user_spec.rb
@@ -559,10 +559,14 @@ describe User do
   end
 
   describe '#public_key_signature' do
-    let(:user) { create(:user, public_key: File.read('spec/support/key_fixtures/valid_public_key.pub')) }
-
     it 'returns the hex MD5 hash of the DER form of the user\'s public key' do
+      user = create(:user, public_key: File.read('spec/support/key_fixtures/valid_public_key.pub'))
       expect(user.public_key_signature).to eq("0f:d2:d4:d9:76:14:ab:8e:bd:67:87:d5:d6:a7:24:29")
+    end
+
+    it 'returns nil if there is no public key on the user\'s account' do
+      user = create(:user, public_key: nil)
+      expect(user.public_key_signature).to be_nil
     end
   end
 end


### PR DESCRIPTION
If something has gone horribly awry with OC-ID and the oauth tango has not given Supermarket a public key to associate with the user, this stops the exception when attempting the produce a fingerprint for the key that's really nil.

If the key is missing, say so on the user's profile page with something to try to fix it.
![so, your key is missing](https://cloud.githubusercontent.com/assets/517302/25757582/0b353a90-3199-11e7-8c6d-513d1bb56817.png)

