### PR TITLE
update rubyzip to address CVE-2019-16892

### DIFF
--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -240,8 +240,6 @@ GEM
     html_truncator (0.4.1)
       nokogiri (~> 1.5)
     htmlentities (4.3.4)
-    httparty (0.15.2)
-      multi_xml (>= 0.5.2)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -269,12 +267,12 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     libyajl2 (1.2.0)
-    license_finder (3.0.0)
+    license_finder (5.10.2)
       bundler
-      httparty
       rubyzip
       thor
-      with_env (> 1.0)
+      toml (= 0.2.0)
+      with_env (= 1.1.0)
       xml-simple
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -371,6 +369,7 @@ GEM
     parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
+    parslet (1.8.2)
     pg (0.20.0)
     pg_search (2.0.1)
       activerecord (>= 4.2)
@@ -497,7 +496,7 @@ GEM
     ruby-filemagic (0.7.2)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
+    rubyzip (2.0.0)
     rufus-lru (1.1.0)
     safe_yaml (1.0.4)
     sass (3.4.24)
@@ -556,6 +555,8 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
+    toml (0.2.0)
+      parslet (~> 1.8.0)
     tomlrb (1.2.4)
     treetop (1.6.10)
       polyglot (~> 0.3)


### PR DESCRIPTION
## Description

This is an audit appeaser. Supermarket does not use rubyzip during operation. It comes in as a depencency of license_finder which is a dev/test time tool. This updates that gem, too.

## Related Issue

Once merged, this should address the error seen in #1824.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- ~I have updated the documentation accordingly.~
- ~I have added tests to cover my changes.~
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
