### PR TITLE
Revert "use Chef, not shell-out, to fix directory permissions"

### DIFF
--- a/omnibus/cookbooks/supermarket-builder/recipes/default.rb
+++ b/omnibus/cookbooks/supermarket-builder/recipes/default.rb
@@ -29,10 +29,8 @@ end
 
 include_recipe 'omnibus::default'
 
-directory "the one bundler might write to during a build" do
-  path "#{node['omnibus']['build_user_home']}/.bundle"
-  owner node['omnibus']['build_user']
-  recursive true
+execute 'fix bundler directory permissions' do
+  command "chown -R #{node['omnibus']['build_user']} #{node['omnibus']['build_user_home']}/.bundle"
 end
 
 # do the build


### PR DESCRIPTION
This reverts commit c1a4ceed261dfe368fda441af5343b0c4d43baa9.

Turns out, the recursive directory permission applied by Chef's directory resource was insufficient to fix `.bundle/cache` being created and populated with stuff by root. So, let's go back to executing a chmod which worked a treat.