### PR TITLE
use a supported Ubuntu release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
       addons:
         apt:
           sources:
-            - chef-stable-precise
+            - chef-stable-trusty
           packages:
             - chefdk
       cache:
@@ -113,7 +113,7 @@ matrix:
       addons:
         apt:
           sources:
-            - chef-stable-precise
+            - chef-stable-trusty
           packages:
             - chefdk
       cache:


### PR DESCRIPTION
The precise APT repo is no longer. Trusty is the release used by the workers at the moment, so let's use that.

Attempting to resolve:
```
Adding APT Sources (BETA)
Disallowing sources: chef-stable-precise
To add unlisted APT sources, follow instructions in https://docs.travis-ci.com/user/installing-dependencies#Installing-Packages-with-the-APT-Addon
```