### PR TITLE
[ci] Add artifactory to omnibus/Gemfile

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -7,6 +7,9 @@ gem 'omnibus', git: 'https://github.com/chef/omnibus.git'
 # software definitions, but you can clone/fork Chef's to get you started.
 gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software.git'
 
+# Install artifactory. Used for publishing packages.
+gem 'artifactory'
+
 # This development group is installed by default when you run `bundle install`,
 # but if you are using Omnibus in a CI-based infrastructure, you do not need
 # the Test Kitchen-based build lab. You can skip these unnecessary dependencies

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -8,9 +8,9 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 968307c129ee54416f5a4d07ca8f8ca2d2b12825
+  revision: 33bddeefb10afe23a57ea72807625881ab01990f
   specs:
-    omnibus (6.0.27)
+    omnibus (6.1.0)
       aws-sdk-s3 (~> 1)
       chef-sugar (>= 3.3)
       cleanroom (~> 1.0)
@@ -28,21 +28,22 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    artifactory (3.0.5)
     awesome_print (1.8.0)
     aws-eventstream (1.0.3)
-    aws-partitions (1.168.0)
-    aws-sdk-core (3.54.0)
+    aws-partitions (1.195.0)
+    aws-sdk-core (3.61.2)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.21.0)
-      aws-sdk-core (~> 3, >= 3.53.0)
+    aws-sdk-kms (1.24.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.40.0)
-      aws-sdk-core (~> 3, >= 3.53.0)
+    aws-sdk-s3 (1.46.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.0)
+      aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
     berkshelf (7.0.7)
@@ -187,7 +188,7 @@ GEM
     plist (3.5.0)
     progressbar (1.10.1)
     proxifier (1.0.3)
-    public_suffix (3.1.0)
+    public_suffix (3.1.1)
     rack (2.0.6)
     retryable (2.0.4)
     rspec (3.8.0)
@@ -271,6 +272,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  artifactory
   berkshelf
   kitchen-vagrant
   omnibus!
@@ -278,4 +280,4 @@ DEPENDENCIES
   test-kitchen
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
### Description

This change only affects CI. A new version of omnibus is required and the artifactory gem is required for the publish part of the build stage.

### Related Issue

https://github.com/chef/omnibus-buildkite-plugin/issues/22