### PR TITLE
Convert S3_URLS_EXPIRE to a number on use

### DIFF
--- a/src/supermarket/app/controllers/api/v1/cookbook_versions_controller.rb
+++ b/src/supermarket/app/controllers/api/v1/cookbook_versions_controller.rb
@@ -27,6 +27,6 @@ class Api::V1::CookbookVersionsController < Api::V1Controller
     Cookbook.increment_counter(:api_download_count, @cookbook.id)
     Supermarket::Metrics.increment('cookbook.downloads.api')
 
-    redirect_to @cookbook_version.tarball.url
+    redirect_to @cookbook_version.cookbook_artifact_url
   end
 end

--- a/src/supermarket/app/models/cookbook_version.rb
+++ b/src/supermarket/app/models/cookbook_version.rb
@@ -77,7 +77,7 @@ class CookbookVersion < ApplicationRecord
 
   def cookbook_artifact_url
     if Paperclip::Attachment.default_options[:storage] == 's3'
-      ENV['S3_URLS_EXPIRE'].present? ? tarball.expiring_url(ENV['S3_URLS_EXPIRE']) : tarball.url
+      ENV['S3_URLS_EXPIRE'].present? ? tarball.expiring_url(ENV['S3_URLS_EXPIRE'].to_i) : tarball.url
     else
       "#{Supermarket::Host.full_url}#{tarball.url}"
     end

--- a/src/supermarket/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
+++ b/src/supermarket/spec/controllers/api/v1/cookbook_versions_controller_spec.rb
@@ -68,7 +68,7 @@ describe Api::V1::CookbookVersionsController do
     it '302s to the cookbook version file URL' do
       get :download, params: { cookbook: cookbook.name, version: version.to_param, format: :json }
 
-      expect(response).to redirect_to(version.tarball.url)
+      expect(response).to redirect_to(version.cookbook_artifact_url)
       expect(response.status.to_i).to eql(302)
     end
 

--- a/src/supermarket/spec/models/cookbook_version_spec.rb
+++ b/src/supermarket/spec/models/cookbook_version_spec.rb
@@ -177,7 +177,7 @@ describe CookbookVersion do
 
         it 'includes the expiration' do
           expect(version.tarball).to receive(:expiring_url)
-            .with(ENV['S3_URLS_EXPIRE'])
+            .with(ENV['S3_URLS_EXPIRE'].to_i)
 
           version.cookbook_artifact_url
         end


### PR DESCRIPTION
I'm attempting to set up a private supermarket that is backed with S3 and uses presigned urls for access when downloading cookbooks.

While doing this I found that setting the `S3_URLS_EXPIRE` environment variable causes the cookbook download to fail with a 500 error. The error in the log states: `ArgumentError (comparison of String with 604800 failed)`. After some digging I found that the issue is caused by the `S3_URLS_EXPIRE` environment variable is always a string, and gets passed down to the aws-sdk via paperclip and hits a comparison that ensures the given expiry time is less than one week (604800 seconds).

This PR fixes this by always converting the string to a number when asking for the expiry_url.

I haven't been able to set up a proper dev environment for this, so I'm unsure if the tests actually run.
