### PR TITLE
Use new omnibus-toolchain scripts in omnibus-test.sh

### DIFF
--- a/omnibus/omnibus-test.sh
+++ b/omnibus/omnibus-test.sh
@@ -6,25 +6,19 @@ product="${PRODUCT:-supermarket}"
 version="${VERSION:-latest}"
 
 echo "--- Installing $channel $product $version"
-package_file="$(install-omnibus-product -c "$channel" -P "$product" -v "$version" | tail -n 1)"
+package_file="$(/opt/omnibus-toolchain/bin/install-omnibus-product -c "$channel" -P "$product" -v "$version" | tail -n 1)"
 
-if [[ "$package_file" == *.rpm ]]; then
-  check-rpm-signed "$package_file"
-fi
+echo "--- Verifying omnibus package is signed"
+/opt/omnibus-toolchain/bin/check-omnibus-package-signed "$package_file"
 
-echo "--- Testing $channel $product $version"
+sudo rm -f "$package_file"
 
 export PATH="/opt/supermarket/bin:/opt/supermarket/embedded/bin:$PATH"
 export INSTALL_DIR="/opt/supermarket"
 
-echo ""
-echo ""
-echo "============================================================"
-echo "Verifying ownership of package files"
-echo "============================================================"
-echo ""
+echo "--- Verifying ownership of package files"
 
-NONROOT_FILES="$(find "$INSTALL_DIR" ! -uid 0 -print)"
+NONROOT_FILES="$(find "$INSTALL_DIR" ! -user 0 -print)"
 if [[ "$NONROOT_FILES" == "" ]]; then
   echo "Packages files are owned by root.  Continuing verification."
 else
@@ -33,21 +27,11 @@ else
   exit 1
 fi
 
-echo ""
-echo ""
-echo "============================================================"
-echo "Reconfiguring $product"
-echo "============================================================"
-echo ""
+echo "--- Reconfiguring $channel $product $version"
 
 sudo supermarket-ctl reconfigure || true
 sleep 120
 
-echo ""
-echo ""
-echo "============================================================"
-echo "Running verification for $product"
-echo "============================================================"
-echo ""
+echo "--- Running verification for $channel $product $version"
 
 sudo supermarket-ctl test -J pedant.xml


### PR DESCRIPTION
### Description

This just updates the `omnibus-test.sh` script to use tools that have been moved into the omnibus-toolchain. It also makes some changes to output to be more consistent across our omnibus projects.