### PR TITLE
remove unnecessary build cruft before packaging (reduces size ~12%)

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 8cb4ba11226f61a78d6ef71a83353b95c8fdd528
+  revision: 72dd1e333c638af8089c2d5904172640181bd29c
   specs:
     omnibus-software (4.0.0)
       chef-sugar (>= 3.4.0)
@@ -8,9 +8,9 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: ca035f744ece299cbdf81f52edb997b4ba1693b2
+  revision: 5ac799cdcc5a7865b452daa96f92812144dccb3d
   specs:
-    omnibus (6.0.7)
+    omnibus (6.0.10)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -30,8 +30,8 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.0.1)
-    aws-partitions (1.121.0)
-    aws-sdk-core (3.42.0)
+    aws-partitions (1.126.0)
+    aws-sdk-core (3.44.1)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -39,7 +39,7 @@ GEM
     aws-sdk-kms (1.13.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.28.0)
+    aws-sdk-s3 (1.30.0)
       aws-sdk-core (~> 3, >= 3.39.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -58,10 +58,10 @@ GEM
       solve (~> 4.0)
       thor (>= 0.20)
     builder (3.2.3)
-    chef (14.7.17)
+    chef (14.8.12)
       addressable
       bundler (>= 1.10)
-      chef-config (= 14.7.17)
+      chef-config (= 14.8.12)
       chef-zero (>= 13.0)
       diff-lcs (~> 1.2, >= 1.2.4)
       erubis (~> 2.7)
@@ -88,13 +88,13 @@ GEM
       specinfra (~> 2.10)
       syslog-logger (~> 1.6)
       uuidtools (~> 2.1.5)
-    chef-config (14.7.17)
+    chef-config (14.8.12)
       addressable
       fuzzyurl
       mixlib-config (>= 2.2.12, < 3.0)
       mixlib-shellout (~> 2.0)
       tomlrb (~> 1.2)
-    chef-sugar (4.1.0)
+    chef-sugar (4.2.1)
     chef-zero (14.0.11)
       ffi-yajl (~> 2.2)
       hashie (>= 2.0, < 4.0)
@@ -103,7 +103,7 @@ GEM
       uuidtools (~> 2.1)
     citrus (3.0.2)
     cleanroom (1.0.0)
-    concurrent-ruby (1.1.3)
+    concurrent-ruby (1.1.4)
     diff-lcs (1.3)
     erubis (2.7.0)
     faraday (0.15.4)
@@ -126,7 +126,7 @@ GEM
     kitchen-vagrant (1.3.6)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (1.0.18)
+    license_scout (1.0.20)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
       toml-rb (~> 1.0)
@@ -135,19 +135,19 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     minitar (0.7)
-    mixlib-archive (0.4.18)
+    mixlib-archive (0.4.19)
       mixlib-log
     mixlib-authentication (2.1.1)
     mixlib-cli (1.7.0)
-    mixlib-config (2.2.13)
+    mixlib-config (2.2.18)
       tomlrb
     mixlib-install (3.11.5)
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-log (2.0.4)
-    mixlib-shellout (2.4.0)
-    mixlib-versioning (1.2.2)
+    mixlib-log (2.0.9)
+    mixlib-shellout (2.4.4)
+    mixlib-versioning (1.2.7)
     molinillo (0.6.6)
     multi_json (1.13.1)
     multipart-post (2.0.0)
@@ -165,7 +165,7 @@ GEM
     nori (2.6.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (14.6.2)
+    ohai (14.8.10)
       chef-config (>= 12.8, < 15)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
@@ -214,24 +214,24 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
-    semverse (2.0.0)
+    semverse (3.0.0)
     serverspec (2.41.3)
       multi_json
       rspec (~> 3.0)
       rspec-its
       specinfra (~> 2.72)
     sfl (2.3)
-    solve (4.0.0)
+    solve (4.0.2)
       molinillo (~> 0.6)
-      semverse (>= 1.1, < 3.0)
-    specinfra (2.76.3)
+      semverse (>= 1.1, < 4.0)
+    specinfra (2.76.5)
       net-scp
       net-ssh (>= 2.7)
       net-telnet (= 0.1.1)
       sfl
     syslog-logger (1.6.8)
     systemu (2.6.5)
-    test-kitchen (1.23.2)
+    test-kitchen (1.23.5)
       mixlib-install (~> 3.6)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
@@ -246,7 +246,7 @@ GEM
       citrus (~> 3.0, > 3.0)
     tomlrb (1.2.7)
     uuidtools (2.1.5)
-    winrm (2.3.0)
+    winrm (2.3.1)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)
@@ -255,15 +255,15 @@ GEM
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0, >= 0.6.1)
-    winrm-elevated (1.1.0)
+    winrm-elevated (1.1.1)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
-    winrm-fs (1.3.1)
+    winrm-fs (1.3.2)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
       winrm (~> 2.0)
-    wmi-lite (1.0.0)
+    wmi-lite (1.0.1)
     zhexdump (0.0.2)
 
 PLATFORMS

--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -46,6 +46,9 @@ dependency "supermarket-ctl"
 # Version manifest file
 dependency "version-manifest"
 
+# remove lots of ruby clutter we don't need
+dependency "ruby-cleanup"
+
 exclude "**/.git"
 exclude "**/bundler/git"
 


### PR DESCRIPTION
In other projects we've seen up to a 30% reduction in the install size with this change.

Signed-off-by: Tim Smith <tsmith@chef.io>