### PR TITLE
drop support for RHEL6 builds

### DIFF
--- a/.expeditor/release.omnibus.yml
+++ b/.expeditor/release.omnibus.yml
@@ -5,8 +5,6 @@ test-path: omnibus/omnibus-test.sh
 fips-platforms:
   - el-*-x86_64
 builder-to-testers-map:
-  el-6-x86_64:
-    - el-6-x86_64
   el-7-x86_64:
     - el-7-x86_64
     - el-8-x86_64

--- a/omnibus/.kitchen.yml
+++ b/omnibus/.kitchen.yml
@@ -16,7 +16,6 @@ platforms:
   # for Ubuntu, only need earliest supported version for build
   # testing occurs on earliest supported and later in a different kitchen
   - name: ubuntu-16.04
-  - name: centos-6
   - name: centos-7
   - name: centos-8
 

--- a/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
+++ b/omnibus/cookbooks/omnibus-supermarket/.kitchen.yml
@@ -20,7 +20,6 @@ platforms:
   - name: ubuntu-16.04
   - name: ubuntu-18.04
   - name: ubuntu-20.04
-  - name: centos-6
   - name: centos-7
   - name: centos-8
   - name: amazonlinux-2


### PR DESCRIPTION
## Description

RHEL6 is coming up on end-of-life this month, November 2020. The RHEL6 builders for Supermarket packages are currently wedged and won't build. So, instead of investing a lot of labor in fixing them for an OS that is about to go out of support, let's stop building now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
