### PR TITLE
upgrade omnibus-embedded nginx

### DIFF
--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -31,7 +31,6 @@ build_iteration 1
 override :postgresql, version: '9.3.18'
 override :ruby, version: "2.5.3"
 override :rubygems, version: '2.6.14'
-override :nginx, version: '1.10.2'
 override :'chef-gem', version: '14.5.33'
 override :berkshelf, version: 'v6.3.1'
 override :'openssl-fips', version: '2.0.16'


### PR DESCRIPTION
Removes the version pin for nginx in omnibus project. Updates omnibus-software to the latest which includes the latest nginx and an nginx software definition that sets the default version to the latest nginx. No longer need to keep changing the pinned version to get a newer release, just need to update omnibus-software.