### PR TITLE
Remove deprecated maintainer_group config in expeditor

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -17,8 +17,6 @@ github:
   # The file where our CHANGELOG is kept. This file is updated automatically with
   # details from the Pull Request via the `built_in:update_changelog` merge_action.
   changelog_file: "CHANGELOG.md"
-  # The Github Team primarily responsible for handling incoming Pull Requests.
-  maintainer_group: chef/supermarket
 
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:


### PR DESCRIPTION
This isn't doing anything at this point.

Signed-off-by: Tim Smith <tsmith@chef.io>