### PR TITLE
Changed text test-kitchen to Test Kitchen

### DIFF
--- a/src/supermarket/app/views/cookbooks/directory.html.erb
+++ b/src/supermarket/app/views/cookbooks/directory.html.erb
@@ -99,7 +99,7 @@
         </li>
 
         <li>
-          <%= link_to 'test-kitchen documentation', chef_docs_url('kitchen.html') %>
+          <%= link_to 'Test Kitchen documentation', chef_docs_url('kitchen.html') %>
         </li>
 
         <li>

--- a/src/supermarket/spec/views/cookbooks/directory.html.erb_spec.rb
+++ b/src/supermarket/spec/views/cookbooks/directory.html.erb_spec.rb
@@ -8,5 +8,11 @@ describe "cookbooks/directory.html.erb" do
     assign(:most_followed_cookbooks, [])
   end
 
+  it "has Test Kitchen text correct" do
+    render
+    test_kitchen_text = "Test Kitchen documentation"
+    expect(rendered).to have_selector("a[href]", text: test_kitchen_text)
+  end
+
   it_behaves_like "community stats"
 end


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

Text change - `test-kitchen` should be changed to `Test Kitchen` in page cookbooks-directory.

## Description
Change of text to `Test Kitchen` in page directory.html.erb to match the requirements

## Related Issue
https://github.com/chef/supermarket/issues/1974

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
