### PR TITLE
Use the built-in apt resource in the omnibus build cookbook

### DIFF
--- a/omnibus/cookbooks/supermarket-builder/metadata.rb
+++ b/omnibus/cookbooks/supermarket-builder/metadata.rb
@@ -3,9 +3,9 @@ maintainer       'Chef Supermarket Team'
 maintainer_email 'supermarket@chef.io'
 license          'Apache-2.0'
 description      'Builds a Supermarket omnibus package for development/testing'
-long_description 'Builds a Supermarket omnibus package for development/testing'
 version          '1.0.0'
 
-depends          'apt'
 depends          'yum-epel'
 depends          'omnibus'
+
+chef_version     '>= 13.0'

--- a/omnibus/cookbooks/supermarket-builder/recipes/default.rb
+++ b/omnibus/cookbooks/supermarket-builder/recipes/default.rb
@@ -22,7 +22,7 @@
 # ensure packages available up-to-date
 case node['platform_family']
 when 'debian'
-  include_recipe 'apt::default'
+  apt_update
 when 'rhel'
   include_recipe 'yum-epel::default'
 end


### PR DESCRIPTION
Modern Chef gives us apt_update out of the box. No need for the apt cookbook now.

Signed-off-by: Tim Smith <tsmith@chef.io>