### PR TITLE
avoid Double Bundler by pinning rubygems version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@
 
 #### Security Fixes
 - include secrets found in secrets.json in runtime omnibus config [#1832](https://github.com/chef/supermarket/pull/1832) ([robbkidd](https://github.com/robbkidd)) <!-- 3.3.13 -->
+- Bump rack from 2.0.7 to 2.0.8 in /omnibus [#1834](https://github.com/chef/supermarket/pull/1834) ([dependabot[bot]](https://github.com/dependabot[bot])) <!-- 3.3.12 -->
 - update for CVE-2019-13117 &amp; CVE-2019-16782 [#1833](https://github.com/chef/supermarket/pull/1833) ([robbkidd](https://github.com/robbkidd)) <!-- 3.3.11 -->
 - Bump loofah from 2.2.3 to 2.3.1 [#1830](https://github.com/chef/supermarket/pull/1830) ([dependabot[bot]](https://github.com/dependabot[bot])) <!-- 3.3.10 -->
+- update rubyzip to address CVE-2019-16892 [#1825](https://github.com/chef/supermarket/pull/1825) ([robbkidd](https://github.com/robbkidd)) <!-- 3.3.9 -->
 
 #### Merged Pull Requests
-- Bump rack from 2.0.7 to 2.0.8 in /omnibus [#1834](https://github.com/chef/supermarket/pull/1834) ([dependabot[bot]](https://github.com/dependabot[bot])) <!-- 3.3.12 -->
-- update rubyzip to address CVE-2019-16892 [#1825](https://github.com/chef/supermarket/pull/1825) ([robbkidd](https://github.com/robbkidd)) <!-- 3.3.9 -->
 - add a version command to supermarket-ctl [#1811](https://github.com/chef/supermarket/pull/1811) ([robbkidd](https://github.com/robbkidd)) <!-- 3.3.8 -->
 <!-- release_rollup -->
 

--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -9,7 +9,8 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 14.5.33
+  product_name: chef
+  product_version: 14
 
 platforms:
   # for Ubuntu, only need earliest supported version for build

--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -30,6 +30,7 @@ build_iteration 1
 
 override :postgresql, version: '9.3.18'
 override :ruby, version: "2.5.3"
+override :rubygems, version: "3.0.3" # rubygems ships its own bundler which may differ from bundler defined below and then we get double bundler which makes the omnibus environment unhappy. Make sure these versions match before bumping either.
 override :bundler, version: "1.17.3" # this must match the BUNDLED WITH in all the repo's Gemfile.locks
 override :'chef-gem', version: '14.5.33'
 override :'openssl-fips', version: '2.0.16'


### PR DESCRIPTION
## Description

RubyGems library embeds a version of bundler. To ensure we only have one version of bundler included in our package, rubygems and bundler must move together. This version of rubygems embeds bundler 1.17.3 which is the version of bundler the rest of Supermarket's components expects.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~
- ~Chore (non-breaking change that does not add functionality or fix an issue)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- ~I have updated the documentation accordingly.~
- ~I have added tests to cover my changes.~
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
