### PR TITLE
add FIPS 140-2 support

### DIFF
--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -34,6 +34,7 @@ override :rubygems, version: '2.6.14'
 override :nginx, version: '1.10.2'
 override :'chef-gem', version: '14.5.33'
 override :berkshelf, version: 'v6.3.1'
+override :'openssl-fips', version: '2.0.16'
 
 # Creates required build directories
 dependency "preparation"

--- a/omnibus/cookbooks/omnibus-supermarket/Berksfile
+++ b/omnibus/cookbooks/omnibus-supermarket/Berksfile
@@ -3,3 +3,4 @@ source 'https://supermarket.chef.io'
 metadata
 
 cookbook 'enterprise'
+cookbook 'fipsify'

--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -260,6 +260,7 @@ default['supermarket']['ssl']['email_address'] = 'you@example.com'
 # If your infrastructure still has requirements for the vulnerable/venerable SSLV3, you can add
 # "SSLv3" to the below line.
 default['supermarket']['ssl']['ciphers'] = 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA'
+default['supermarket']['ssl']['fips_ciphers'] = 'FIPS@STRENGTH:!aNULL:!eNULL'
 default['supermarket']['ssl']['protocols'] = 'TLSv1 TLSv1.1 TLSv1.2'
 default['supermarket']['ssl']['session_cache'] = 'shared:SSL:4m'
 default['supermarket']['ssl']['session_timeout'] = '5m'
@@ -338,6 +339,7 @@ default['supermarket']['redis_jobq_url'] = nil
 default['supermarket']['sentry_url'] = nil
 default['supermarket']['api_item_limit'] = 100
 default['supermarket']['rails_log_to_stdout'] = true
+default['supermarket']['fips_enabled'] = nil
 
 # Allow owners to remove their cookbooks, cookbook versions, or tools.
 # Added as a step towards implementing RFC072 Artifact Yanking

--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/test.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/test.rb
@@ -15,6 +15,7 @@ add_command 'test', 'Run the Supermarket installation test suite', 2 do
   command_text = '/opt/supermarket/embedded/bin/inspec exec'
   command_text += ' /opt/supermarket/embedded/cookbooks/omnibus-supermarket/test/integration/default/inspec'
   command_text += ' --color'
+  command_text += ' --no-distinct-exit' # skipped tests are OK
 
   if options[:junit_xml]
     command_text += " --reporter junit:#{options[:junit_xml]}"

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
@@ -35,6 +35,7 @@ Supermarket::Config.load_or_create_secrets!(
 )
 
 Supermarket::Config.audit_config(node['supermarket'])
+Supermarket::Config.maybe_turn_on_fips(node)
 
 # Copy things we need from the supermarket namespace to the top level. This is
 # necessary for some community cookbooks.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/rails.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/rails.rb
@@ -49,6 +49,7 @@ template 'rails.nginx.conf' do
   variables(nginx: node['supermarket']['nginx'],
             rails: node['supermarket']['rails'],
             fqdn: node['supermarket']['fqdn'],
+            fips_enabled: node['supermarket']['fips_enabled'],
             ssl: node['supermarket']['ssl'],
             app_directory: node['supermarket']['app_directory'])
 end

--- a/omnibus/cookbooks/omnibus-supermarket/spec/recipes/config_spec.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/spec/recipes/config_spec.rb
@@ -1,9 +1,8 @@
+require 'spec_helper'
+
 describe 'omnibus-supermarket::config' do
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04') do |node|
-      node.automatic['memory']['total'] = '16000MB'
-    end.converge(described_recipe)
-  end
+  platform 'ubuntu', '16.04'
+  automatic_attributes['memory']['total'] = '16000MB'
 
   it 'creates the supermarket user' do
     expect(chef_run).to create_user('supermarket')

--- a/omnibus/cookbooks/omnibus-supermarket/templates/rails.nginx.conf.erb
+++ b/omnibus/cookbooks/omnibus-supermarket/templates/rails.nginx.conf.erb
@@ -34,7 +34,7 @@ server {
   ssl_certificate_key <%= @ssl['certificate_key'] %>;
   ssl_dhparam <%= @ssl['ssl_dhparam'] %>;
   ssl_prefer_server_ciphers on;
-  ssl_ciphers <%= @ssl['ciphers'] %>;
+  ssl_ciphers <%= @fips_enabled ? @ssl['fips_ciphers'] : @ssl['ciphers'] %>;
   ssl_protocols <%= @ssl['protocols'] %>;
   ssl_session_cache <%= @ssl['session_cache'] %>;
   ssl_session_timeout <%= @ssl['session_timeout'] %>;

--- a/omnibus/cookbooks/omnibus-supermarket/templates/sv-nginx-run.erb
+++ b/omnibus/cookbooks/omnibus-supermarket/templates/sv-nginx-run.erb
@@ -1,5 +1,7 @@
 #!/bin/sh
 exec 2>&1
+<%= "export OPENSSL_FIPS=1" if node['supermarket']['fips_enabled'] == true %>
+
 exec <%= node['runit']['chpst_bin'] %> \
        -P \
      <%= node['supermarket']['install_directory'] %>/embedded/sbin/nginx \

--- a/omnibus/cookbooks/omnibus-supermarket/templates/sv-rails-run.erb
+++ b/omnibus/cookbooks/omnibus-supermarket/templates/sv-rails-run.erb
@@ -5,6 +5,7 @@ export PATH=<%= node['supermarket']['install_directory'] %>/embedded/bin:$PATH
 export LD_LIBRARY_PATH=<%= node['supermarket']['install_directory'] %>/embedded/lib
 export DIR=<%= node['supermarket']['app_directory'] %>
 export HOME=$DIR
+<%= "export OPENSSL_FIPS=1" if node['supermarket']['fips_enabled'] == true %>
 
 cd $DIR
 

--- a/omnibus/cookbooks/omnibus-supermarket/templates/sv-sidekiq-run.erb
+++ b/omnibus/cookbooks/omnibus-supermarket/templates/sv-sidekiq-run.erb
@@ -3,6 +3,7 @@ exec 2>&1
 
 export DIR=<%= node['supermarket']['app_directory'] %>
 export HOME=$DIR
+<%= "export OPENSSL_FIPS=1" if node['supermarket']['fips_enabled'] == true %>
 
 cd $DIR
 

--- a/omnibus/cookbooks/omnibus-supermarket/test/integration/default/inspec/controls/install-check.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/test/integration/default/inspec/controls/install-check.rb
@@ -34,6 +34,22 @@ control 'ssl-config' do
   end
 end
 
+control 'FIPS' do
+  title 'FIPS 140-2 enablement'
+
+  only_if { property['supermarket']['fips_enabled'] }
+
+  %w(nginx rails sidekiq).each do |service_name|
+    describe file("/opt/supermarket/service/#{service_name}/run") do
+      its(:content) { should match(/export OPENSSL_FIPS=1/) }
+    end
+  end
+
+  describe file('/var/opt/supermarket/nginx/etc/sites-enabled/rails') do
+    its(:content) { should match(/ssl_ciphers FIPS/) }
+  end
+end
+
 control 'log-management' do
   title 'Manage The Logs'
 

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -44,3 +44,7 @@ fetcher_read_timeout 120
 # ------------------------------
 # software_gems ['omnibus-software', 'my-company-software']
 # local_software_dirs ['/path/to/local/software']
+
+# Build in FIPS compatability mode
+# ------------------------------
+fips_mode (ENV['OMNIBUS_FIPS_MODE'] || '').downcase == "true"

--- a/src/supermarket/app/lib/supermarket/fips.rb
+++ b/src/supermarket/app/lib/supermarket/fips.rb
@@ -1,0 +1,30 @@
+require 'digest'
+require 'openssl'
+
+module Supermarket
+  class FIPS
+    # FIPS 140-2 Annex A references NIST Digital Signature Standard (DSS),
+    # FIPS Publication 186-4 to identify several algorithms as the
+    # Secure Hash Standard (SHS). Algorithms listed here are in the SHS
+    # and are used in various places in the Rails framework.
+    SECURE_HASHES = %w[SHA1 SHA256 SHA512].freeze
+
+    def self.enable!
+      OpenSSL.fips_mode = true
+      use_openssl_hash_algorithms!
+    end
+
+    def self.use_openssl_hash_algorithms!
+      # Most of Ruby's standard Digest algorithms will error when used
+      # in FIPS mode because their implementation is not in a
+      # FIPS-approved library.
+      # Reroute calls to Ruby Digest's hash algorithms to use the OpenSSL
+      # library's algorithms which are allowed when compiled with the
+      # OpenSSL FIPS Object Model adjunct.
+      SECURE_HASHES.each do |algorithm|
+        Digest.send(:remove_const, algorithm) if Digest.const_defined?(algorithm)
+        Digest.const_set(algorithm, OpenSSL::Digest(algorithm))
+      end
+    end
+  end
+end

--- a/src/supermarket/config/initializers/fipsify.rb
+++ b/src/supermarket/config/initializers/fipsify.rb
@@ -1,0 +1,4 @@
+if ENV['OPENSSL_FIPS'] == "1"
+  Supermarket::FIPS.enable!
+  Rails.logger.info "FIPS 140-2 mode is enabled."
+end


### PR DESCRIPTION
Three of the five services that comprise Supermarket are identified as appropriate for enabling FIPS mode on:

* front-facing reverse web proxy (nginx): in single-server standalone environments nginx is responsible for SSL termination
* web application service (rails): some crypto is performed by the web service for user authentication via hashing secrets
* background jobs (sidekiq): no crypto for secrets is performed in background jobs as of this writing, but the jobs share a code base and runtime configuration with the web service, so enabling it is no more difficult

# Changes

## Configuration options

+ new `['supermarket']['fips_enabled']` item added to the omnibus install to explicitly enable or disable FIPS mode; the default is set to nil which the omnibus install will treat as "determine FIPS mode based on whether FIPS is enabled in the kernel"
+ new `['supermarket']['ssl']['fips_ciphers']` added to provide overridable default ciphers when operating in FIPS mode

## Service Behavior

The service startup scripts for nginx, rails, and sidekiq are updated to `export OPENSSL_FIPS=1` per the OpenSSL documentation for enabling FIPS mode when `['supermarket']['fips_enabled']` is true--whether explicitly or when detected as enabled in the kernel.

An initializer has been added to the web application such that the rails and sidekiq services react to this environment variable by enabling `fips_mode` in the loaded Ruby OpenSSL library.

## Test

The `install-check` Inspec tests are updated with a FIPS section to test that an environment variable `OPENSSL_FIPS` has been set to `1` for the three services and that FIPS ciphers are set in the nginx SSL configuration.