### PR TITLE
update rack for CVE-2018-16471

### DIFF
--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -396,7 +396,7 @@ GEM
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     raabro (1.1.6)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.1)
       rack
     rack-test (0.6.3)

--- a/src/supermarket/engines/fieri/Gemfile.lock
+++ b/src/supermarket/engines/fieri/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (2.0.5)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.1)
       rack
     rack-test (0.6.3)


### PR DESCRIPTION
Resolves bundle-audit finding for [CVE-2018-16471](https://groups.google.com/forum/#!topic/ruby-security-ann/NAalCee8n6o).