### PR TITLE
update mixlib-authn to fix un/sharing with large keys

### DIFF
--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -309,8 +309,7 @@ GEM
     minitest (5.10.2)
     mixlib-archive (0.4.1)
       mixlib-log
-    mixlib-authentication (1.4.1)
-      mixlib-log
+    mixlib-authentication (1.4.2)
     mixlib-cli (1.7.0)
     mixlib-config (2.2.4)
     mixlib-log (1.7.1)


### PR DESCRIPTION
mixlib-authentication 1.4.2 contains a fix for ordering signature
headers. Signatures generated from keys with large bit lengths would
themselves be long enough to spill over into 10 or more of the
X-Ops-Auth headers mixlib-authn expects and would misorder in earlier
versions of the library. See chef/mixlib-authentication#5 for gory
details.

Fixes #1656