### PR TITLE
update rubyzip

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       rspec-core (>= 2, < 4, != 2.12.0)
     ruby-progressbar (1.10.0)
     rubyntlm (0.6.2)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -488,7 +488,7 @@ GEM
     ruby-filemagic (0.7.2)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     rufus-lru (1.1.0)
     safe_yaml (1.0.4)
     sass (3.4.24)


### PR DESCRIPTION
Appease CVE check that finds [CVE-2017-5946](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5946):

> The Zip::File component in the rubyzip gem before 1.2.1 for Ruby has a directory traversal vulnerability. If a site allows uploading of .zip files, an attacker can upload a malicious file that uses "../" pathname substrings to write arbitrary files to the filesystem.

rubyzip is brought into Supermarket as a dependency of license_finder, which is only present in a development environment. This CVE does not apply to the public Supermarket or to onprem installs using the Supermarket omnibus package.