### PR TITLE
update ffi gem to reduce CVE audit noise

### DIFF
--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -192,7 +192,7 @@ GEM
       i18n (~> 0.5)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
+    ffi (1.9.25)
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
     foodcritic (14.0.0)


### PR DESCRIPTION
Appease CVE check that finds [CVE-2018-1000201](https://nvd.nist.gov/vuln/detail/CVE-2018-1000201):

> ruby-ffi version 1.9.23 and earlier has a DLL loading issue which can
> be hijacked on Windows OS

Supermarket does not run on Windows, so it is not affected by this CVE. This change is to help reduce the noise of CVE audits.