### PR TITLE
Remove Chef Provisioning from the tools page

### DIFF
--- a/src/supermarket/app/models/tool.rb
+++ b/src/supermarket/app/models/tool.rb
@@ -1,7 +1,7 @@
 class Tool < ApplicationRecord
   include PgSearch
 
-  ALLOWED_TYPES = %w[knife_plugin ohai_plugin chef_tool handler provisioning_driver kitchen_driver powershell_module dsc_resource compliance_profile].freeze
+  ALLOWED_TYPES = %w[knife_plugin ohai_plugin chef_tool handler kitchen_driver powershell_module dsc_resource compliance_profile].freeze
 
   self.inheritance_column = nil
 


### PR DESCRIPTION
We're in the process of winding down Chef provisioning and the only
tools here were from Chef and stuart. I've deleted all of the entries
from Chef.

Signed-off-by: Tim Smith <tsmith@chef.io>