### PR TITLE
update nokogiri to quiet CVE audit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
         - cd $TRAVIS_BUILD_DIR/src/$NAME
         - bundle exec rake spec
         - bundle exec rubocop
-        - bundle exec bundle-audit check --update --ignore CVE-2018-1000544
+        - bundle exec bundle-audit check --update
 
     # Fieri Spec
     - env:

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
     net-telnet (0.1.1)
     newrelic_rpm (4.1.0.333)
     nio4r (2.0.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -666,4 +666,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/src/supermarket/engines/fieri/Gemfile.lock
+++ b/src/supermarket/engines/fieri/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     mixlib-log (1.7.1)
     multipart-post (2.0.0)
     nio4r (2.1.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -234,4 +234,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.2
+   1.16.6


### PR DESCRIPTION
Also, turn the check for CVE-2018-1000544 back on now that rubyzip had an update we updated to already.
