### PR TITLE
Disable append_timestamps on Omnibus builds

### DIFF
--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -28,6 +28,10 @@
 # ------------------------------
 # use_git_caching false
 
+# Disable timestamps on Omnibus builds
+# ------------------------------------
+append_timestamp false
+
 # Enable S3 asset caching
 # ------------------------------
 use_s3_caching true


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Tom Duffield

So it looks like timestamps are being appended to resulting builds. This will remove that and allow stuff to work as expected in the "new world order."

Signed-off-by: Tom Duffield <tom@chef.io>



Ready to merge? View this change in Chef Automate and click the Approve button: https://automate.chef.co/e/chef/#/organizations/products/projects/supermarket/changes/7cf91df8-e1b8-44b4-8c3c-9ca26507652d