### PR TITLE
remove some interpolated default attributes for sensible ocid default

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -340,19 +340,27 @@ default['supermarket']['api_item_limit'] = 100
 # ### Chef URL Settings
 #
 # URLs for various links used within Supermarket
-default['supermarket']['chef_identity_url'] = "#{node['supermarket']['chef_server_url']}/id"
-default['supermarket']['chef_manage_url'] = node['supermarket']['chef_server_url']
-default['supermarket']['chef_profile_url'] = node['supermarket']['chef_server_url']
-default['supermarket']['chef_sign_up_url'] = "#{node['supermarket']['chef_server_url']}/signup?ref=community"
+#
+# These have defaults in the app based on the chef_server_url along the lines of the interpolations below.
+# Override if you need to set these URLs to targets other than the configured chef_server_url.
+#
+#default['supermarket']['chef_identity_url'] = "#{node['supermarket']['chef_server_url']}/id"
+#default['supermarket']['chef_manage_url'] = node['supermarket']['chef_server_url']
+#default['supermarket']['chef_profile_url'] = node['supermarket']['chef_server_url']
+#default['supermarket']['chef_sign_up_url'] = "#{node['supermarket']['chef_server_url']}/signup?ref=community"
 
 # URLs for Chef Software, Inc. sites. Most of these have defaults set in
 # Supermarket already, but you can customize them here to your liking
 default['supermarket']['chef_domain'] = 'chef.io'
-default['supermarket']['chef_blog_url'] = "https://www.#{node['supermarket']['chef_domain']}/blog"
-default['supermarket']['chef_docs_url'] = "https://docs.#{node['supermarket']['chef_domain']}"
-default['supermarket']['chef_downloads_url'] = "https://downloads.#{node['supermarket']['chef_domain']}"
-default['supermarket']['chef_www_url'] = "https://www.#{node['supermarket']['chef_domain']}"
-default['supermarket']['learn_chef_url'] = "https://learn.#{node['supermarket']['chef_domain']}"
+default['supermarket']['chef_www_url'] = 'https://www.chef.io'
+#
+# These have defaults in the app based on the chef_domain along the lines of the interpolations below.
+# Override if you need to set these URLs to targets other than the configured chef_domain.
+#
+#default['supermarket']['chef_blog_url'] = "https://www.#{node['supermarket']['chef_domain']}/blog"
+#default['supermarket']['chef_docs_url'] = "https://docs.#{node['supermarket']['chef_domain']}"
+#default['supermarket']['chef_downloads_url'] = "https://downloads.#{node['supermarket']['chef_domain']}"
+#default['supermarket']['learn_chef_url'] = "https://learn.#{node['supermarket']['chef_domain']}"
 
 # ### Chef OAuth2 Settings
 #


### PR DESCRIPTION
This is the start of removing interpolated values from the omnibus' cookbook attribute defaults. Interpolating the default chef_server_url into chef_identity_url in the defaults caused no end of trouble with onprem installations. The [application URL helpers](https://github.com/chef/supermarket/blob/c6970b5aeb95746c24386e7c8cb88000ea5c8790/src/supermarket/app/helpers/custom_url_helper.rb) already perform run-time interpolation with the chef_server_url when no env var is present. So we'll leave these attributes unset which will omit them from the list of things that get exported as env vars.

Administrators still have the option to set a value for these attributes which will set the associated env var and will override in the Rails app.