### PR TITLE
Remove bundler-audit from tests; we're auditing with GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,6 @@ matrix:
         - cd $TRAVIS_BUILD_DIR/src/$NAME
         - bundle exec rake spec
         - bundle exec rubocop
-        - bundle exec bundle-audit check --update --ignore CVE-2015-9284
 
     # Fieri Spec
     - env:
@@ -83,7 +82,6 @@ matrix:
         - cd $TRAVIS_BUILD_DIR/src/supermarket/engines/$NAME
         - bundle exec rake spec
         - bundle exec rubocop
-        - bundle exec bundle-audit check --update
 
     # omnibus-supermarket-reconfigure-cookstyle
     - env:

--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -81,7 +81,6 @@ end
 
 group :development, :test do
   gem 'brakeman'
-  gem 'bundler-audit', git: 'https://github.com/rubysec/bundler-audit.git', ref: '4e32fca'
   gem 'byebug'
   gem 'factory_bot_rails', require: false
   gem 'faker'

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/rubysec/bundler-audit.git
-  revision: 4e32fca89d75f0e249671431ff38aadc02bfb28b
-  ref: 4e32fca
-  specs:
-    bundler-audit (0.4.0)
-      bundler (~> 1.2)
-      thor (~> 0.18)
-
 PATH
   remote: engines/fieri
   specs:
@@ -606,7 +597,6 @@ DEPENDENCIES
   and_feathers-gzipped_tarball (>= 1.0.0.pre)
   aws-sdk
   brakeman
-  bundler-audit!
   byebug
   capybara
   capybara-screenshot

--- a/src/supermarket/engines/fieri/Gemfile
+++ b/src/supermarket/engines/fieri/Gemfile
@@ -13,7 +13,6 @@ gemspec
 # To use debugger
 # gem 'debugger'
 group :development, :test do
-  gem 'bundler-audit', git: 'https://github.com/rubysec/bundler-audit.git', ref: '4e32fca'
   gem 'pry'
   gem 'rspec-rails', '~> 3.0'
   gem 'rubocop'

--- a/src/supermarket/engines/fieri/Gemfile.lock
+++ b/src/supermarket/engines/fieri/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/rubysec/bundler-audit.git
-  revision: 4e32fca89d75f0e249671431ff38aadc02bfb28b
-  ref: 4e32fca
-  specs:
-    bundler-audit (0.4.0)
-      bundler (~> 1.2)
-      thor (~> 0.18)
-
 PATH
   remote: .
   specs:
@@ -224,7 +215,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler-audit!
   fieri!
   pry
   rspec-rails (~> 3.0)

--- a/src/supermarket/engines/fieri/lib/tasks/spec.rake
+++ b/src/supermarket/engines/fieri/lib/tasks/spec.rake
@@ -3,10 +3,6 @@ namespace :spec do
     fail unless system 'bundle exec rubocop'
   end
 
-  task :bundle_audit do
-    fail unless system 'bundle exec bundle-audit check --update'
-  end
-
   desc 'Run RSpec tests and rubocop'
-  task all: [:spec, :rubocop, :bundle_audit]
+  task all: [:spec, :rubocop]
 end

--- a/src/supermarket/lib/tasks/spec/all.rake
+++ b/src/supermarket/lib/tasks/spec/all.rake
@@ -3,10 +3,6 @@ namespace :spec do
     fail unless system 'bundle exec rubocop'
   end
 
-  task :bundle_audit do
-    fail unless system 'bundle exec bundle-audit check --update --ignore CVE-2018-1000544'
-  end
-
   desc 'Run RSpec tests and rubocop'
-  task all: [:spec, :javascripts, :rubocop, :bundle_audit]
+  task all: [:spec, :javascripts, :rubocop]
 end


### PR DESCRIPTION
Given that we're auditing with GitHub and have Dependabot opening PRs to update dependencies, we need bundler-audit less than we need to work with Ruby 2.7+