### PR TITLE
upgrade loofah to 2.2.3

### DIFF
--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -278,7 +278,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)

--- a/src/supermarket/engines/fieri/Gemfile.lock
+++ b/src/supermarket/engines/fieri/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     libyajl2 (1.2.0)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)


### PR DESCRIPTION
loofah < 2.2.3 has a cross-site scriting vulnerability [reported](https://github.com/flavorjones/loofah/issues/154).

Supermarket is not vulnerable to this. The library is being updated out of an abundance of caution and to appease the vulnerability scanner.