### PR TITLE
Update the bundled Chef Infra Client to 16.3.45

### DIFF
--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -32,7 +32,7 @@ override :postgresql, version: '9.3.18'
 override :ruby, version: "2.6.5"
 override :rubygems, version: "3.1.2" # rubygems ships its own bundler which may differ from bundler defined below and then we get double bundler which makes the omnibus environment unhappy. Make sure these versions match before bumping either.
 override :bundler, version: "2.1.2" # this must match the BUNDLED WITH in all the repo's Gemfile.locks
-override :'chef-gem', version: '14.14.29'
+override :'chef-gem', version: '16.3.45'
 override :'openssl-fips', version: '2.0.16'
 override :'omnibus-ctl', version: 'master'
 


### PR DESCRIPTION
Avoids double gems and should drop the overall package size.

Signed-off-by: Tim Smith <tsmith@chef.io>