### PR TITLE
Add s3_private_objects info to omnibus attributes

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -459,6 +459,12 @@ default['supermarket']['s3_region'] = nil
 # A cdn_url can be used for an alias if the S3 bucket is behind a CDN like CloudFront.
 default['supermarket']['cdn_url'] = nil
 
+# If set then supermarket will apply an object-level private ACL. For this to work,
+# the relevant IAM and bucket policies will need to allow PutObjectACL permissions.
+# Note: if this is not set, and "Block all public access" is on for the bucket then Chef
+# Supermarket will be unable to update cookbooks.
+# default['supermarket']['s3_private_objects'] = nil
+
 # If using IAM user credentials for bucket access, set these.
 default['supermarket']['s3_access_key_id'] = nil
 default['supermarket']['s3_secret_access_key'] = nil


### PR DESCRIPTION
## Description
As more people roll out restrictions on public ACLs for their S3 buckets to avoid being the next headline we're likely to see people running into problems with their internal supermarket.  The info they need is here in the repository but it's not easy to find. This change is to surface that in a place people can find directly from the cookbook README.

This is all commented out so we don't change the defaults, and I believe it falls under the obvious-fix guidelines.  I'm just surfacing work already done by another developer within the documentation.

## Related Issue
N/A

## Types of changes
- ~Bug fix (non-breaking change which fixes an issue)~
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~
- [X] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- ~I have run the pre-merge tests locally and they pass.~
- ~I have updated the documentation accordingly.~
- ~I have added tests to cover my changes.~
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
