### PR TITLE
Put build-cookbook and supermarket-deploy back on master for helpers

### DIFF
--- a/.delivery/build_cookbook/Berksfile
+++ b/.delivery/build_cookbook/Berksfile
@@ -3,5 +3,4 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'expeditor-build',
-         git: 'git@github.com:chef-cookbooks/expeditor-build.git',
-         branch: 'tduffield/add-terraform'
+         git: 'git@github.com:chef-cookbooks/expeditor-build.git'

--- a/.delivery/build_cookbook/metadata.rb
+++ b/.delivery/build_cookbook/metadata.rb
@@ -2,11 +2,7 @@ name 'build_cookbook'
 maintainer 'The Authors'
 maintainer_email 'you@example.com'
 license 'all_rights'
-version '0.2.5'
-
-gem 'aws-sdk'
-gem 'json', '~> 1.8'
-gem 'chef-sugar'
+version '0.2.6'
 
 chef_version '>= 12.19'
 

--- a/cookbooks/supermarket-deploy/Berksfile
+++ b/cookbooks/supermarket-deploy/Berksfile
@@ -7,5 +7,5 @@ source 'https://supermarket.chef.io'
 metadata
 
 # These definitions can be removed when supermarket.chef.co is fully online
-cookbook 'cd-deploy', git: 'git@github.com:chef-cookbooks/cd-deploy.git', branch: 'tduffield/channel-fallback'
+cookbook 'cd-deploy', git: 'git@github.com:chef-cookbooks/cd-deploy.git'
 cookbook 'chefops-dcc', git: 'git@github.com:chef-cookbooks/chefops-dcc'

--- a/cookbooks/supermarket-deploy/metadata.rb
+++ b/cookbooks/supermarket-deploy/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'engineering@chef.io'
 license 'all_rights'
 description 'Installs/Configures supermarket in ACC'
 long_description 'Installs/Configures supermarket in ACC'
-version '0.1.3'
+version '0.1.4'
 
 chef_version '>= 12.1' if respond_to?(:chef_version)
 


### PR DESCRIPTION
This Pull Request was opened by Chef Automate user Tom Duffield

Signed-off-by: Tom Duffield <tom@chef.io>



----
Ready to merge? [View this change](https://automate.chef.co/e/chef/#/organizations/products/projects/supermarket/changes/b81e2193-d631-47b4-92c9-2662421aa46d) in Chef Automate and click the Approve button.