### PR TITLE
add packages for Amazon Linux 2 to the pipeline

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -10,6 +10,7 @@ builder-to-testers-map:
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64
+    - amazon-2-x86_64
   ubuntu-16.04-x86_64:
     - ubuntu-16.04-x86_64
     - ubuntu-18.04-x86_64

--- a/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
+++ b/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
@@ -23,6 +23,7 @@ platforms:
   - name: centos-6
   - name: centos-7
   - name: centos-8
+  - name: amazonlinux-2
 
 suites:
   - name: default


### PR DESCRIPTION
Amazon Linux 2 is just RHEL 7 so anything supported on RHEL 7 is
supported there as well, but this way it shows up on the downloads page.

Signed-off-by: Tim Smith <tsmith@chef.io>