### PR TITLE
pin inspec to fix '-ctl test' requiring license acceptance

### DIFF
--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -33,6 +33,7 @@ override :ruby, version: "2.5.3"
 override :'chef-gem', version: '14.5.33'
 override :berkshelf, version: 'v6.3.1'
 override :'openssl-fips', version: '2.0.16'
+override :inspec, version: 'v3.9.2' # TODO: remove when license_acceptance is added
 
 # Creates required build directories
 dependency "preparation"


### PR DESCRIPTION
## Description

Until Supermarket is ready for adding license acceptance, package it with a version of InSpec that does not require license acceptance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
-  ~I have updated the documentation accordingly.~
-  ~I have added tests to cover my changes.~
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
