### PR TITLE
update rack-protection (addresses underlying CVE audit that does not apply to Supermarket installs)

### DIFF
--- a/src/fieri/Gemfile.lock
+++ b/src/fieri/Gemfile.lock
@@ -128,8 +128,8 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (2.0.5)
-    rack (2.0.3)
-    rack-protection (2.0.0)
+    rack (2.0.4)
+    rack-protection (2.0.1)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -412,8 +412,8 @@ GEM
     public_suffix (2.0.5)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
-    rack (2.0.3)
-    rack-protection (2.0.0)
+    rack (2.0.4)
+    rack-protection (2.0.1)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)


### PR DESCRIPTION
Addresses [CVE-2018-7212 reported in rack-protection](https://github.com/sinatra/sinatra/pull/1379). CVE does not affect Supermarket because the vulnerability is only on Windows platforms.