### PR TITLE
update nokogiri to address CVE-2017-9050

### DIFF
--- a/src/fieri/Gemfile.lock
+++ b/src/fieri/Gemfile.lock
@@ -105,15 +105,15 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.2)
     mixlib-archive (0.4.1)
       mixlib-log
     mixlib-log (1.7.1)
     multipart-post (2.0.0)
     nio4r (2.1.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.11.2)
@@ -231,4 +231,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.2)
     mixlib-archive (0.4.1)
       mixlib-log
@@ -332,8 +332,8 @@ GEM
     net-telnet (0.1.1)
     newrelic_rpm (4.1.0.333)
     nio4r (2.0.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -688,4 +688,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.15.3
+   1.15.4


### PR DESCRIPTION
Noted here that the omnibus build of Supermarket is not vulnerable as a result of including its own build of libxml. This update makes the security auditing green.
