### PR TITLE
add QM pass rate percentage to search results, show page

### DIFF
--- a/src/supermarket/app/models/cookbook_version.rb
+++ b/src/supermarket/app/models/cookbook_version.rb
@@ -87,6 +87,10 @@ class CookbookVersion < ApplicationRecord
     user || cookbook.owner
   end
 
+  def metric_result_pass_rate
+    ((metric_results.where(failure: false).count / metric_results.count.to_f) * 100).round(0)
+  end
+
   private
 
   #

--- a/src/supermarket/app/views/cookbooks/_cookbook.html.erb
+++ b/src/supermarket/app/views/cookbooks/_cookbook.html.erb
@@ -7,6 +7,7 @@
         <small><%= cookbook.latest_cookbook_version.version %></small>
       </h2>
       <span class="meta">
+        <i class="fa fa-dashboard"></i> <%= cookbook.latest_cookbook_version.metric_result_pass_rate %>%
         <i class="fa fa-clock-o"></i> Updated <span itemprop="dateModified"><%= cookbook.updated_at.to_s(:longish) %></span><br />
       </span>
 

--- a/src/supermarket/app/views/cookbooks/_main.html.erb
+++ b/src/supermarket/app/views/cookbooks/_main.html.erb
@@ -62,7 +62,7 @@
     <% end %>
     <% if Feature.active?(:fieri) %>
       <dd>
-      <a href="#quality" rel="quality">Quality</a>
+      <a href="#quality" rel="quality">Quality <i class="fa fa-dashboard"></i> <%= version.metric_result_pass_rate %>%</a>
       </dd>
     <% end %>
   </dl>


### PR DESCRIPTION
CookbookVersion now knows how to compute a version's pass rate percentage for quality metrics.

Add that display with a gauge to search results and on the Quality tab of the cookbook version display page.