### PR TITLE
Add channel fallback support to deploy cookbook

### DIFF
--- a/cookbooks/supermarket-deploy/Berksfile
+++ b/cookbooks/supermarket-deploy/Berksfile
@@ -7,5 +7,5 @@ source 'https://supermarket.chef.io'
 metadata
 
 # These definitions can be removed when supermarket.chef.co is fully online
-cookbook 'cd-deploy', git: 'git@github.com:chef-cookbooks/cd-deploy.git'
+cookbook 'cd-deploy', git: 'git@github.com:chef-cookbooks/cd-deploy.git', branch: 'tduffield/channel-fallback'
 cookbook 'chefops-dcc', git: 'git@github.com:chef-cookbooks/chefops-dcc'

--- a/cookbooks/supermarket-deploy/metadata.rb
+++ b/cookbooks/supermarket-deploy/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@chef.io'
 license 'all_rights'
 description 'Installs/Configures supermarket in ACC'
 long_description 'Installs/Configures supermarket in ACC'
-version '0.1.2'
+version '0.1.3'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 

--- a/cookbooks/supermarket-deploy/recipes/omnibus_standalone.rb
+++ b/cookbooks/supermarket-deploy/recipes/omnibus_standalone.rb
@@ -39,7 +39,7 @@ end
 supermarket_ocid = Chef::JSONCompat.from_json(Chef::HTTP.new("https://#{server_fqdn_for('chef-server')}").get('/supermarket-credentials'))
 
 chef_ingredient 'supermarket' do
-  channel omnibus_channel_for_environment
+  channel omnibus_channel_for_environment('supermarket')
   version version_for_environment('supermarket')
   config Chef::JSONCompat.to_json_pretty(
     fqdn: server_fqdn_for('supermarket'),


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Tom Duffield

The unstable and current channels have artifact expiration, which means
that if the pipeline is not updated very frequently you can start having
CCR failures since the version is no longer available in that channel.

This leverages new code from cd-deploy to handle this case.

Signed-off-by: Tom Duffield <tom@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/products/projects/supermarket/changes/59f5ae27-da1d-45d0-84df-227a1a0a5945) in Chef Automate and click the Approve button.