### PR TITLE
include secrets found in secrets.json in runtime omnibus config

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/libraries/config.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/libraries/config.rb
@@ -43,6 +43,7 @@ class Supermarket
     def self.load_or_create_secrets!(filename, node)
       create_directory!(filename)
       secrets = Chef::JSONCompat.from_json(File.open(filename).read)
+      node.consume_attributes('supermarket' => secrets)
     rescue Errno::ENOENT
       begin
         secrets = { 'secret_key_base' => SecureRandom.hex(50) }


### PR DESCRIPTION
## Description

When the secrets.json already exists, the config items weren't getting added to the node. Let's fix that.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~
- ~Chore (non-breaking change that does not add functionality or fix an issue)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- ~I have updated the documentation accordingly.~
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
