### PR TITLE
Minor comment fix to get full Cookstyle compliance in omnibus

### DIFF
--- a/omnibus/cookbooks/supermarket-builder/recipes/default.rb
+++ b/omnibus/cookbooks/supermarket-builder/recipes/default.rb
@@ -1,8 +1,8 @@
 #
-# Cookbook Name:: supermarket-builder
+# Cookbook:: supermarket-builder
 # Recipe:: default
 #
-# Copyright 2018 Chef Software, Inc.
+# Copyright:: 2018 Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This tiny comment fix gets the cookstyle runs green against the omnibus
cookbooks

Signed-off-by: Tim Smith <tsmith@chef.io>