### PR TITLE
update embedded libxml2 and libxslt

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 34e176df09ad80a49cbf516f18b108a48fc76d15
+  revision: 23de2052e79b7a03d2b0a080d2f6e111ce4c760d
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -30,13 +30,13 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     artifactory (2.8.2)
     awesome_print (1.8.0)
-    aws-sdk (2.10.45)
-      aws-sdk-resources (= 2.10.45)
-    aws-sdk-core (2.10.45)
+    aws-sdk (2.10.53)
+      aws-sdk-resources (= 2.10.53)
+    aws-sdk-core (2.10.53)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.45)
-      aws-sdk-core (= 2.10.45)
+    aws-sdk-resources (2.10.53)
+      aws-sdk-core (= 2.10.53)
     aws-sigv4 (1.0.2)
     berkshelf (6.3.0)
       buff-config (~> 2.0)
@@ -185,7 +185,7 @@ GEM
       progressbar
       zhexdump (>= 0.0.2)
     plist (3.3.0)
-    progressbar (1.8.2)
+    progressbar (1.9.0)
     proxifier (1.0.3)
     public_suffix (3.0.0)
     rack (2.0.3)
@@ -227,7 +227,7 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    ruby-progressbar (1.8.3)
+    ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)


### PR DESCRIPTION
update embedded omnibus software to build against new libxml2 and libxslt

Addresses CVE-2017-0663, CVE-2017-7375, CVE-2017-7376, CVE-2017-9047,
CVE-2017-9048, CVE-2017-9049, CVE-2017-9050.

See https://github.com/chef/omnibus-software/pull/886