### PR TITLE
Resolve upcoming OpenSSL Ruby library deprecation of algorithm constants

### DIFF
--- a/src/supermarket/app/models/user.rb
+++ b/src/supermarket/app/models/user.rb
@@ -226,7 +226,7 @@ class User < ApplicationRecord
     #   with private key: openssl rsa -in private_key.pem -pubout -outform DER | openssl md5 -c
     #   with public key: openssl rsa -in public_key.pub -pubin -outform DER | openssl md5 -c
     key_in_der_format = OpenSSL::PKey::RSA.new(public_key).to_der
-    OpenSSL::Digest::MD5.hexdigest(key_in_der_format).scan(/../).join(':')
+    OpenSSL::Digest.hexdigest('MD5', key_in_der_format).scan(/../).join(':')
   end
 
   private


### PR DESCRIPTION
# Description

> Lint/DeprecatedOpenSSLConstant:
>   Use `OpenSSL::Digest.hexdigest('MD5', key_in_der_format)` instead of
>   `OpenSSL::Digest::MD5.hexdigest(key_in_der_format)`.

[Rubocop has a new cop](https://github.com/rubocop-hq/rubocop/pull/7950) that detects an [upcoming deprecation to the OpenSSL gem](https://github.com/ruby/openssl/pull/366) that's built into Ruby.

The previous constant will cause failures in Ruby 3.

# Related Issue(s)

Closes #1859 