### PR TITLE
add a tooltip to explain the metric pass rate display

### DIFF
--- a/src/supermarket/app/assets/stylesheets/listing.scss
+++ b/src/supermarket/app/assets/stylesheets/listing.scss
@@ -76,6 +76,12 @@
         margin: rem-calc(10 0 0);
         text-align: right;
 
+        .has-tip {
+          border-bottom: none;
+          color: $concrete;
+          font: $normal rem-calc(12) $accent_font;
+        }
+
         .fa {
           @include inline-block;
           color: $silver;

--- a/src/supermarket/app/assets/stylesheets/tabs.scss
+++ b/src/supermarket/app/assets/stylesheets/tabs.scss
@@ -29,6 +29,15 @@
         background-color: transparent;
         color: $silver;
       }
+
+      .has-tip {
+        border-bottom: none;
+        color: $concrete;
+        font: {
+          size: rem-calc(14);
+          weight: $normal;
+        }
+      }
     }
 
     &.active {
@@ -44,6 +53,15 @@
         line-height: rem-calc(10);
         padding-bottom: rem-calc(19);
         margin-bottom: rem-calc(-1);
+
+        .has-tip {
+          border-bottom: none;
+          color: $primary_blue;
+          font: {
+            size: rem-calc(14);
+            weight: $bold;
+          }
+        }
       }
     }
   }

--- a/src/supermarket/app/models/cookbook_version.rb
+++ b/src/supermarket/app/models/cookbook_version.rb
@@ -92,7 +92,7 @@ class CookbookVersion < ApplicationRecord
     if total_metric_results.positive?
       ((metric_results.where(failure: false).count / total_metric_results.to_f) * 100).round(0)
     else
-      0
+      '-'
     end
   end
 

--- a/src/supermarket/app/views/cookbooks/_cookbook.html.erb
+++ b/src/supermarket/app/views/cookbooks/_cookbook.html.erb
@@ -8,7 +8,9 @@
       </h2>
       <span class="meta">
         <% if Feature.active?(:fieri) -%>
+        <span class="has-tip" title="<%= t('cookbook.quality_metric_pass_rate_tip') %>">
         <i class="fa fa-dashboard"></i> <%= cookbook.latest_cookbook_version.metric_result_pass_rate %>%
+        </span>
         <% end -%>
         <i class="fa fa-clock-o"></i> Updated <span itemprop="dateModified"><%= cookbook.updated_at.to_s(:longish) %></span><br />
       </span>

--- a/src/supermarket/app/views/cookbooks/_main.html.erb
+++ b/src/supermarket/app/views/cookbooks/_main.html.erb
@@ -62,7 +62,10 @@
     <% end %>
     <% if Feature.active?(:fieri) %>
       <dd>
-      <a href="#quality" rel="quality">Quality <i class="fa fa-dashboard"></i> <%= version.metric_result_pass_rate %>%</a>
+      <a href="#quality" rel="quality">Quality
+      <span class="has-tip" title="<%= t('cookbook.quality_metric_pass_rate_tip') %>">
+        <i class="fa fa-dashboard"></i> <%= version.metric_result_pass_rate %>%</a>
+      </span>
       </dd>
     <% end %>
   </dl>

--- a/src/supermarket/config/locales/en.yml
+++ b/src/supermarket/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
     updated: "The %{name} cookbook has been successfully updated."
     not_found: "The %{name} cookbook was not found."
     version_not_found: "Version %{version} of %{name} cookbook was not found."
+    quality_metric_pass_rate_tip: "the percentage of passing quality metrics"
   contributor:
     removed: "Contributor removed."
   contributor_requests:


### PR DESCRIPTION
Also show a "-" when there are no results with which to compute a pass rate.

### Search Results
![screen shot 2017-10-12 at 4 55 15 pm](https://user-images.githubusercontent.com/517302/31518868-9883afa0-af6e-11e7-8bc7-96a5803875d1.png)


### Cookbook Show Page
![screen shot 2017-10-12 at 4 56 06 pm](https://user-images.githubusercontent.com/517302/31518876-9bbd719c-af6e-11e7-8f14-bf283604b591.png)
