### PR TITLE
upgrade version of omnibus-embedded nginx

### DIFF
--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -32,6 +32,7 @@ override :postgresql, version: '9.3.18'
 override :ruby, version: "2.4.2"
 override :'chef-gem', version: '12.19.36'
 override :rubygems, version: '2.6.14'
+override :nginx, version: '1.10.2'
 
 # Creates required build directories
 dependency "preparation"


### PR DESCRIPTION
Addresses [CVE-2016-4450](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4450) (and possibly others to be determined)

Closes #1705