### PR TITLE
add support for S3 storage using IAM roles (IAM user and a key no longer required)

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -445,23 +445,34 @@ default['supermarket']['robots_disallow'] = nil
 # If these are not set, uploaded cookbooks will be stored on the local
 # filesystem (this means that running multiple application servers will require
 # some kind of shared storage, which is not provided.)
-#
-# If these are set, cookbooks will be uploaded to the to the given S3 bucket
-# using the provided credentials. A cdn_url can be used for an alias if the
-# given S3 bucket is behind a CDN like CloudFront.
-default['supermarket']['s3_access_key_id'] = nil
+
+# #### Required S3
+
+# If these are set, cookbooks will be uploaded to the to the given S3 bucket.
+# The default is to rely on an IAM role with access to the bucket be attached to
+# the compute resources running Supermarket.
 default['supermarket']['s3_bucket'] = nil
-default['supermarket']['s3_secret_access_key'] = nil
+default['supermarket']['s3_region'] = nil
+
+# #### Optional S3
+
+# A cdn_url can be used for an alias if the S3 bucket is behind a CDN like CloudFront.
 default['supermarket']['cdn_url'] = nil
 
-# ### Additional S3 Settings
-# By default, Supermarket will use domain style S3 urls that look like this
-# bucketname.s3.amazonaws.com
-# This style of url will work across all regions
+# If using IAM user credentials for bucket access, set these.
+default['supermarket']['s3_access_key_id'] = nil
+default['supermarket']['s3_secret_access_key'] = nil
+
+# By default, Supermarket will use domain style S3 urls that look like this:
+#
+#   bucketname.s3.amazonaws.com
+#
+# This style of url will work across all regions.
+#
 # If this is set as ':s3_path_url', the S3 urls will look like this
 # s3.amazonaws.com/bucketname.
 # This will only work if the S3 bucket is in N. Virginia.
-# If your S3 bucket name as had "." in it - i.e. "my.bucket.name",
+# If your S3 bucket name contains any periods "." - i.e. "my.bucket.name",
 # you must use the path style url and your S3 bucket must be in N. Virginia
 default['supermarket']['s3_domain_style'] = ':s3_domain_url'
 

--- a/omnibus/cookbooks/omnibus-supermarket/libraries/config.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/libraries/config.rb
@@ -64,12 +64,20 @@ class Supermarket
     end
 
     def self.audit_s3_config(config)
-      required_s3_vars = %w(s3_bucket s3_access_key_id s3_secret_access_key s3_region).freeze
-      any_s3_settings = required_s3_vars.any? { |key| !(config[key].nil? || config[key].empty?) }
-      all_s3_settings = required_s3_vars.all? { |key| !(config[key].nil? || config[key].empty?) }
+      required_s3_vars = %w(s3_bucket s3_region).freeze
+      any_required_s3_vars = required_s3_vars.any? { |key| !config[key].nil? }
+      all_required_s3_vars = required_s3_vars.all? { |key| !(config[key].nil? || config[key].empty?) }
 
-      if any_s3_settings && !all_s3_settings
-        raise IncompleteConfig, "Got some, but not all, of the required S3 configs. Must provide none or all of #{required_s3_vars} to configure cookbook storage in an S3 bucket."
+      if any_required_s3_vars && !all_required_s3_vars
+        raise IncompleteConfig, "Got some, but not all, of the required S3 configs. Must provide #{required_s3_vars} to configure cookbook storage in an S3 bucket."
+      end
+
+      static_s3_creds = %w(s3_access_key_id s3_secret_access_key).freeze
+      any_static_s3_creds = static_s3_creds.any? { |key| !config[key].nil? }
+      all_static_s3_creds = static_s3_creds.all? { |key| !(config[key].nil? || config[key].empty?) }
+
+      if any_static_s3_creds && !all_static_s3_creds
+        raise IncompleteConfig, "Got some, but not all, of AWS user credentials. To access an S3 bucket with IAM user credentials, provide #{static_s3_creds}. To use an IAM role, do not set these."
       end
 
       if config['s3_bucket'] =~ /\./ &&

--- a/src/supermarket/app/lib/supermarket/s3_config_audit.rb
+++ b/src/supermarket/app/lib/supermarket/s3_config_audit.rb
@@ -2,16 +2,29 @@ module Supermarket
   module S3ConfigAudit
     class IncompleteConfig < StandardError; end
 
-    REQUIRED_S3_VARS = %w[S3_BUCKET S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY S3_REGION].freeze
+    REQUIRED_S3_VARS = %w[S3_BUCKET S3_REGION].freeze
+    REQUIRED_S3_STATIC_CREDS_VARS = %w[S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY].freeze
 
     def self.use_s3?(environment)
-      any_s3_settings = REQUIRED_S3_VARS.any? { |key| environment[key].present? }
+      any_s3_settings = REQUIRED_S3_VARS.any? { |key| environment.key?(key) }
       all_s3_settings = REQUIRED_S3_VARS.all? { |key| environment[key].present? }
 
       if any_s3_settings && !all_s3_settings
-        raise IncompleteConfig.new "Got some, but not all, of the required S3 configs. Must provide none or all of #{REQUIRED_S3_VARS} to configure cookbook storage in an S3 bucket."
+        raise IncompleteConfig.new "Got some, but not all, of the required S3 configs. Must provide #{REQUIRED_S3_VARS} to configure cookbook storage in an S3 bucket."
       end
       return true if all_s3_settings
+      false
+    end
+
+    def self.use_s3_with_static_creds?(environment)
+      any_s3_creds = REQUIRED_S3_STATIC_CREDS_VARS.any? { |key| environment.key?(key) }
+      all_s3_creds = REQUIRED_S3_STATIC_CREDS_VARS.all? { |key| environment[key].present? }
+
+      # Handle situation when one of S3_ACCESS_KEY_ID or S3_SECRET_ACCESS_KEY is missing while other one is present
+      if any_s3_creds && !all_s3_creds
+        raise IncompleteConfig.new "Got some, but not all, of AWS user credentials. To access an S3 bucket with IAM user credentials, provide #{REQUIRED_S3_STATIC_CREDS_VARS}. To use an IAM role, do not set these."
+      end
+      return true if all_s3_creds
       false
     end
   end

--- a/src/supermarket/config/initializers/paperclip.rb
+++ b/src/supermarket/config/initializers/paperclip.rb
@@ -20,15 +20,23 @@ Paperclip.io_adapters
     options = {
       storage: 's3',
       s3_credentials: {
-        bucket: ENV['S3_BUCKET'],
-        access_key_id: ENV['S3_ACCESS_KEY_ID'],
-        secret_access_key: ENV['S3_SECRET_ACCESS_KEY']
+        bucket: ENV['S3_BUCKET']
       },
       path: path,
       bucket: ENV['S3_BUCKET'],
       s3_protocol: ENV['PROTOCOL'],
       s3_region: ENV['S3_REGION']
     }
+
+    # If static creds are present in config - use them
+    if Supermarket::S3ConfigAudit.use_s3_with_static_creds?(ENV)
+      options = options.merge(
+        s3_credentials: {
+          access_key_id: ENV['S3_ACCESS_KEY_ID'],
+          secret_access_key: ENV['S3_SECRET_ACCESS_KEY']
+        }
+      )
+    end
 
     if ENV['S3_PRIVATE_OBJECTS'] == 'true'
       options = options.merge(

--- a/src/supermarket/spec/lib/supermarket/s3_config_audit_spec.rb
+++ b/src/supermarket/spec/lib/supermarket/s3_config_audit_spec.rb
@@ -5,8 +5,6 @@ describe Supermarket::S3ConfigAudit do
     it 'is true if required S3 configs are given in environment' do
       mock_env = {
         'S3_BUCKET' => 'bettergetabucket',
-        'S3_ACCESS_KEY_ID' => 'thisismyidtherearemanylikeitbutthisoneismine',
-        'S3_SECRET_ACCESS_KEY' => 'superdupersecret',
         'S3_REGION' => 'over-yonder-1'
       }
       expect(Supermarket::S3ConfigAudit.use_s3?(mock_env)).to be true
@@ -19,11 +17,47 @@ describe Supermarket::S3ConfigAudit do
 
     it 'throws an exception if some but not all of the required S3 configs are present' do
       mock_env = {
-        'S3_BUCKET' => 'bettergetabucket',
+        'S3_BUCKET' => 'bettergetabucket'
+      }
+      expect { Supermarket::S3ConfigAudit.use_s3?(mock_env) }.to raise_exception Supermarket::S3ConfigAudit::IncompleteConfig
+    end
+
+    it 'throws an exception if any of the required S3 configs are blank' do
+      mock_env = {
+        'S3_BUCKET' => '',
+        'S3_REGION' => ''
+      }
+      expect { Supermarket::S3ConfigAudit.use_s3?(mock_env) }.to raise_exception Supermarket::S3ConfigAudit::IncompleteConfig
+    end
+  end
+
+  context '#use_s3_with_static_creds?' do
+    it 'is true if both S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY are present' do
+      mock_env = {
         'S3_ACCESS_KEY_ID' => 'thisismyidtherearemanylikeitbutthisoneismine',
         'S3_SECRET_ACCESS_KEY' => 'superdupersecret'
       }
-      expect { Supermarket::S3ConfigAudit.use_s3?(mock_env) }.to raise_exception Supermarket::S3ConfigAudit::IncompleteConfig
+      expect(Supermarket::S3ConfigAudit.use_s3_with_static_creds?(mock_env)).to be true
+    end
+
+    it 'is false if S3_ACCESS_KEY_ID and S3_SECRET_ACCESS_KEY are absent' do
+      mock_env = {}
+      expect(Supermarket::S3ConfigAudit.use_s3_with_static_creds?(mock_env)).to be false
+    end
+
+    it 'throws an exception if only S3_ACCESS_KEY_ID or only S3_SECRET_ACCESS_KEY is present' do
+      mock_env = {
+        'S3_ACCESS_KEY_ID' => 'thisismyidtherearemanylikeitbutthisoneismine'
+      }
+      expect { Supermarket::S3ConfigAudit.use_s3_with_static_creds?(mock_env) }.to raise_exception Supermarket::S3ConfigAudit::IncompleteConfig
+    end
+
+    it 'throws an exception if S3_ACCESS_KEY_ID or S3_SECRET_ACCESS_KEY is an empty string' do
+      mock_env = {
+        'S3_ACCESS_KEY_ID' => '',
+        'S3_SECRET_ACCESS_KEY' => ''
+      }
+      expect { Supermarket::S3ConfigAudit.use_s3_with_static_creds?(mock_env) }.to raise_exception Supermarket::S3ConfigAudit::IncompleteConfig
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: pavel-kazhavets <pavel.kozhevets@gmail.com>

Currently using supermarket with S3 cookbook storage requires having static IAM credentials in config file, which is not secure and requires manual key rotation.

Paperclip supports credentials from metadata endpoint (IAM instance profile), but supermarket won't start if `s3_access_key_id` and `s3_secret_access_key` are not present in the config.

This PR should fix https://github.com/chef/supermarket/issues/1724