### PR TITLE
 fix itemprop schema for cookbook create/update datetimes

### DIFF
--- a/src/supermarket/app/views/cookbooks/_sidebar.html.erb
+++ b/src/supermarket/app/views/cookbooks/_sidebar.html.erb
@@ -52,8 +52,8 @@
     </div>
 
     <h4>
-      <i class="fa fa-clock-o"></i> Updated <span itemprop="datePublished"><%= version.updated_at.to_s(:longish) %></span>
-      <small>Created on <span itemprop="dateModified"><%= cookbook.created_at.to_s(:longish) %></span></small>
+      <i class="fa fa-clock-o"></i> Updated <span itemprop="dateModified"><%= version.updated_at.to_s(:longish) %></span>
+      <small>Created on <span itemprop="datePublished"><%= cookbook.created_at.to_s(:longish) %></span></small>
     </h4>
 
     <h4><i class="fa fa-desktop"></i> Platforms</h4>


### PR DESCRIPTION
(Opening a new PR for @rmoriz because #1753 has gotten very confused.)

[`dateModified`](https://schema.org/dateModified) and [`datePublished`](https://schema.org/dateCreated) are the wrong way around in the cookbook view HTML, causing wrong dates on google search results (since ~2014).

For example:

![ohai cookbook - chef supermarket](https://user-images.githubusercontent.com/1527/44623394-92884900-a8cc-11e8-9a30-d6e409f14760.jpg)

![ohai cookbook - google-suche-1](https://user-images.githubusercontent.com/1527/44623389-6a004f00-a8cc-11e8-9e91-7687f2192908.jpg)

![chef cookbook openssl - google-suche](https://user-images.githubusercontent.com/1527/47852312-ad4ed080-dddb-11e8-8900-c80e13bbcd8c.jpg)
