### PR TITLE
omit web server version from response headers

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/templates/default/nginx.conf.erb
+++ b/omnibus/cookbooks/omnibus-supermarket/templates/default/nginx.conf.erb
@@ -35,9 +35,8 @@ http {
   <% unless @nginx['disable_access_log'] -%>
   access_log	<%= @nginx['log_dir'] %>/access.log supermarket;
   <% end %>
-  <% if @nginx['server_tokens'] -%>
-  server_tokens <%= @nginx['server_tokens'] %>;
-  <% end -%>
+  
+  server_tokens off;
 
   sendfile <%= @nginx['sendfile'] %>;
   tcp_nopush on;

--- a/omnibus/cookbooks/omnibus-supermarket/test/integration/default/inspec/controls/install-check.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/test/integration/default/inspec/controls/install-check.rb
@@ -66,10 +66,24 @@ control "proxy" do
     its('protocols') { should include 'tcp' }
   end
 
+  describe "http GET to Port #{property['supermarket']['nginx']['non_ssl_port']}" do
+    subject { http("http://localhost:#{property['supermarket']['nginx']['non_ssl_port']}") }
+    it "should not include server version number in response headers" do
+      expect(subject.headers.server).to cmp("nginx")
+    end
+  end
+
   if property['supermarket']['ssl']['enabled'] && property['supermarket']['nginx']['force_ssl']
     describe port(property['supermarket']['nginx']['ssl_port']) do
       it { should be_listening }
       its('protocols') { should include 'tcp' }
+    end
+
+    describe "http GET to Port #{property['supermarket']['nginx']['ssl_port']}" do
+      subject { http("http://localhost:#{property['supermarket']['nginx']['ssl_port']}", ssl_verify: false) }
+      it "should not include server version number in response headers" do
+        expect(subject.headers.server).to cmp("nginx")
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes MSYS-879

- By using 'server_tokens off' in the main nginx config file, version
  number of the server can be omitted by default for any server entries
  declared.
- Tests for version number omission were added to the internal cookbook

- [Similar changes were applied for chef-server](chef/chef-server#1514) by using
  'more_clear_headers', but that would require 'Nginx-More' module,
  hence we are using an nginx-only solution for the moment