### PR TITLE
fix omnibus build, pin rubygems to 2.6.x

### DIFF
--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -31,6 +31,7 @@ build_iteration 1
 override :postgresql, version: '9.3.18'
 override :ruby, version: "2.4.2"
 override :'chef-gem', version: '12.19.36'
+override :rubygems, version: '2.6.14'
 
 # Creates required build directories
 dependency "preparation"


### PR DESCRIPTION
RubyGems 2.7.0-.3 seems to break the omnibus build with:

```
ERROR:  Error installing bundler:
"bundle" from bundler conflicts with /opt/supermarket/embedded/bin/bundle
```

Pinning to latest 2.6.x to fix the pipeline for release.

PEOPLE OF THE FUTURE, this pin should get revisited.