### PR TITLE
Upgrade Sprockets [CVE-2018-3760]

### DIFF
--- a/src/fieri/Gemfile.lock
+++ b/src/fieri/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (2.0.5)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-protection (2.0.1)
       rack
     rack-test (0.6.3)
@@ -198,7 +198,7 @@ GEM
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
     slop (3.6.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -412,7 +412,7 @@ GEM
     public_suffix (2.0.5)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-protection (2.0.1)
       rack
     rack-test (0.6.3)
@@ -555,7 +555,7 @@ GEM
       activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)


### PR DESCRIPTION
Upgrade the Sprockets gem to patch for
[CVE-2018-3760](https://nvd.nist.gov/vuln/detail/CVE-2018-3760)

The actual sprockets CVE doesn't affect Supermarket because it does
not do asset compilation during the request/response cycle. However,
this will upgrade the gem to clear a bundle-audit failure.

Fixes #1742