### PR TITLE
Changes Chef cookbooks text to Chef Infra Cookbooks as per issue

### DIFF
--- a/src/supermarket/app/views/pages/welcome.html.erb
+++ b/src/supermarket/app/views/pages/welcome.html.erb
@@ -9,7 +9,7 @@
   <% end %>
 
   <section class="sign_up_in">
-    <h2 class="text-center">Welcome to Supermarket. Find, explore and view Chef cookbooks for all of your ops needs.</h2>
+    <h2 class="text-center">Welcome to Supermarket. Find, explore and view Chef Infra Cookbooks for all of your ops needs.</h2>
 
     <p class="text-center">
       <%= link_to 'Sign Up For a Chef Account', chef_sign_up_url, class: 'button radius' %>

--- a/src/supermarket/spec/views/pages/welcome.html.erb_spec.rb
+++ b/src/supermarket/spec/views/pages/welcome.html.erb_spec.rb
@@ -1,5 +1,11 @@
 require "spec_helper"
 
 describe "pages/welcome.html.erb" do
+  it "has correct text" do
+    render
+    welcome_text = "Welcome to Supermarket. Find, explore and view Chef Infra Cookbooks for all of your ops needs."
+    expect(rendered).to have_selector("h2", text: welcome_text)
+  end
+
   it_behaves_like "community stats"
 end


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

Text changes on welcom.html.erb 

## Description
Changed text `Chef cookbooks` to `Chef Infra Cookbooks`

## Related Issue
https://github.com/chef/supermarket/issues/1972

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
