### PR TITLE
Require Chef 14+ in omnibus now

### DIFF
--- a/omnibus/cookbooks/supermarket-builder/metadata.rb
+++ b/omnibus/cookbooks/supermarket-builder/metadata.rb
@@ -8,4 +8,4 @@ version          '1.0.0'
 depends          'yum-epel'
 depends          'omnibus'
 
-chef_version     '>= 13.0'
+chef_version     '>= 14.0'


### PR DESCRIPTION
I just bumped the omnibus cookbook to require 14 so we should require 14
here as well. It dropped 2 cookbook deps by removing build_essential

Signed-off-by: Tim Smith <tsmith@chef.io>