### PR TITLE
update nokogiri to quiet gem audit finding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,13 @@ matrix:
         - gem install bundler --no-ri --no-rdoc
         - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle config build.nokogiri --use-system-libraries
       before_script:
-        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake $COMPONENT:travis:before_script
+        - psql -c 'create database supermarket_test;' -U postgres
+        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake db:schema:load
       script:
-        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake $COMPONENT:travis:script
+        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT
+        - bundle exec rake spec
+        - bundle exec rubocop
+        - bundle exec bundle-audit check --update
 
     # Fieri Spec
     - env:
@@ -71,10 +75,11 @@ matrix:
       before_install:
         - gem install bundler --no-ri --no-rdoc
         - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle config build.nokogiri --use-system-libraries
-      before_script:
-        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake $COMPONENT:travis:before_script
       script:
-        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT && bundle exec rake $COMPONENT:travis:script
+        - cd $TRAVIS_BUILD_DIR/src/$COMPONENT
+        - bundle exec rake spec
+        - bundle exec rubocop
+        - bundle exec bundle-audit check --update
 
     # Terraform Lint
     - env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
     - "$TRAVIS_BUILD_DIR/src/$COMPONENT/vendor/bundle"
 
 before_install:
-  - curl https://raw.githubusercontent.com/chef/ci-studio-common/master/install.sh | bash
+  - curl https://raw.githubusercontent.com/chef/ci-studio-common/pre-1.0/install.sh | bash
   - export PATH="$PATH:$HOME/ci-studio-common/bin:$HOME/tools/bin"
 
 env:

--- a/src/fieri/Gemfile.lock
+++ b/src/fieri/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     mixlib-log (1.7.1)
     multipart-post (2.0.0)
     nio4r (2.1.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -337,7 +337,7 @@ GEM
     net-telnet (0.1.1)
     newrelic_rpm (4.1.0.333)
     nio4r (2.0.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)


### PR DESCRIPTION
The CVE alert bundle-audit produces does not really apply to Supermarket because the package built by omnibus uses libxml libraries directly, not the libxml2 libraries bundled with the nokogiri gem. But this change will quiet the gem audit.
