### PR TITLE
Create omnibus buildkite pipelines

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -30,6 +30,13 @@ changelog:
     - "Bug": "Bug Fixes"
     - "Security": "Security Fixes"
 
+pipelines:
+  - omnibus/release
+  - omnibus/adhoc:
+      definition: .expeditor/release.omnibus.yml
+      env:
+        - ADHOC: true
+
 # These actions are taken, in order they are specified, anytime a Pull Request is merged.
 merge_actions:
   - built_in:bump_version:

--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -1,0 +1,15 @@
+---
+project-name: supermarket
+config: omnibus/omnibus.rb
+test-path: omnibus/omnibus-test.sh
+fips-platforms:
+  - el-*-x86_64
+builder-to-testers-map:
+  el-6-x86_64:
+    - el-6-x86_64
+  el-7-x86_64:
+    - el-7-x86_64
+  ubuntu-14.04-x86_64:
+    - ubuntu-14.04-x86_64
+    - ubuntu-16.04-x86_64
+    - ubuntu-18.04-x86_64

--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -ueo pipefail
+
+channel="${CHANNEL:-unstable}"
+product="${PRODUCT:-supermarket}"
+version="${VERSION:-latest}"
+
+echo "--- Installing $channel $product $version"
+package_file="$(install-omnibus-product -c "$channel" -P "$product" -v "$version" | tail -n 1)"
+
+if [[ "$package_file" == *.rpm ]]; then
+  check-rpm-signed "$package_file"
+fi
+
+echo "--- Testing $channel $product $version"
+
+export PATH="/opt/supermarket/bin:/opt/supermarket/embedded/bin:$PATH"
+export INSTALL_DIR="/opt/supermarket"
+
+echo ""
+echo ""
+echo "============================================================"
+echo "Verifying ownership of package files"
+echo "============================================================"
+echo ""
+
+NONROOT_FILES="$(find "$INSTALL_DIR" ! -uid 0 -print)"
+if [[ "$NONROOT_FILES" == "" ]]; then
+  echo "Packages files are owned by root.  Continuing verification."
+else
+  echo "Exiting with an error because the following files are not owned by root:"
+  echo "$NONROOT_FILES"
+  exit 1
+fi
+
+echo ""
+echo ""
+echo "============================================================"
+echo "Reconfiguring $product"
+echo "============================================================"
+echo ""
+
+sudo supermarket-ctl reconfigure || true
+sleep 120
+
+echo ""
+echo ""
+echo "============================================================"
+echo "Running verification for $product"
+echo "============================================================"
+echo ""
+
+sudo supermarket-ctl test -J pedant.xml


### PR DESCRIPTION
This creates buildkite pipelines that will be used for omnibus builds/tests. It does not actually replace the current build/test infrastructure. That will be done in a separate PR once we finish testing the new pipelines.