### PR TITLE
fix fieri metrics that use artifact_url

### DIFF
--- a/src/fieri/app/models/foodcritic_worker.rb
+++ b/src/fieri/app/models/foodcritic_worker.rb
@@ -5,7 +5,7 @@ class FoodcriticWorker
   include ::Sidekiq::Worker
 
   def perform(params)
-    cookbook = CookbookArtifact.new(params['cookbook_artifact_url'], jid)
+    cookbook = CookbookArtifact.new(params['artifact_url'], jid)
     feedback, status = cookbook.criticize
     make_post(params, feedback, status)
     cookbook.cleanup
@@ -21,13 +21,13 @@ class FoodcriticWorker
     response = Net::HTTP.post_form(
       URI.parse("#{ENV['FIERI_SUPERMARKET_ENDPOINT']}/api/v1/quality_metrics/foodcritic_evaluation"),
       fieri_key: ENV['FIERI_KEY'],
-      cookbook_name: params['cookbook_name'],
-      cookbook_version: params['cookbook_version'],
+      cookbook_name: params['name'],
+      cookbook_version: params['version'],
       foodcritic_feedback: format_feedback(feedback, status),
       foodcritic_failure: status
     )
     return if response.is_a? Net::HTTPSuccess
-    raise "Unable to POST Foodcritic Evaluation of #{params['cookbook_name']} " + response.message
+    raise "Unable to POST Foodcritic Evaluation of #{params['name']} " + response.message
   end
 
   private

--- a/src/fieri/app/models/no_binaries_worker.rb
+++ b/src/fieri/app/models/no_binaries_worker.rb
@@ -5,7 +5,7 @@ class NoBinariesWorker
   include ::Sidekiq::Worker
 
   def perform(params)
-    cookbook = CookbookArtifact.new(params['cookbook_artifact_url'], jid)
+    cookbook = CookbookArtifact.new(params['artifact_url'], jid)
     binary_files = cookbook.binaries
 
     failure = !binary_files.empty?
@@ -29,12 +29,12 @@ class NoBinariesWorker
     response = Net::HTTP.post_form(
       URI.parse("#{ENV['FIERI_SUPERMARKET_ENDPOINT']}/api/v1/quality_metrics/no_binaries_evaluation"),
       fieri_key: ENV['FIERI_KEY'],
-      cookbook_name: params['cookbook_name'],
-      cookbook_version: params['cookbook_version'],
+      cookbook_name: params['name'],
+      cookbook_version: params['version'],
       no_binaries_feedback: feedback,
       no_binaries_failure: failure
     )
     return if response.is_a? Net::HTTPSuccess
-    raise "Unable to POST No Binaries Evaluation of #{params['cookbook_name']} " + response.message
+    raise "Unable to POST No Binaries Evaluation of #{params['name']} " + response.message
   end
 end

--- a/src/fieri/spec/models/foodcritic_worker_spec.rb
+++ b/src/fieri/spec/models/foodcritic_worker_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 describe FoodcriticWorker do
   let(:valid_params) do
-    { 'cookbook_artifact_url' => 'http://example.com/apache.tar.gz',
-      'cookbook_name' => 'apache2',
-      'cookbook_version' => '1.2.0' }
+    { 'artifact_url' => 'http://example.com/apache.tar.gz',
+      'name' => 'apache2',
+      'version' => '1.2.0' }
   end
 
   let(:test_evaluation_endpoint) do
@@ -54,7 +54,7 @@ describe FoodcriticWorker do
 
   describe 'when posting results back to Supermarket' do
     let(:not_gonna_work_params) do
-      valid_params.merge('cookbook_name' => 'not_gonna_work')
+      valid_params.merge('name' => 'not_gonna_work')
     end
 
     it 'rescues a POST error' do

--- a/src/fieri/spec/models/no_binaries_worker_spec.rb
+++ b/src/fieri/spec/models/no_binaries_worker_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 describe NoBinariesWorker do
   let(:valid_params) do
-    { 'cookbook_artifact_url' => 'http://example.com/apache.tar.gz',
-      'cookbook_name' => 'apache2',
-      'cookbook_version' => '1.2.0' }
+    { 'artifact_url' => 'http://example.com/apache.tar.gz',
+      'name' => 'apache2',
+      'version' => '1.2.0' }
   end
 
   let(:test_evaluation_endpoint) do
@@ -40,7 +40,7 @@ describe NoBinariesWorker do
 
   describe 'when posting results back to Supermarket' do
     let(:not_gonna_work_params) do
-      valid_params.merge('cookbook_name' => 'not_gonna_work')
+      valid_params.merge('name' => 'not_gonna_work')
     end
 
     it 'rescues a POST error' do


### PR DESCRIPTION
These workers did not get updated with the new, shorter key names used for the params passed to the jobs.
