### PR TITLE
Change log directory mode to use an attribute

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -72,6 +72,7 @@ default['supermarket']['config_directory'] = '/etc/supermarket'
 default['supermarket']['install_directory'] = '/opt/supermarket'
 default['supermarket']['app_directory'] = "#{node['supermarket']['install_directory']}/embedded/service/supermarket"
 default['supermarket']['log_directory'] = '/var/log/supermarket'
+default['supermarket']['log_directory']['mode'] = '0700'
 default['supermarket']['var_directory'] = '/var/opt/supermarket'
 default['supermarket']['data_directory'] = '/var/opt/supermarket/data'
 default['supermarket']['user'] = 'supermarket'

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
@@ -67,7 +67,7 @@ end
 directory node['supermarket']['log_directory'] do
   owner node['supermarket']['user']
   group node['supermarket']['group']
-  mode '0700'
+  mode node['supermarket']['log_directory']['mode']
   recursive true
 end
 

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/nginx.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/nginx.rb
@@ -27,7 +27,7 @@ include_recipe 'omnibus-supermarket::config'
   directory dir do
     owner node['supermarket']['user']
     group node['supermarket']['group']
-    mode '0700'
+    mode node['supermarket']['log_directory']['mode']
     recursive true
   end
 end

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/postgresql.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/postgresql.rb
@@ -31,7 +31,7 @@ end
 directory node['supermarket']['postgresql']['log_directory'] do
   owner node['supermarket']['user']
   group node['supermarket']['group']
-  mode '0700'
+  mode node['supermarket']['log_directory']['mode']
   recursive true
 end
 

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/rails.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/rails.rb
@@ -25,7 +25,7 @@ include_recipe 'omnibus-supermarket::nginx'
   directory dir do
     owner node['supermarket']['user']
     group node['supermarket']['group']
-    mode '0700'
+    mode node['supermarket']['log_directory']['mode']
     recursive true
   end
 end

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/redis.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/redis.rb
@@ -28,7 +28,7 @@ include_recipe 'enterprise::runit'
   directory dir do
     owner node['supermarket']['user']
     group node['supermarket']['group']
-    mode '0700'
+    mode node['supermarket']['log_directory']['mode']
     recursive true
   end
 end

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/sidekiq.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/sidekiq.rb
@@ -20,7 +20,7 @@
 directory "#{node['supermarket']['log_directory']}/sidekiq" do
   owner node['supermarket']['user']
   group node['supermarket']['group']
-  mode '0700'
+  mode node['supermarket']['log_directory']['mode']
 end
 
 if node['supermarket']['sidekiq']['enable']


### PR DESCRIPTION
* Users may want to set different permissions on the log directories
  than our default of 0700, using an attribute allows them to do so.

Signed-off-by: Shaun Mouton <smouton@chef.io>

## Description
If a user wants to allow a group to access the log directory, the current recipe doesn't allow them to do so. This updates the recipe to fix this, the default attribute is set to mode '0700', the same as the current line in each recipe, so no behavior change is introduced for folks who don't set this attribute.

## Related Issue
Fixes #1856 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
