### PR TITLE
update omnibus ctl test command for Inspec 3.0

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/test.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/test.rb
@@ -12,24 +12,19 @@ add_command 'test', 'Run the Supermarket installation test suite', 2 do
     end
   end.parse!
 
-  command_text = "/opt/supermarket/embedded/bin/inspec exec --color"
+  command_text = '/opt/supermarket/embedded/bin/inspec exec'
+  command_text += ' /opt/supermarket/embedded/cookbooks/omnibus-supermarket/test/integration/default/inspec'
+  command_text += ' --color'
 
   if options[:junit_xml]
-    command_text += " --format junit" \
+    command_text += " --reporter junit:#{options[:junit_xml]}"
   end
 
-  command_text += ' /opt/supermarket/embedded/cookbooks/omnibus-supermarket/test/integration/default/inspec' \
 
   shell_out = Mixlib::ShellOut.new(command_text)
   shell_out.run_command
   $stdout.puts shell_out.stdout
   $stderr.puts shell_out.stderr if options[:verbose]
-
-  if options[:junit_xml]
-    File.open(options[:junit_xml], 'w') do |junit_xml|
-      junit_xml.write shell_out.stdout
-    end
-  end
 
   exit shell_out.exitstatus
 end


### PR DESCRIPTION
`--format` was deprecated in 2.0 and removed in 3.0

Reorder the command built so that the switches come at the end. Use Inspec's reporter ability to write to an output file instead of doing the write ourselves in the ctl command.

```
vagrant@default-ubuntu-1604:~$ sudo supermarket-ctl test -J pedant.xml

vagrant@default-ubuntu-1604:~$ echo $?
0
vagrant@default-ubuntu-1604:~$ cat pedant.xml
<?xml version='1.0'?>
<testsuites>
  <testsuite name='omnibus-supermarket-test' tests='27' failed='0' failures='0'>
    <testcase name='Command: `supermarket-ctl console` stderr should match /supermarket-ctl console should be run as the supermarket OS user./' classname='omnibus-supermarket-test.supermarket-ctl-perms' target='local://' time='0.083338514'/>
    <testcase name='Command: `supermarket-ctl make-admin` stderr should match /supermarket-ctl make-admin should be run as the supermarket OS user./' classname='omnibus-supermarket-test.supermarket-ctl-perms' target='local://' time='0.087811592'/>
    <testcase name='Command: `sudo -u supermarket supermarket-ctl make-admin user=nope` stdout should match /nope was not found in Supermarket./' classname='omnibus-supermarket-test.supermarket-ctl-perms' target='local://' time='3.112217706'/>
    <testcase name='File /var/opt/supermarket/ssl/ca/dhparams.pem should be file' classname='omnibus-supermarket-test.ssl-config' target='local://' time='0.002105947'/>
    <testcase name='File /var/opt/supermarket/ssl/ca/dhparams.pem content should match /BEGIN DH PARAMETERS/' classname='omnibus-supermarket-test.ssl-config' target='local://' time='0.000237771'/>
    <testcase name='File /var/opt/supermarket/nginx/etc/sites-enabled/rails content should match /ssl_dhparam/' classname='omnibus-supermarket-test.ssl-config' target='local://' time='0.000123776'/>
    <testcase name='File /var/opt/supermarket/etc/logrotate.d should be directory' classname='omnibus-supermarket-test.log-management' target='local://' time='0.00010437'/>
    <testcase name='File /var/opt/supermarket/etc/logrotate.conf should be file' classname='omnibus-supermarket-test.log-management' target='local://' time='9.5736e-05'/>
    <testcase name='File /var/opt/supermarket/etc/logrotate.conf content should match /include \/var\/opt\/supermarket\/etc\/logrotate.d/' classname='omnibus-supermarket-test.log-management' target='local://' time='0.000331378'/>
    <testcase name='File /etc/cron.hourly/supermarket_logrotate should be file' classname='omnibus-supermarket-test.log-management' target='local://' time='0.000105546'/>
    <testcase name='File /etc/cron.hourly/supermarket_logrotate content should match /logrotate \/var\/opt\/supermarket\/etc\/logrotate.conf/' classname='omnibus-supermarket-test.log-management' target='local://' time='0.000149632'/>
    <testcase name='File /var/opt/supermarket/etc/logrotate.d/nginx should be file' classname='omnibus-supermarket-test.log-management' target='local://' time='8.7805e-05'/>
    <testcase name='File /var/opt/supermarket/etc/logrotate.d/nginx content should match /\/var\/log\/supermarket\/nginx\/\*.log/' classname='omnibus-supermarket-test.log-management' target='local://' time='0.000119932'/>
    <testcase name='Port 80 should be listening' classname='omnibus-supermarket-test.proxy' target='local://' time='0.044886769'/>
    <testcase name='Port 80 protocols should include &quot;tcp&quot;' classname='omnibus-supermarket-test.proxy' target='local://' time='0.002450746'/>
    <testcase name='http GET to Port 80 should not include server version number in response headers' classname='omnibus-supermarket-test.proxy' target='local://' time='0.004516449'/>
    <testcase name='Port 443 should be listening' classname='omnibus-supermarket-test.proxy' target='local://' time='0.00049774'/>
    <testcase name='Port 443 protocols should include &quot;tcp&quot;' classname='omnibus-supermarket-test.proxy' target='local://' time='0.000150465'/>
    <testcase name='http GET to Port 443 should not include server version number in response headers' classname='omnibus-supermarket-test.proxy' target='local://' time='0.001211491'/>
    <testcase name='Port 15432 should be listening' classname='omnibus-supermarket-test.database' target='local://' time='0.000366446'/>
    <testcase name='Port 15432 protocols should include &quot;tcp&quot;' classname='omnibus-supermarket-test.database' target='local://' time='0.000112651'/>
    <testcase name='File /var/opt/supermarket/cache should be directory' classname='omnibus-supermarket-test.cache-dirs' target='local://' time='0.000195745'/>
    <testcase name='File /opt/supermarket/embedded/cookbooks/local-mode-cache should not exist' classname='omnibus-supermarket-test.cache-dirs' target='local://' time='0.000975247'/>
    <testcase name='Port 16379 should be listening' classname='omnibus-supermarket-test.redis' target='local://' time='0.00031308'/>
    <testcase name='Port 16379 protocols should include &quot;tcp&quot;' classname='omnibus-supermarket-test.redis' target='local://' time='0.000116171'/>
    <testcase name='Port 13000 should be listening' classname='omnibus-supermarket-test.web-app' target='local://' time='0.000265973'/>
    <testcase name='Port 13000 protocols should include &quot;tcp&quot;' classname='omnibus-supermarket-test.web-app' target='local://' time='0.000134956'/>
  </testsuite>
</testsuites>
```