### PR TITLE
pin omnibus build's berkshelf version to latest stable

### DIFF
--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -33,6 +33,7 @@ override :ruby, version: "2.4.2"
 override :'chef-gem', version: '12.19.36'
 override :rubygems, version: '2.6.14'
 override :nginx, version: '1.10.2'
+override :berkshelf, version: 'v6.3.1'
 
 # Creates required build directories
 dependency "preparation"


### PR DESCRIPTION
There is a major version bump for berkshelf in progress on its master branch. The software definition for berkshelf rides master, so we're pinning to latest released version of berkshelf 6.