### PR TITLE
habitat skeleton to get started

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *_override.tf
 # License Scout
 license-cache
+results/

--- a/habitat/README.md
+++ b/habitat/README.md
@@ -1,0 +1,9 @@
+# Habitat package: supermarket
+
+## Description
+
+Provide a brief description of the `supermarket` plan / purpose.
+
+## Usage
+
+Describe the general usage for the `supermarket` plan

--- a/habitat/default.toml
+++ b/habitat/default.toml
@@ -1,0 +1,3 @@
+# Use this file to templatize your application's native configuration files.
+# See the docs at https://www.habitat.sh/docs/create-packages-configure/.
+# You can safely delete this file if you don't need it.

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,0 +1,6 @@
+pkg_name=supermarket
+pkg_origin=chefops
+pkg_version="0.1.0"
+pkg_maintainer="Chef Operations <ops@chef.io>"
+pkg_license=("Apache-2.0")
+pkg_source="http://some_source_url/releases/${pkg_name}-${pkg_version}.tar.gz"


### PR DESCRIPTION
We've started work on packaging the Supermarket application with
Habitat. This is an initial skeleton via `hab plan init` so we can
point to a plan on Habitat Builder. This won't do anything yet, and
the package will be private for a time.