### PR TITLE
update gems, update celluloid to latest ref

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
         - cd $TRAVIS_BUILD_DIR/src/$NAME
         - bundle exec rake spec
         - bundle exec rubocop
-        - bundle exec bundle-audit check --update
+        - bundle exec bundle-audit check --update --ignore CVE-2018-1000544
 
     # Fieri Spec
     - env:

--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -14,8 +14,7 @@ gem 'omniauth-oauth2', '~> 1.3.1'
 gem 'sidekiq', '~> 4.2'
 # Required until to build from master until Celluloid 0.17.4 or 0.18.0 is released
 # https://github.com/celluloid/celluloid/issues/728
-gem 'celluloid', git: 'https://github.com/celluloid/celluloid', submodules: true, require: false,
-                 ref: '0d192022ffff8e46722771b4865bfce4114b00a3'
+gem 'celluloid', git: 'https://github.com/celluloid/celluloid', require: false, ref: '471b7d8'
 gem 'sidetiq'
 
 gem 'aws-sdk'

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -1,16 +1,10 @@
 GIT
   remote: https://github.com/celluloid/celluloid
-  revision: 0d192022ffff8e46722771b4865bfce4114b00a3
-  ref: 0d192022ffff8e46722771b4865bfce4114b00a3
-  submodules: true
+  revision: 471b7d862878721091238f7649b9bfc39689b9a4
+  ref: 471b7d8
   specs:
-    celluloid (0.17.4)
-      celluloid-essentials
-      celluloid-extras
-      celluloid-fsm
-      celluloid-pool
-      celluloid-supervision
-      timers (>= 4.1.1)
+    celluloid (0.18.0.pre)
+      timers (~> 4)
 
 GIT
   remote: https://github.com/rubysec/bundler-audit.git
@@ -105,16 +99,6 @@ GEM
     capybara-screenshot (1.0.14)
       capybara (>= 1.0, < 3)
       launchy
-    celluloid-essentials (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-extras (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-fsm (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-pool (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-supervision (0.20.6)
-      timers (>= 4.1.1)
     chef (13.0.118)
       addressable
       bundler (>= 1.10)
@@ -252,7 +236,7 @@ GEM
     hashdiff (0.3.4)
     hashie (3.5.5)
     highline (1.7.8)
-    hitimes (1.2.5)
+    hitimes (1.3.0)
     html_truncator (0.4.1)
       nokogiri (~> 1.5)
     htmlentities (4.3.4)
@@ -690,4 +674,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.2
+   1.16.4

--- a/src/supermarket/lib/tasks/spec/all.rake
+++ b/src/supermarket/lib/tasks/spec/all.rake
@@ -4,7 +4,7 @@ namespace :spec do
   end
 
   task :bundle_audit do
-    fail unless system 'bundle exec bundle-audit check --update'
+    fail unless system 'bundle exec bundle-audit check --update --ignore CVE-2018-1000544'
   end
 
   desc 'Run RSpec tests and rubocop'


### PR DESCRIPTION
- workaround for celluloid #1754 
- ignore CVE-2018-1000544 (rubyzip directory traversal) because has [no upstream fix yet ](https://github.com/rubyzip/rubyzip/issues/369) (it's required by `license_finder` gem)
