### PR TITLE
No more Ubuntu 14 builds. Canonical ended support for trusty in April 2019.

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -9,7 +9,6 @@ builder-to-testers-map:
     - el-6-x86_64
   el-7-x86_64:
     - el-7-x86_64
-  ubuntu-14.04-x86_64:
-    - ubuntu-14.04-x86_64
+  ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64

--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -14,7 +14,6 @@ provisioner:
 platforms:
   # for Ubuntu, only need earliest supported version for build
   # testing occurs on earliest supported and later in a different kitchen
-  - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: centos-6
   - name: centos-7

--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -15,6 +15,7 @@ platforms:
   # for Ubuntu, only need earliest supported version for build
   # testing occurs on earliest supported and later in a different kitchen
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
   - name: centos-6
   - name: centos-7
 

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -91,14 +91,14 @@ liking, you can bring up an individual build environment using the `kitchen`
 command.
 
 ```shell
-$ kitchen converge ubuntu-1404
+$ kitchen converge ubuntu-1604
 ```
 
 Then login to the instance and build the project as described in the Usage
 section:
 
 ```shell
-$ kitchen login ubuntu-1404
+$ kitchen login ubuntu-1604
 [vagrant@ubuntu...] $ cd supermarket
 [vagrant@ubuntu...] $ bundle install
 [vagrant@ubuntu...] $ ...

--- a/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
+++ b/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
@@ -17,7 +17,6 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: ubuntu-18.04
   - name: centos-6

--- a/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
+++ b/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
@@ -19,6 +19,7 @@ verifier:
 platforms:
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: ubuntu-18.04
   - name: centos-6
   - name: centos-7
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Ubuntu 14 is EOL and has been removed from the build pipeline in favor of Ubuntu 16

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
