### PR TITLE
InSpec smoke test improvements

### DIFF
--- a/inspec/supermarket-smoke/controls/base.rb
+++ b/inspec/supermarket-smoke/controls/base.rb
@@ -19,12 +19,9 @@ title 'Supermarket Smoke Tests'
   end
 end
 
-# Only perform SSL verification on hosts where we know the SSL certs are
-# properly configured
-verify = fetch_target_host.include?('cd.chef.co') ? false : true
 supermarket_version = fetch_supermarket_version
 
-describe http("https://#{fetch_target_host}/status", ssl_verify: verify) do
+describe http("https://#{fetch_target_host}/status") do
   its('status') { should eq 200 }
 end
 

--- a/inspec/supermarket-smoke/libraries/helper.rb
+++ b/inspec/supermarket-smoke/libraries/helper.rb
@@ -1,7 +1,7 @@
 def fetch_supermarket_version
-  attribute('application_version', default: ENV['SUPERMARKET_VERSION'])
+  attribute('application_version', default: ENV['APPLICATION_VERSION'])
 end
 
 def fetch_target_host
-  attribute('target_host', default: command('cat /etc/supermarket/supermarket.json | grep -Po "fqdn[\"\'\s:]+\K.*(?=[\"\']+?)"').stdout.strip)
+  inspec.backend.hostname
 end


### PR DESCRIPTION
* Use SSL verifications by default now (our wildcard cert now covers
  *.cd.chef.co)
* Extract the target host from the InSpec backend

Signed-off-by: Seth Chisamore <schisamo@chef.io>