### PR TITLE
disambiguate columns used in query ordering

### DIFF
--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -26,11 +26,11 @@ class Cookbook < ApplicationRecord
   }
 
   ORDER_OPTIONS = {
-    "recently_updated" => Arel.sql("updated_at DESC"),
-    "recently_added" => Arel.sql("id DESC"),
-    "most_downloaded" => Arel.sql("(cookbooks.web_download_count + cookbooks.api_download_count) DESC, id ASC"),
-    "most_followed" => Arel.sql("cookbook_followers_count DESC, id ASC"),
-    "by_name" => Arel.sql("name ASC"),
+    "recently_updated" => Arel.sql("cookbooks.updated_at DESC"),
+    "recently_added" => Arel.sql("cookbooks.id DESC"),
+    "most_downloaded" => Arel.sql("(cookbooks.web_download_count + cookbooks.api_download_count) DESC, cookbooks.id ASC"),
+    "most_followed" => Arel.sql("cookbook_followers_count DESC, cookbooks.id ASC"),
+    "by_name" => Arel.sql("cookbooks.name ASC"),
   }.freeze
 
   scope :ordered_by, lambda { |option|

--- a/src/supermarket/spec/api/cookbooks_root_spec.rb
+++ b/src/supermarket/spec/api/cookbooks_root_spec.rb
@@ -51,5 +51,37 @@ describe "GET /api/v1/cookbooks" do
       expect(json_body["items"])
         .to match_array([redis_test_signature, redisio_test_signature])
     end
+
+    context "returns results for a user with ordering options" do
+      it "recently_updated" do
+        get "/api/v1/cookbooks?order=recently_updated&user=#{user.username}"
+
+        expect(json_body["total"]).to eql(2)
+      end
+
+      it "recently_added" do
+        get "/api/v1/cookbooks?order=recently_added&user=#{user.username}"
+
+        expect(json_body["total"]).to eql(2)
+      end
+
+      it "most_downloaded" do
+        get "/api/v1/cookbooks?order=most_downloaded&user=#{user.username}"
+
+        expect(json_body["total"]).to eql(2)
+      end
+
+      it "most_followed" do
+        get "/api/v1/cookbooks?order=most_followed&user=#{user.username}"
+
+        expect(json_body["total"]).to eql(2)
+      end
+
+      it "by_name" do
+        get "/api/v1/cookbooks?order=by_name&user=#{user.username}"
+
+        expect(json_body["total"]).to eql(2)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

Queries using the named ordering options and also joins with other tables were failing with:

    ActionView::Template::Error: PG::AmbiguousColumn:
    ERROR:  column reference "id" is ambiguous
    LINE 1: SELECT DISTINCT cookbook_followers_count, id AS alias_0, "c…

Database query was traced to these ordering options in the Cookbook scopes.

Added tests for the API route and query parameters that triggered these errors. Added tablenames to the column references to pass the tests.


## Related Issue

Fixes #1892

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- ~New feature (non-breaking change which adds functionality)~
- ~Breaking change (fix or feature that would cause existing functionality to change)~
- ~Chore (non-breaking change that does not add functionality or fix an issue)~

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- ~I have updated the documentation accordingly.~
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
