### PR TITLE
upgrade nokogiri & libxml2

### DIFF
--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -18,5 +18,12 @@ platforms:
 
 suites:
   - name: default
+    attributes:
+      omnibus:
+        build_user: vagrant
+        build_user_group: vagrant
+        build_user_home: /home/vagrant
+        build_dir: /home/vagrant/supermarket/omnibus
+        install_dir: /opt/supermarket
     run_list:
       - supermarket-builder

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 4f03b681b46e9d7300dd6764d8b68b1f6b8a16b8
+  revision: 4ef2d1a5b9162f4f5f52617d2a0122796b4f3c43
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -8,17 +8,17 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 9f281bfb7fb44aa5d152b38e73ce04805fdb8958
+  revision: 9a3a97bb0c6b437524fdea15b4cd15a65ff6ac29
   specs:
-    omnibus (5.6.4)
+    omnibus (5.6.10)
       aws-sdk (~> 2)
       chef-sugar (~> 3.3)
       cleanroom (~> 1.0)
       ffi-yajl (~> 2.2)
-      license_scout
+      license_scout (~> 1.0)
       mixlib-shellout (~> 2.0)
       mixlib-versioning
-      ohai (~> 8.0)
+      ohai (>= 8.6.0.alpha.1, < 15)
       pedump
       ruby-progressbar (~> 1.7)
       thor (~> 0.18)
@@ -29,13 +29,13 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
-    aws-sdk (2.10.125)
-      aws-sdk-resources (= 2.10.125)
-    aws-sdk-core (2.10.125)
+    aws-sdk (2.11.0)
+      aws-sdk-resources (= 2.11.0)
+    aws-sdk-core (2.11.0)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.125)
-      aws-sdk-core (= 2.10.125)
+    aws-sdk-resources (2.11.0)
+      aws-sdk-core (= 2.11.0)
     aws-sigv4 (1.0.2)
     berkshelf (6.3.1)
       buff-config (~> 2.0)
@@ -108,13 +108,14 @@ GEM
       mixlib-log (~> 1.3)
       rack (~> 2.0)
       uuidtools (~> 2.1)
+    citrus (3.0.2)
     cleanroom (1.0.0)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     erubis (2.7.0)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
+    ffi (1.9.21)
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
@@ -134,9 +135,10 @@ GEM
     kitchen-vagrant (1.3.0)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (0.1.3)
+    license_scout (1.0.0)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
+      toml-rb (~> 1.0)
     little-plugger (1.1.4)
     logging (2.2.2)
       little-plugger (~> 1.1)
@@ -146,7 +148,7 @@ GEM
       mixlib-log
     mixlib-authentication (1.4.2)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.4)
+    mixlib-config (2.2.5)
     mixlib-install (3.9.0)
       mixlib-shellout
       mixlib-versioning
@@ -193,7 +195,7 @@ GEM
     plist (3.4.0)
     progressbar (1.9.0)
     proxifier (1.0.3)
-    public_suffix (3.0.1)
+    public_suffix (3.0.2)
     rack (2.0.3)
     retryable (2.0.4)
     ridley (5.1.1)
@@ -269,6 +271,8 @@ GEM
     thor (0.19.1)
     timers (4.0.4)
       hitimes
+    toml-rb (1.1.1)
+      citrus (~> 3.0, > 3.0)
     uuidtools (2.1.5)
     varia_model (0.6.0)
       buff-extensions (~> 2.0)

--- a/omnibus/cookbooks/supermarket-builder/recipes/default.rb
+++ b/omnibus/cookbooks/supermarket-builder/recipes/default.rb
@@ -27,12 +27,6 @@ when 'rhel'
   include_recipe 'yum-epel::default'
 end
 
-# configure the omnibus build environment
-node.set['omnibus']['build_user'] = 'vagrant'
-node.set['omnibus']['build_user_home'] = '/home/vagrant'
-node.set['omnibus']['build_dir'] = '/home/vagrant/supermarket/omnibus'
-node.set['omnibus']['install_dir'] = '/opt/supermarket'
-
 include_recipe 'omnibus::default'
 
 execute 'fix bundler directory permissions' do
@@ -44,6 +38,7 @@ omnibus_build 'supermarket' do
   environment 'HOME' => node['omnibus']['build_user_home']
   project_dir node['omnibus']['build_dir']
   log_level :internal
+  live_stream true
   config_overrides(
     append_timestamp: true
   )

--- a/src/fieri/Gemfile.lock
+++ b/src/fieri/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     mixlib-log (1.7.1)
     multipart-post (2.0.0)
     nio4r (2.1.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -337,7 +337,7 @@ GEM
     net-telnet (0.1.1)
     newrelic_rpm (4.1.0.333)
     nio4r (2.0.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)


### PR DESCRIPTION
Upgraded the gem references for nokogiri and upgraded omnibus/-software for an updated libxml2 "system library." Addresses CVE-2017-15412

Also, remove `node.set` (deprecated) from dev build cookbook. `node.set` is deprecated. Use `node.default`/`node.override` ...  OR just set them in the kitchen config!