### PR TITLE
upgrade yard

### DIFF
--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -611,7 +611,7 @@ GEM
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yajl-ruby (1.3.1)
-    yard (0.9.9)
+    yard (0.9.12)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Only used to generate docs, but quiets vulnerability scanners because this upgrade addresses [CVE-2017-17042](https://nvd.nist.gov/vuln/detail/CVE-2017-17042)
