### PR TITLE
Update Ruby to 2.6.6 to resolve 2 CVEs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 
 language: ruby
 rvm:
-  - 2.6.5
+  - 2.6.6
 bundler_args: "--without development --jobs 7"
 
 notifications:

--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -29,7 +29,7 @@ build_version   IO.read(File.expand_path("../../../../VERSION", __FILE__)).strip
 build_iteration 1
 
 override :postgresql, version: '9.3.18'
-override :ruby, version: "2.6.5"
+override :ruby, version: "2.6.6"
 override :rubygems, version: "3.1.2" # rubygems ships its own bundler which may differ from bundler defined below and then we get double bundler which makes the omnibus environment unhappy. Make sure these versions match before bumping either.
 override :bundler, version: "2.1.2" # this must match the BUNDLED WITH in all the repo's Gemfile.locks
 override :'chef-gem', version: '14.14.29'


### PR DESCRIPTION
Updating to Ruby 2.6.6 resolves these 2 CVEs:

    CVE-2020-10663: Unsafe Object Creation Vulnerability in JSON (Additional fix)
    CVE-2020-10933: Heap exposure vulnerability in the socket library

Signed-off-by: Tim Smith <tsmith@chef.io>