### PR TITLE
Make sure chefstyle and yard aren't in the package

### DIFF
--- a/omnibus/config/software/supermarket.rb
+++ b/omnibus/config/software/supermarket.rb
@@ -42,7 +42,7 @@ build do
          " --jobs #{workers}" \
          " --retry 3" \
          " --path=vendor/bundle" \
-         " --without development",
+         " --without development doc",
          env: env
   # This fails because we're installing Ruby C extensions in the wrong place!
   bundle "exec rake assets:precompile", env: env.merge('RAILS_ENV' => 'production')

--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -70,7 +70,6 @@ group :development do
 end
 
 group :test do
-  gem "chefstyle"
   gem "capybara"
   gem "capybara-screenshot"
   gem "database_cleaner"
@@ -82,6 +81,7 @@ group :test do
 end
 
 group :development, :test do
+  gem "chefstyle"
   gem "brakeman"
   gem "factory_bot_rails", require: false
   gem "faker"


### PR DESCRIPTION
Exclude doc from the bundle install and move chefstyle back to
development.

Signed-off-by: Tim Smith <tsmith@chef.io>