### PR TITLE
Add AURD Terraform + Cookbook

### DIFF
--- a/.delivery/build_cookbook/libraries/helpers.rb
+++ b/.delivery/build_cookbook/libraries/helpers.rb
@@ -64,6 +64,18 @@ module BuildCookbook
     end
 
     #########################################################################
+    # Deploy Helpers
+    #########################################################################
+
+    # Determine which recipe to use for the given scenario
+    def recipe_for(infra_node)
+      package_type = infra_node.attribute?('scenario_package_type') ? infra_node['scenario_package_type'] : 'omnibus'
+      topology = infra_node.attribute?('scenario_topology') ? infra_node['scenario_topology'] : 'standalone'
+
+      "#{package_type}_#{topology}"
+    end
+
+    #########################################################################
     # Inspec
     #########################################################################
     # Coming soon!

--- a/.delivery/build_cookbook/metadata.rb
+++ b/.delivery/build_cookbook/metadata.rb
@@ -2,7 +2,7 @@ name 'build_cookbook'
 maintainer 'The Authors'
 maintainer_email 'you@example.com'
 license 'all_rights'
-version '0.2.1'
+version '0.2.2'
 
 gem 'aws-sdk'
 gem 'json', '~> 1.8'

--- a/.delivery/build_cookbook/recipes/deploy.rb
+++ b/.delivery/build_cookbook/recipes/deploy.rb
@@ -3,3 +3,25 @@
 # Recipe:: deploy
 #
 # Copyright (c) 2016 The Authors, All Rights Reserved.
+
+infra_nodes = infra_nodes_for(workflow_change_project, workflow_change_pipeline, workflow_stage)
+infra_node_names = infra_nodes.map(&:name)
+
+# Set the run list on all nodes
+infra_nodes.each do |infra_node|
+  chef_node infra_node.name do
+    chef_server automate_chef_server_details
+    run_list %W(
+      recipe[cd-infrastructure-base::default]
+      recipe[supermarket-deploy::#{recipe_for(infra_node)}]
+    )
+  end
+end
+
+# Execute a CCR on the instances to bring up Supermarket
+parallel_remote_execute "Run CCR on #{infra_node_names}" do
+  command 'sudo /opt/chef/bin/chef-client'
+  hosts infra_node_names
+  private_key aws_private_key
+  timeout 7200 # 2 hours
+end

--- a/.delivery/build_cookbook/recipes/provision.rb
+++ b/.delivery/build_cookbook/recipes/provision.rb
@@ -23,4 +23,10 @@ expeditor_artifactory workflow_change_project do
   only_if { workflow_stage?('union') }
 end
 
-# TODO: Terraform up some environments!
+# Stand up the Supermarket instance
+execute 'apply-terraform' do
+  command 'make apply'
+  cwd supermarket_repo_terraform_directory
+  environment supermarket_terraform_environment_vars
+  live_stream true
+end

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,41 +1,79 @@
-sudo: false
-addons:
-  postgresql: '9.3'
-  apt:
-    packages:
-    - libxslt1-dev
-    - libxml2-dev
-    - libmagic-dev
-before_install:
-- cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle config build.nokogiri --use-system-libraries
-before_script:
-- cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake $COMPONENT:travis:before_script
 branches:
   only:
-  - master
-bundler_args: "--without development --jobs 7"
+    - master
+
+sudo: false
+
 cache:
   apt: true
   bundler: true
   directories:
-  - "$TRAVIS_BUILD_DIR/src/$COMPONENT/vendor/bundle"
+    - $HOME/tools
+    - "$TRAVIS_BUILD_DIR/src/$COMPONENT/vendor/bundle"
+
 env:
   global:
-  - CAPYBARA_SCREENSHOT_TO_S3=true
-  - secure: zmBguz2BE0upyqhYJbr73wXVPkLO8Me1WisL4bh6B+HVAK6fCHSkdf/FGiiGz1h+HLF39K8DweNw7uPoyQfDxpN3E14MCUkk+jG7I+0IyT5istEsLeJXEBDp2sqgBYcPpCvw73Q4SGYsG2Uf+Ofz5ihKTw4zaxYGYkbuJ7UAs80=
-  - secure: RfOhiaSlkbK0x798woj4sASE0VM2gGn6tdUqkWLWeOYvlRT1wqWs8ZLrVALfpyDiutFyxSPFIALp1fObCBTzswOtBxAQXc347dqVbYmqH92VbTp+qSJO9+dOHIoGe9hrV89Fe73AeL85n2rXzPEXLSJoE3Ap4F8nAGbkpbSf/+M=
-  matrix:
-  - COMPONENT=supermarket
-  - COMPONENT=fieri
+    - CAPYBARA_SCREENSHOT_TO_S3=true
+    - secure: zmBguz2BE0upyqhYJbr73wXVPkLO8Me1WisL4bh6B+HVAK6fCHSkdf/FGiiGz1h+HLF39K8DweNw7uPoyQfDxpN3E14MCUkk+jG7I+0IyT5istEsLeJXEBDp2sqgBYcPpCvw73Q4SGYsG2Uf+Ofz5ihKTw4zaxYGYkbuJ7UAs80=
+    - secure: RfOhiaSlkbK0x798woj4sASE0VM2gGn6tdUqkWLWeOYvlRT1wqWs8ZLrVALfpyDiutFyxSPFIALp1fObCBTzswOtBxAQXc347dqVbYmqH92VbTp+qSJO9+dOHIoGe9hrV89Fe73AeL85n2rXzPEXLSJoE3Ap4F8nAGbkpbSf/+M=
+
 language: ruby
+rvm:
+  - 2.4.1
+bundler_args: "--without development --jobs 7"
+
 notifications:
   email: false
   slack:
     secure: P9Mioa/7QFudKan2uKfJgP68xcvOLbLwqtjg5Sx1mnY41OzVKT4f5HM/T1gmhEC6s4nDlM/q+OBnNwOvi/5wNY+EkOFQsnfVlODsyVHdtPzo+421HD5mCIyIQocBSTsA720vGVHU3QNOM8hgnkTokWmFVVcF0Z66ICQMHzlS7E4=
-rvm:
-- 2.4.1
-script:
-- cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake $COMPONENT:travis:script
-services:
-- redis-server
-- postgresql
+
+matrix:
+  include:
+
+    # Supermarket Spec
+    - env:
+        - COMPONENT=supermarket
+      addons:
+        postgresql: '9.3'
+        apt:
+          packages:
+            - libxslt1-dev
+            - libxml2-dev
+            - libmagic-dev
+      services:
+        - redis-server
+        - postgresql
+      before_install:
+        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle config build.nokogiri --use-system-libraries
+      before_script:
+        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake $COMPONENT:travis:before_script
+      script:
+        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake $COMPONENT:travis:script
+
+    # Fieri Spec
+    - env:
+        - COMPONENT=fieri
+      addons:
+        postgresql: '9.3'
+        apt:
+          packages:
+            - libxslt1-dev
+            - libxml2-dev
+            - libmagic-dev
+      services:
+        - redis-server
+        - postgresql
+      before_install:
+        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle config build.nokogiri --use-system-libraries
+      before_script:
+        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake $COMPONENT:travis:before_script
+      script:
+        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake $COMPONENT:travis:script
+
+    # Terraform Lint
+    - env:
+        - NAME=lint-terraform
+        - PATH=$HOME/tools/terraform-0.8.1:$PATH
+      install: ./scripts/install_terraform.sh
+      before_script: cd terraform
+      script: make lint

--- a/cookbooks/supermarket-deploy/.gitignore
+++ b/cookbooks/supermarket-deploy/.gitignore
@@ -1,0 +1,21 @@
+.vagrant
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+# test kitchen
+.kitchen/
+.kitchen.local.yml
+
+# Chef
+Berksfile.lock
+.zero-knife.rb
+Policyfile.lock.json

--- a/cookbooks/supermarket-deploy/Berksfile
+++ b/cookbooks/supermarket-deploy/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/cookbooks/supermarket-deploy/README.md
+++ b/cookbooks/supermarket-deploy/README.md
@@ -1,0 +1,3 @@
+# supermarket-deploy
+
+TODO: Enter the cookbook description here.

--- a/cookbooks/supermarket-deploy/attributes/default.rb
+++ b/cookbooks/supermarket-deploy/attributes/default.rb
@@ -1,0 +1,5 @@
+#
+# Cookbook:: supermarket-deploy
+# Attributes:: default
+#
+# Copyright:: 2017, Chef Software Inc Engineering, All Rights Reserved.

--- a/cookbooks/supermarket-deploy/chefignore
+++ b/cookbooks/supermarket-deploy/chefignore
@@ -1,0 +1,107 @@
+# Put files/directories that should be ignored in this file when uploading
+# to a chef-server or supermarket.
+# Lines that start with '# ' are comments.
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+nohup.out
+ehthumbs.db
+Thumbs.db
+
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED ##
+##############
+a.out
+*.o
+*.pyc
+*.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
+
+# Testing #
+###########
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+test/*
+features/*
+examples/*
+Guardfile
+Procfile
+.kitchen*
+.rubocop.yml
+spec/*
+Rakefile
+.travis.yml
+.foodcritic
+.codeclimate.yml
+
+# SCM #
+#######
+.git
+*/.git
+.gitignore
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+# Berkshelf #
+#############
+Berksfile
+Berksfile.lock
+cookbooks/*
+tmp
+
+# Policyfile #
+##############
+Policyfile.rb
+Policyfile.lock.json
+
+# Cookbooks #
+#############
+CONTRIBUTING*
+CHANGELOG*
+TESTING*
+MAINTAINERS.toml
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
+.vagrant
+Vagrantfile

--- a/cookbooks/supermarket-deploy/libraries/helpers.rb
+++ b/cookbooks/supermarket-deploy/libraries/helpers.rb
@@ -1,0 +1,35 @@
+module ChefWorkflow
+  module Helpers
+    def environment
+      node['terraform_environment'] || (node.chef_environment =~ /^acceptance.*$/ ? 'acceptance' : node.chef_environment)
+    end
+
+    def in_dev_or_acceptance?
+      environment == 'acceptance' || node.chef_environment =~ /^dev/
+    end
+
+    # The channel to provide chef_ingredient
+    def omnibus_channel_for_environment
+      in_dev_or_acceptance? ? :unstable : :current
+    end
+
+    # The version to provide chef_ingredient
+    def supermarket_version_for_environment
+      node.attribute?('applications') && node['applications']['supermarket'] ? node['applications']['supermarket'] : 'latest'
+    end
+
+    def server_fqdn_for(product_key)
+      if environment == 'delivered'
+        # We drop the environment on our delivered instances
+        "#{product_key}.chef.co"
+      else
+        # A-U-R instances include the environment
+        "#{product_key}-#{environment}.cd.chef.co"
+      end
+    end
+  end
+end
+
+Chef::Node.send(:include, ChefWorkflow::Helpers)
+Chef::Recipe.send(:include, ChefWorkflow::Helpers)
+Chef::Resource.send(:include, ChefWorkflow::Helpers)

--- a/cookbooks/supermarket-deploy/metadata.rb
+++ b/cookbooks/supermarket-deploy/metadata.rb
@@ -1,0 +1,14 @@
+name 'supermarket-deploy'
+maintainer 'Chef Software Inc Engineering'
+maintainer_email 'engineering@chef.io'
+license 'all_rights'
+description 'Installs/Configures supermarket in ACC'
+long_description 'Installs/Configures supermarket in ACC'
+version '0.0.1'
+
+chef_version '>= 12.1' if respond_to?(:chef_version)
+
+depends 'chef-ingredient'
+
+# TODO: extract common libraries to cd-deploy
+# depends 'cd-deploy'

--- a/cookbooks/supermarket-deploy/recipes/default.rb
+++ b/cookbooks/supermarket-deploy/recipes/default.rb
@@ -1,0 +1,8 @@
+#
+# Cookbook:: supermarket-deploy
+# Recipe:: default
+#
+# Copyright:: 2017, Chef Software Inc Engineering, All Rights Reserved.
+
+node.default['citadel']['bucket'] = 'chef-cd-citadel'
+node.default['citadel']['region'] = 'us-west-2'

--- a/cookbooks/supermarket-deploy/recipes/omnibus_standalone.rb
+++ b/cookbooks/supermarket-deploy/recipes/omnibus_standalone.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook:: supermarket-deploy
+# Recipe:: omnibus_standalone
+#
+# Copyright:: 2017, Chef Software Inc Engineering, All Rights Reserved.
+
+include_recipe 'supermarket-deploy::default'
+
+supermarket_ocid = Chef::JSONCompat.from_json(Chef::HTTP.new("https://#{server_fqdn_for('chef-server')}").get('/supermarket-credentials'))
+
+chef_ingredient 'supermarket' do
+  channel omnibus_channel_for_environment
+  version supermarket_version_for_environment
+  config Chef::JSONCompat.to_json_pretty(
+    fqdn: server_fqdn_for('supermarket'),
+    host: server_fqdn_for('supermarket'),
+    chef_server_url: "https://#{server_fqdn_for('chef-server')}",
+    chef_oauth2_app_id: supermarket_ocid['uid'],
+    chef_oauth2_secret: supermarket_ocid['secret']
+  )
+
+  action :upgrade
+end
+
+ingredient_config 'supermarket' do
+  notifies :reconfigure, 'chef_ingredient[supermarket]'
+end

--- a/scripts/install_terraform.sh
+++ b/scripts/install_terraform.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ ! -d "$HOME/tools/terraform-0.8.1" ]; then
+  mkdir -p $HOME/tools/terraform-0.8.1
+  cd $HOME/tools || exit
+  curl -sLo terraform.zip https://releases.hashicorp.com/terraform/0.8.1/terraform_0.8.1_linux_amd64.zip
+  unzip terraform.zip
+  rm -f terraform.zip || true
+  mv terraform terraform-0.8.1
+fi
+
+echo "terraform --version"
+$HOME/tools/terraform-0.8.1/terraform --version

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,0 +1,95 @@
+# Existing environments: dev, acceptance, union, rehearsal, delivered.
+TF_ENVIRONMENT ?= dev
+TF_DIRECTORY ?= acceptance
+TF_STATE ?= $(TF_ENVIRONMENT).tfstate
+
+ifeq ($(TF_ENVIRONMENT), dev)
+	# We have 4 isolated dev environments
+	export TF_STATE=dev-$(TF_ENVIRONMENT_INDEX).tfstate
+	export TF_VAR_environment=dev-$(TF_ENVIRONMENT_INDEX)
+
+	export TF_VAR_chef_environment ?= $(TF_ENVIRONMENT)
+	export TF_VAR_chef_server_url ?= https://chef-server.chef.co/organizations/chef
+	export TF_VAR_chef_user_name ?= $(USER)
+	export TF_VAR_chef_user_key ?= $(HOME)/.chef/$(USER).pem
+	export TF_VAR_aws_key_name ?= $(USER)
+	export TF_VAR_aws_private_key ?= $(HOME)/.ssh/id_rsa
+else ifeq ($(TF_ENVIRONMENT), acceptance)
+	export TF_DIRECTORY = acceptance
+endif
+
+$(TF_VAR_aws_private_key):
+	$(error Oops, looks like you are missing your AWS private key \($(TF_VAR_aws_private_key)\). Please make sure the file exists, has the correct permissions \(0600\), and is not password protected.)
+
+$(TF_VAR_chef_user_key):
+	$(error Oops, looks like you are missing your Chef user key \($(TF_VAR_chef_user_key)\). Please make sure the file exists. If you need to regenerate it, please visit $(TF_VAR_chef_server_url).)
+
+init: $(TF_VAR_aws_private_key) $(TF_VAR_chef_user_key)
+	$(info ===============================================================)
+ifeq ($(TF_ENVIRONMENT), dev)
+ifeq ($(TF_ENVIRONMENT_INDEX),)
+	$(error The dev environment requires an index! Please export $$TF_ENVIRONMENT_INDEX and try again.)
+endif
+	$(info Environment........$(TF_VAR_environment))
+else
+	$(info Environment........$(TF_ENVIRONMENT))
+endif
+	$(info Terraform State....$(TF_STATE))
+	$(info Chef Environment...$(TF_VAR_chef_environment))
+	$(info Chef Server URL....$(TF_VAR_chef_server_url))
+	$(info Chef User Name.....$(TF_VAR_chef_user_name))
+	$(info Chef User Key......$(TF_VAR_chef_user_key))
+	$(info AWS Keypair Name...$(TF_VAR_aws_key_name))
+	$(info AWS Private Key....$(TF_VAR_aws_private_key))
+	$(info ===============================================================)
+	$(info )
+
+remote-state: init
+	# We make sure that existing local state is deleted before configuring
+	# the remote state. If it is not removed state gets contaminated between
+	# environments.
+
+	cd $(TF_DIRECTORY) && \
+	rm -rf .terraform && \
+	terraform remote config \
+		-backend=s3 \
+		-backend-config="profile=chef-cd" \
+		-backend-config="bucket=chef-cd-terraform-state" \
+		-backend-config="key=supermarket/$(TF_STATE)" \
+		-backend-config="region=us-west-2" && \
+	terraform get
+
+plan: remote-state
+	cd $(TF_DIRECTORY) && terraform plan -var-file=vars/$(TF_ENVIRONMENT).tfvars
+
+apply: remote-state
+	cd $(TF_DIRECTORY) && terraform apply -var-file=vars/$(TF_ENVIRONMENT).tfvars
+
+destroy: remote-state
+ifeq ($(TF_ENVIRONMENT), dev)
+	cd $(TF_DIRECTORY) && terraform destroy -var-file=vars/$(TF_ENVIRONMENT).tfvars
+else
+	@echo "The destroy target is only supported for dev environments."
+endif
+
+show: remote-state
+	cd $(TF_DIRECTORY) && terraform show
+
+output: remote-state
+	cd $(TF_DIRECTORY) && terraform output
+
+console: remote-state
+	cd $(TF_DIRECTORY) && terraform console
+
+# Lint _all_ the directories (including modules)
+# terraform fmt will always exit 0, so we need to check to see if the diff
+# returns anything in order to determine if lint fails
+lint:
+	set -e; \
+	LINT_OUTPUT=$$(terraform fmt --diff --list --write=false ./); \
+	if test -n "$$LINT_OUTPUT"; then \
+		echo "$$LINT_OUTPUT"; \
+		exit 1; \
+	fi
+
+.PHONY: init remote-state plan apply destroy show output console lint

--- a/terraform/acceptance/omnibus-standalone-inplace-upgrade.tf
+++ b/terraform/acceptance/omnibus-standalone-inplace-upgrade.tf
@@ -1,0 +1,28 @@
+module "supermarket_omnibus_standalone_inplace_upgrade_server" {
+  source = "git@github.com:chef/es-terraform.git//modules/chef_managed_instance"
+
+  # Global Settings
+  environment = "${var.environment}"
+
+  # AWS Settings
+  aws_private_key      = "${var.aws_private_key}"
+  aws_key_name         = "${var.aws_key_name}"
+  aws_root_volume_size = 200
+  aws_subdomain        = "supermarket"
+
+  # AWS Tags
+  aws_tag_chef_product      = "supermarket"
+  aws_tag_automate_project  = "${var.automate_project}"
+  aws_tag_automate_pipeline = "${var.automate_pipeline}"
+
+  # Scenario
+  scenario_package_type     = "omnibus"
+  scenario_topology         = "standalone"
+  scenario_install_strategy = "inplace-upgrade"
+
+  # Chef Provisioner
+  chef_environment = "${var.chef_environment}"
+  chef_server_url  = "${var.chef_server_url}"
+  chef_user_name   = "${var.chef_user_name}"
+  chef_user_key    = "${var.chef_user_key}"
+}

--- a/terraform/acceptance/outputs.tf
+++ b/terraform/acceptance/outputs.tf
@@ -1,0 +1,3 @@
+output "supermarket_fqdn" {
+  value = "${module.supermarket_omnibus_standalone_inplace_upgrade_server.fqdn}"
+}

--- a/terraform/acceptance/variables.tf
+++ b/terraform/acceptance/variables.tf
@@ -1,0 +1,49 @@
+#########################################################################
+# Default
+#########################################################################
+# Environment and the associated delivery environment
+# Can be one of dev, acceptance, union, rehearsal or delivered
+variable "environment" {
+  type = "string"
+}
+
+#########################################################################
+# Automate Pipeline
+#########################################################################
+variable "automate_project" {
+  description = "Name of the Automate Workflow project that manages this code"
+}
+
+variable "automate_pipeline" {
+  description = "Name of the Automate Workflow pipeline that manages this code"
+}
+
+#########################################################################
+# AWS
+#########################################################################
+variable "aws_key_name" {
+  description = "AWS keypair name to provison instances with"
+}
+
+variable "aws_private_key" {
+  description = "File path to private key to provision with"
+}
+
+#########################################################################
+# Chef
+#########################################################################
+variable "chef_environment" {
+  description = "Chef environments new nodes will join"
+}
+
+variable "chef_server_url" {
+  description = "Chef Server to bootstrap nodes against"
+}
+
+variable "chef_user_name" {
+  description = "The name of the Chef user to register the new Chef Client with"
+}
+
+variable "chef_user_key" {
+  description = "File path to the user key to authenticate with the Chef Server"
+}

--- a/terraform/acceptance/vars/acceptance.tfvars
+++ b/terraform/acceptance/vars/acceptance.tfvars
@@ -1,0 +1,1 @@
+environment = "acceptance"

--- a/terraform/acceptance/vars/dev.tfvars
+++ b/terraform/acceptance/vars/dev.tfvars
@@ -1,0 +1,5 @@
+# This is set via the `TF_VAR_environment` var in the `Makefile` now
+# environment = "dev"
+monitoring_enabled = "0"
+automate_project = "NA"
+automate_pipeline = "NA"

--- a/terraform/u-r-d/omnibus-standalone-inplace-upgrade.tf
+++ b/terraform/u-r-d/omnibus-standalone-inplace-upgrade.tf
@@ -1,0 +1,30 @@
+module "supermarket_omnibus_standalone_inplace_upgrade_server" {
+  source = "git@github.com:chef/es-terraform.git//modules/chef_managed_instance"
+
+  # Global Settings
+  environment = "${var.environment}"
+
+  # AWS Settings
+  aws_instance_type    = "m4.large"
+  aws_private_key      = "${var.aws_private_key}"
+  aws_key_name         = "${var.aws_key_name}"
+  aws_root_volume_size = 200
+  aws_subdomain        = "supermarket"
+
+  # AWS Tags
+  aws_tag_chef_product      = "supermarket"
+  aws_tag_automate_project  = "${var.automate_project}"
+  aws_tag_automate_pipeline = "${var.automate_pipeline}"
+  aws_tag_backup            = "${var.environment == "delivered" ? true : false}"
+
+  # Scenario
+  scenario_package_type     = "omnibus"
+  scenario_topology         = "standalone"
+  scenario_install_strategy = "inplace-upgrade"
+
+  # Chef Provisioner
+  chef_environment = "${var.chef_environment}"
+  chef_server_url  = "${var.chef_server_url}"
+  chef_user_name   = "${var.chef_user_name}"
+  chef_user_key    = "${var.chef_user_key}"
+}

--- a/terraform/u-r-d/outputs.tf
+++ b/terraform/u-r-d/outputs.tf
@@ -1,0 +1,3 @@
+output "supermarket_fqdn" {
+  value = "${module.supermarket_omnibus_standalone_inplace_upgrade_server.fqdn}"
+}

--- a/terraform/u-r-d/variables.tf
+++ b/terraform/u-r-d/variables.tf
@@ -1,0 +1,49 @@
+#########################################################################
+# Default
+#########################################################################
+# Environment and the associated delivery environment
+# Can be one of dev, acceptance, union, rehearsal or delivered
+variable "environment" {
+  type = "string"
+}
+
+#########################################################################
+# Automate Pipeline
+#########################################################################
+variable "automate_project" {
+  description = "Name of the Automate Workflow project that manages this code"
+}
+
+variable "automate_pipeline" {
+  description = "Name of the Automate Workflow pipeline that manages this code"
+}
+
+#########################################################################
+# AWS
+#########################################################################
+variable "aws_key_name" {
+  description = "AWS keypair name to provison instances with"
+}
+
+variable "aws_private_key" {
+  description = "File path to private key to provision with"
+}
+
+#########################################################################
+# Chef
+#########################################################################
+variable "chef_environment" {
+  description = "Chef environments new nodes will join"
+}
+
+variable "chef_server_url" {
+  description = "Chef Server to bootstrap nodes against"
+}
+
+variable "chef_user_name" {
+  description = "The name of the Chef user to register the new Chef Client with"
+}
+
+variable "chef_user_key" {
+  description = "File path to the user key to authenticate with the Chef Server"
+}

--- a/terraform/u-r-d/vars/delivered.tfvars
+++ b/terraform/u-r-d/vars/delivered.tfvars
@@ -1,0 +1,1 @@
+environment = "delivered"

--- a/terraform/u-r-d/vars/dev.tfvars
+++ b/terraform/u-r-d/vars/dev.tfvars
@@ -1,0 +1,5 @@
+# This is set via the `TF_VAR_environment` var in the `Makefile` now
+# environment = "dev"
+monitoring_enabled = "0"
+automate_project = "NA"
+automate_pipeline = "NA"

--- a/terraform/u-r-d/vars/rehearsal.tfvars
+++ b/terraform/u-r-d/vars/rehearsal.tfvars
@@ -1,0 +1,1 @@
+environment = "rehearsal"

--- a/terraform/u-r-d/vars/union.tfvars
+++ b/terraform/u-r-d/vars/union.tfvars
@@ -1,0 +1,1 @@
+environment = "union"


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Tom Duffield

* Add terraform to stand up AURD
* Add supermarket-deploy cookbook to configure AURD
* Update travis.yml to execute terraform lint tests

Signed-off-by: Tom Duffield <tom@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://automate.chef.co/e/chef/#/organizations/products/projects/supermarket/changes/8650b71e-61c7-4cf6-a039-61812db76fc4