### PR TITLE
[omnibus] use YAML.dump to serialize simple hashes to disk

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/recipes/app.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/app.rb
@@ -36,7 +36,7 @@ link "#{node['supermarket']['app_directory']}/.env.production" do
 end
 
 file "#{node['supermarket']['var_directory']}/etc/database.yml" do
-  content({
+  content(YAML.dump({
     'production' => {
       'adapter' => 'postgresql',
       'database' => node['supermarket']['database']['name'],
@@ -46,7 +46,7 @@ file "#{node['supermarket']['var_directory']}/etc/database.yml" do
       'port' => node['supermarket']['database']['port'],
       'pool' => node['supermarket']['database']['pool'],
     },
-  }.to_yaml)
+  }))
   owner node['supermarket']['user']
   group node['supermarket']['group']
   mode '0600'


### PR DESCRIPTION
## Description

The data for this file resource's content is really a simple Ruby Hash built up from node attributes, not a node object itself. Instead of relying on the .to_yaml behavior previously patched onto Hash, use plain old Ruby YAML.dump with the Hash instead.

Resolves new "NoMethodError: undefined method 'to_yaml' for Hash" error when chefspec'ing.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
