### PR TITLE
🚧WIP 🚧a new route for a simple "recent releases" feed

### DIFF
--- a/src/supermarket/.rubocop.yml
+++ b/src/supermarket/.rubocop.yml
@@ -39,6 +39,7 @@ Metrics/BlockLength:
   Exclude:
     - Guardfile
     - Vagrantfile
+    - config/routes.rb
     - lib/tasks/**/*
     - spec/**/*
 Metrics/PerceivedComplexity:

--- a/src/supermarket/app/controllers/cookbook_versions_controller.rb
+++ b/src/supermarket/app/controllers/cookbook_versions_controller.rb
@@ -1,5 +1,16 @@
 class CookbookVersionsController < ApplicationController
-  before_action :set_cookbook_and_version
+  before_action :set_cookbook_and_version, except: :index
+
+  #
+  # GET /cookbooks/versions
+  #
+  # Returns a collection of cookbook versions (releases)
+  #
+  def index
+    @cookbook_versions = CookbookVersion.includes(:cookbook, :user)
+                                        .limit(10)
+                                        .order('id desc')
+  end
 
   #
   # GET /cookbooks/:cookbook_id/versions/:version/download

--- a/src/supermarket/app/controllers/cookbook_versions_controller.rb
+++ b/src/supermarket/app/controllers/cookbook_versions_controller.rb
@@ -7,9 +7,21 @@ class CookbookVersionsController < ApplicationController
   # Returns a collection of cookbook versions (releases)
   #
   def index
+    index_params = params.permit(:page, :owned_by)
+    @page = index_params[:page].to_i
+
     @cookbook_versions = CookbookVersion.includes(:cookbook, :user)
-                                        .limit(10)
                                         .order('id desc')
+                                        .page(@page)
+                                        .per(20)
+
+    if index_params[:owned_by].present?
+      @cookbook_versions.owned_by(index_params[:owned_by])
+    end
+
+    respond_to do |format|
+      format.atom { render layout: false }
+    end
   end
 
   #

--- a/src/supermarket/app/models/cookbook_version.rb
+++ b/src/supermarket/app/models/cookbook_version.rb
@@ -11,7 +11,8 @@ class CookbookVersion < ApplicationRecord
   has_many :metric_results, -> { includes :quality_metric }, inverse_of: :cookbook_version
 
   belongs_to :cookbook
-  belongs_to :user
+  belongs_to :user, -> { includes :chef_account }, inverse_of: :cookbook_versions
+  has_one :owner, -> { includes :chef_account }, through: :cookbook
 
   # Attachments
   # --------------------

--- a/src/supermarket/app/views/cookbook_versions/index.atom.builder
+++ b/src/supermarket/app/views/cookbook_versions/index.atom.builder
@@ -1,0 +1,21 @@
+atom_feed language: 'en-US' do |feed|
+  feed.title 'Cookbook Releases'
+  feed.updated safe_updated_at(@cookbook_versions)
+
+  @cookbook_versions.each do |release|
+    feed.entry release,
+               url: cookbook_version_url(release.cookbook, release.version),
+               published: release.created_at do |entry|
+      entry.title "#{release.name} #{release.version}"
+      entry.content <<~CONTENT, type: 'html'
+        #{release.owner.name}: #{release.name} #{release.version} released by #{release.published_by.name}
+        #{cookbook_atom_content(release)}
+      CONTENT
+
+      entry.author do |author|
+        author.name "#{release.published_by.name} (#{release.published_by.username})"
+        author.uri user_url(release.published_by)
+      end
+    end
+  end
+end

--- a/src/supermarket/app/views/cookbook_versions/index.atom.builder
+++ b/src/supermarket/app/views/cookbook_versions/index.atom.builder
@@ -1,6 +1,7 @@
 atom_feed language: 'en-US' do |feed|
   feed.title 'Cookbook Releases'
   feed.updated safe_updated_at(@cookbook_versions)
+  feed.link rel_next_prev_link_tags @cookbook_versions
 
   @cookbook_versions.each do |release|
     feed.entry release,

--- a/src/supermarket/config/routes.rb
+++ b/src/supermarket/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
   put 'cookbooks/:id/transfer_ownership' => 'transfer_ownership#transfer', as: :transfer_ownership
   get 'ownership_transfer/:token/accept' => 'transfer_ownership#accept', as: :accept_transfer
   get 'ownership_transfer/:token/decline' => 'transfer_ownership#decline', as: :decline_transfer
+  get 'cookbooks/versions' => 'cookbook_versions#index', as: :cookbook_releases
 
   resources :cookbooks, only: [:index, :show, :update] do
     member do

--- a/src/supermarket/config/routes.rb
+++ b/src/supermarket/config/routes.rb
@@ -57,7 +57,7 @@ Rails.application.routes.draw do
   put 'cookbooks/:id/transfer_ownership' => 'transfer_ownership#transfer', as: :transfer_ownership
   get 'ownership_transfer/:token/accept' => 'transfer_ownership#accept', as: :accept_transfer
   get 'ownership_transfer/:token/decline' => 'transfer_ownership#decline', as: :decline_transfer
-  get 'cookbooks/versions' => 'cookbook_versions#index', as: :cookbook_releases
+  get 'cookbooks/versions' => 'cookbook_versions#index', as: :cookbook_releases, defaults: { format: :atom }
 
   resources :cookbooks, only: [:index, :show, :update] do
     member do

--- a/src/supermarket/spec/controllers/cookbook_versions_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbook_versions_controller_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe CookbookVersionsController do
+  describe '#index' do
+    let(:cookbook) { create(:cookbook) }
+    let(:version) { create(:cookbook_version, cookbook: cookbook) }
+
+    it 'responds to a GET' do
+      get :index
+      expect(assigns[:cookbook_versions]).to_not be_nil
+    end
+  end
+
   describe '#download' do
     let(:cookbook) { create(:cookbook) }
     let(:version) { create(:cookbook_version, cookbook: cookbook) }


### PR DESCRIPTION
This is very WIP. DO NOT MERGE

Intended to address #1684, this will add a new URL endpoint for a simple, reverse chronological atom feed of cookbook _releases_. The current feed available (described in #1684) is based on a `cookbooks/` endpoint that is scoped to the parent cookbook record and not individual released versions. It's that parent scoping that led to published dates tracking the first time a cookbook was released as opposed to when a particular version is released.

# Use Cases

To address a few different use cases for wanting notifications for new cookbook releases: 

## Curated: "I only care about these N cookbooks" ✅ 

This exists already. A user can see a feed of releases of cookbooks they follow. Anyone can subscribe to any user's feed, so this could be the means by which a single account could be used to curate a collection of cookbooks for consumption by many interested parties.

`<super-url>/users/<a_user>/followed_cookbook_activity.atom` 

## Branded: "I only care about cookbooks owned by X" 🆕

**New!** This would be a feed of releases owned by `username` regardless of the collaborator who published the release. This will be useful for release announcements for cookbooks owned by prolific users or organizations (e.g. Sous Chefs). 

`<super-url>/cookbooks/versions.atom?owned_by=<username>`

## Fire Hose: "All the releases, please!" 🆕 

**New!** This would be a feed of _all_ cookbook releases in a Supermarket instance. Probably more useful in private Supermarkets.

`<super-url>/cookbooks/versions.atom`

# Proposed Implementation

A new URL endpoint: `https://supermarket.example.com/cookbooks/versions.atom`

Endpoint would take an optional `owned_by` parameter which must be the username of a user in the Supermarket.

Endpoint responds to `.atom` with a feed:

```
Title: "Cookbook Releases"
Updated: (datetime of the latest updated_at among the cookbook versions)
```

 And has entries that look similar to the followed cookbook activity feed, something like:

```
Title: awesome_sauce 1.2.3
Author: Hot Sauce Fan (ilovehotsauce)
Link: http://localhost:3000/cookbooks/awesome_sauce/versions/1.2.3
Date: (this cookbook version's created_at datetime)

Sauce Chefs: awesome_sauce 1.2.3 released by Hot Sauce Fan

Installs/Configures awesome_sauce

(content from the CHANGELOG if present)
```

# TODO

- [ ] settle on a sensible URL path
    - `/cookbooks/versions`? - given that a feed of cookbook releases maps to a collection of `CookbookVersions`, this would follow the Rail convention for such a collection
    - `/recent_releases`? - maybe a more user friendly feed path, doesn't follow convention
- [ ] testing!
- [ ] support parameters to get a filtered feed; if so, what filters?
    - [ ] filter by owner
    - [ ] pagination