### PR TITLE
replace markdown renderer with GitHub's pipeline

### DIFF
--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -16,10 +16,14 @@ gem 'sidekiq-cron'
 
 gem 'aws-sdk'
 gem 'chef', require: false
+gem 'commonmarker'
 gem 'compass-rails'
 gem 'ddtrace', require: false
 gem 'dotenv'
 gem 'foreman'
+gem 'gemoji'
+gem 'github-linguist'
+gem 'html-pipeline'
 gem 'html_truncator'
 gem 'jbuilder'
 gem 'kaminari'
@@ -33,10 +37,10 @@ gem 'pg_search'
 gem 'premailer-rails', group: [:development, :production]
 gem 'pundit'
 gem 'rb-readline'
-gem 'redcarpet' # markdown parsing
 gem 'redis-rails'
 gem 'rinku', require: 'rails_rinku'
 gem 'rollout'
+gem 'sanitize'
 gem 'sass-globbing'
 gem 'sass-rails'
 gem 'sentry-raven', require: false

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     capybara-screenshot (1.0.14)
       capybara (>= 1.0, < 3)
       launchy
+    charlock_holmes (0.7.6)
     chef (14.5.33)
       addressable
       bundler (>= 1.10)
@@ -142,6 +143,8 @@ GEM
     coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    commonmarker (0.17.4)
+      ruby-enum (~> 0.5)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -182,6 +185,7 @@ GEM
       railties (>= 3.2, < 5.2)
     equalizer (0.0.11)
     erubis (2.7.0)
+    escape_utils (1.2.1)
     et-orbi (1.1.5)
       tzinfo
     execjs (2.7.0)
@@ -212,7 +216,13 @@ GEM
       et-orbi (~> 1.1, >= 1.1.3)
       raabro (~> 1.1)
     fuzzyurl (0.9.0)
+    gemoji (3.0.0)
     gherkin (5.1.0)
+    github-linguist (6.2.0)
+      charlock_holmes (~> 0.7.6)
+      escape_utils (~> 1.2.0)
+      mime-types (>= 1.19)
+      rugged (>= 0.25.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     guard (2.14.1)
@@ -235,6 +245,9 @@ GEM
     hashdiff (0.3.4)
     hashie (3.5.7)
     highline (1.7.10)
+    html-pipeline (2.7.1)
+      activesupport (>= 2)
+      nokogiri (>= 1.4)
     html_truncator (0.4.1)
       nokogiri (~> 1.5)
     htmlentities (4.3.4)
@@ -322,6 +335,8 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    nokogumbo (1.5.0)
+      nokogiri
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -435,7 +450,6 @@ GEM
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
     rb-readline (0.5.4)
-    redcarpet (3.4.0)
     redis (3.3.5)
     redis-actionpack (5.0.2)
       actionpack (>= 4.0, < 6)
@@ -489,12 +503,19 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-enum (0.7.1)
+      i18n
     ruby-filemagic (0.7.2)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     rufus-lru (1.1.0)
+    rugged (0.27.2)
     safe_yaml (1.0.4)
+    sanitize (4.6.5)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.4.4)
+      nokogumbo (~> 1.4)
     sass (3.4.24)
     sass-globbing (1.1.5)
       sass (>= 3.1)
@@ -605,6 +626,7 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   chef
+  commonmarker
   compass-rails
   database_cleaner
   ddtrace
@@ -613,9 +635,12 @@ DEPENDENCIES
   faker
   fieri!
   foreman
+  gemoji
+  github-linguist
   guard
   guard-rspec
   guard-rubocop
+  html-pipeline
   html_truncator
   jbuilder
   kaminari
@@ -640,12 +665,12 @@ DEPENDENCIES
   rails (~> 5.0.0)
   rails-controller-testing
   rb-readline
-  redcarpet
   redis-rails
   rinku
   rollout
   rspec-rails
   rubocop (>= 0.23.0)
+  sanitize
   sass-globbing
   sass-rails
   sentry-raven

--- a/src/supermarket/app/helpers/markdown_helper.rb
+++ b/src/supermarket/app/helpers/markdown_helper.rb
@@ -1,55 +1,6 @@
+require 'html/pipeline'
+
 module MarkdownHelper
-  #
-  # Make auto-links target=_blank
-  #
-  class SupermarketRenderer < Redcarpet::Render::Safe
-    include ActionView::Helpers::TagHelper
-
-    def initialize(extensions = {})
-      super extensions.merge(
-        link_attributes: { target: '_blank' },
-        with_toc_data: true
-      )
-    end
-
-    #
-    # Last stop opportunity to transform the HTML Redcarpet has generated
-    # from markdown input.
-    #
-    # @param html_document [String] the Redcarpet rendered markdown-to-HTML
-    #
-    # @return [String] HTML document fragrant ready for display
-    #
-    def postprocess(html_document)
-      # if more transforms are added here, some sort of proper pipeline
-      # should be considered
-      doc = Nokogiri::HTML::DocumentFragment.parse(html_document)
-      doc = make_img_src_urls_protocol_relative(doc)
-      doc.to_s
-    end
-
-    private
-
-    #
-    # Transform generated image tags to use protocol-relative URL
-    #
-    # @param doc [Nokogiri::HTML::DocumentFragment] already-parsed HTML
-    #
-    # @return [Nokogiri::HTML::DocumentFragment] transformed, parsed HTML
-    #
-    def make_img_src_urls_protocol_relative(doc)
-      doc.search("img").each do |img|
-        next if img['src'].nil?
-        src = img['src'].strip
-        if src.start_with? 'http'
-          img["src"] = src.sub!(/\Ahttps?:/, '')
-        end
-      end
-
-      doc
-    end
-  end
-
   #
   # Renders markdown as escaped HTML.
   #
@@ -58,16 +9,20 @@ module MarkdownHelper
   # @return [String] escaped HTML.
   #
   def render_markdown(text)
-    Redcarpet::Markdown.new(
-      SupermarketRenderer,
-      autolink: true,
-      fenced_code_blocks: true,
-      tables: true,
-      no_intra_emphasis: true,
-      strikethrough: true,
-      superscript: true
-    ).render(
-      text
-    ).html_safe
+    context = {
+      base_url: Supermarket::Host.full_url,
+      http_url: Supermarket::Host.full_url
+    }
+
+    pipeline = HTML::Pipeline.new [
+      HTML::Pipeline::MarkdownFilter,
+      HTML::Pipeline::SanitizationFilter,
+      HTML::Pipeline::ImageMaxWidthFilter,
+      HTML::Pipeline::HttpsFilter,
+      HTML::Pipeline::MentionFilter
+    ], context.merge(gfm: true)
+
+    result = pipeline.call(text)
+    result[:output].to_s.html_safe
   end
 end

--- a/src/supermarket/app/helpers/markdown_helper.rb
+++ b/src/supermarket/app/helpers/markdown_helper.rb
@@ -18,6 +18,7 @@ module MarkdownHelper
       HTML::Pipeline::MarkdownFilter,
       HTML::Pipeline::SanitizationFilter,
       HTML::Pipeline::ImageMaxWidthFilter,
+      HTML::Pipeline::TableOfContentsFilter,
       HTML::Pipeline::HttpsFilter,
       HTML::Pipeline::MentionFilter
     ], context.merge(gfm: true)

--- a/src/supermarket/app/helpers/markdown_helper.rb
+++ b/src/supermarket/app/helpers/markdown_helper.rb
@@ -20,10 +20,41 @@ module MarkdownHelper
       HTML::Pipeline::ImageMaxWidthFilter,
       HTML::Pipeline::TableOfContentsFilter,
       HTML::Pipeline::HttpsFilter,
+      LinksTargetNewWindowFilter,
+      ImgProtocolRelativeFilter,
       HTML::Pipeline::MentionFilter
     ], context.merge(gfm: true)
 
     result = pipeline.call(text)
     result[:output].to_s.html_safe
+  end
+
+  class LinksTargetNewWindowFilter < HTML::Pipeline::HttpsFilter
+    #
+    # Sets every link in a document to open in a new browser window or tab
+    #
+    def call
+      doc.search("a").each do |link|
+        link["target"] = "_blank"
+      end
+      doc
+    end
+  end
+
+  class ImgProtocolRelativeFilter < HTML::Pipeline::HttpsFilter
+    #
+    # Converts the scheme of every img tag http/https src attribute
+    # to be a relative protocol
+    #
+    def call
+      doc.search("img").each do |img|
+        next if img['src'].nil?
+        src = img['src'].strip
+        if src.start_with? 'http'
+          img["src"] = src.sub(/\Ahttps?:/, '')
+        end
+      end
+      doc
+    end
   end
 end

--- a/src/supermarket/spec/helpers/cookbook_versions_helper_spec.rb
+++ b/src/supermarket/spec/helpers/cookbook_versions_helper_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe CookbookVersionsHelper do
   describe '#render_document' do
     it 'converts markdown to html when the extension is "md"' do
-      expect(render_document('*hi*', 'md')).to eql("<p><em>hi</em></p>\n")
+      expect(render_document('*hi*', 'md')).to eql("<p><em>hi</em></p>")
     end
 
     it 'returns the content if no extension is specified' do

--- a/src/supermarket/spec/helpers/markdown_helper_spec.rb
+++ b/src/supermarket/spec/helpers/markdown_helper_spec.rb
@@ -33,13 +33,13 @@ describe MarkdownHelper do
     expect(helper.render_markdown(table)).to match(/<table>/)
   end
 
-  it "doesn't adds br tags on hard wraps" do
-    markdown = <<-HARDWRAP.strip_heredoc
-      There is no hard
+  it "adds br tags on hard wraps" do
+    markdown = <<~HARDWRAP.strip_heredoc
+      There is a hard
       wrap.
     HARDWRAP
 
-    expect(helper.render_markdown(markdown)).to_not match(/<br>/)
+    expect(helper.render_markdown(markdown)).to match(/<br>/)
   end
 
   it "doesn't emphasize underscored words" do

--- a/src/supermarket/spec/helpers/markdown_helper_spec.rb
+++ b/src/supermarket/spec/helpers/markdown_helper_spec.rb
@@ -54,10 +54,6 @@ describe MarkdownHelper do
     expect(helper.render_markdown('~~Ignore This~~')).to match(/<del>/)
   end
 
-  it 'superscripts text using ^ with a sup tag' do
-    expect(helper.render_markdown('Supermarket^2')).to match(/<sup>/)
-  end
-
   context 'protocol in URLs for images get converted' do
     it 'HTTP -> protocol-relative' do
       html = helper.render_markdown('![](http://img.example.com)')


### PR DESCRIPTION
Answering the occasional call for a more GitHub-like markdown rendering, replace our current renderer with GitHub's rendering pipeline tools.

Fixes #1321