### PR TITLE
change "knife cookbook site" references to "knife supermarket"

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/templates/default/rails.nginx.conf.erb
+++ b/omnibus/cookbooks/omnibus-supermarket/templates/default/rails.nginx.conf.erb
@@ -57,7 +57,7 @@ server {
     set $redirect_to_canonical 0;
   }
 
-  # This stops redirects for knife cookbook site share, which uses net/http,
+  # This stops redirects for knife supermarket share, which uses net/http,
   # and thus 'Ruby' as the user agent.
   if ($http_user_agent ~ 'Ruby') {
     set $redirect_to_canonical 0;

--- a/src/supermarket/app/views/cookbooks/_installs.html.erb
+++ b/src/supermarket/app/views/cookbooks/_installs.html.erb
@@ -38,8 +38,8 @@
       </div>
 
       <div class="content <%= current_user.install_preference == 'knife' ? 'active' : '' %>" id="knife">
-        <pre class="install">knife cookbook site install <%= cookbook.name %></pre>
-        <pre class="install">knife cookbook site download <%= cookbook.name %></pre>
+        <pre class="install">knife supermarket install <%= cookbook.name %></pre>
+        <pre class="install">knife supermarket download <%= cookbook.name %></pre>
       </div>
     <% else %>
       <div class="content active" id="berkshelf">
@@ -51,8 +51,8 @@
       </div>
 
       <div class="content" id="knife">
-        <pre class="install">knife cookbook site install <%= cookbook.name %></pre>
-        <pre class="install">knife cookbook site download <%= cookbook.name %></pre>
+        <pre class="install">knife supermarket install <%= cookbook.name %></pre>
+        <pre class="install">knife supermarket download <%= cookbook.name %></pre>
       </div>
     <% end %>
   </div>

--- a/src/supermarket/app/views/cookbooks/directory.html.erb
+++ b/src/supermarket/app/views/cookbooks/directory.html.erb
@@ -65,7 +65,7 @@
 
       <h3>How do I share a cookbook?</h3>
       <p>In order to share and interact with cookbooks on Supermarket, use the
-      <code>knife cookbook site</code> commands. <%= link_to 'The documentation', chef_docs_url('knife_cookbook_site.html') %> for <code>knife cookbook site</code> explains how to
+      <code>knife supermarket</code> commands. <%= link_to 'The documentation', chef_docs_url('knife_supermarket.html') %> for <code>knife supermarket</code> explains how to
       download, share, unshare, search, install and list cookbooks on Supermarket.
       You can also interact with the <%= link_to 'Supermarket API', chef_docs_url('supermarket_api.html') %> directly.</p>
 

--- a/src/supermarket/app/views/pages/dashboard.html.erb
+++ b/src/supermarket/app/views/pages/dashboard.html.erb
@@ -50,10 +50,10 @@
       <p><strong>Looking to upload your cookbooks?</strong></p>
       <ol>
         <li>Ensure you have a Chef repo configured with your private key</li>
-        <li>Share your cookbook with <code>knife cookbook site share COOKBOOK_NAME CATEGORY (options)</code></li>
+        <li>Share your cookbook with <code>knife supermarket share COOKBOOK_NAME CATEGORY (options)</code></li>
       </ol>
 
-      <p><%= link_to 'Read the full share docs.', chef_docs_url('knife_cookbook_site.html#share'), target: '_blank' %></p>
+      <p><%= link_to 'Read the full share docs.', chef_docs_url('knife_supermarket.html#share'), target: '_blank' %></p>
     <% end %>
 
     <h3>Cookbooks You Collaborate On</h3>

--- a/src/supermarket/app/views/pages/welcome.html.erb
+++ b/src/supermarket/app/views/pages/welcome.html.erb
@@ -51,7 +51,7 @@
       <h2>Share</h2>
       <ul>
         <li>
-          <%= link_to 'Share your cookbooks', chef_docs_url('knife_cookbook_site.html#share'), target: '_blank' %>
+          <%= link_to 'Share your cookbooks', chef_docs_url('knife_supermarket.html#share'), target: '_blank' %>
         </li>
         <li>
           <a href="http://community-slack.chef.io/">Join Chef Community Slack</a>


### PR DESCRIPTION
We're in the process of deprecating knife cookbook site in favor of knife supermarket which has been built into Chef for many years now.

Signed-off-by: Tim Smith <tsmith@chef.io>