### PR TITLE
Changed link for chef dk in directory file

### DIFF
--- a/src/supermarket/app/views/cookbooks/directory.html.erb
+++ b/src/supermarket/app/views/cookbooks/directory.html.erb
@@ -107,7 +107,7 @@
         </li>
 
         <li>
-          <%= link_to 'Chef Development Kit (Chef DK)', chef_downloads_url('chef-dk') %>
+          <%= link_to 'Chef Workstation', chef_downloads_url('tools/workstation') %>
         </li>
 
         <li>

--- a/src/supermarket/spec/views/cookbooks/directory.html.erb_spec.rb
+++ b/src/supermarket/spec/views/cookbooks/directory.html.erb_spec.rb
@@ -14,5 +14,10 @@ describe "cookbooks/directory.html.erb" do
     expect(rendered).to have_selector("a[href]", text: test_kitchen_text)
   end
 
+  it "has workstation link pointing to correct url" do
+    render
+    expect(rendered).to have_link("Chef Workstation", href: "https://downloads.chef.io/tools/workstation")
+  end
+
   it_behaves_like "community stats"
 end


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

Chef Development Kit(Chef-DK) on cookbooks-directory page was pointing to wrong link. Corrected the same

## Description
Chef DK link now points to https://downloads.chef.io/tools/workstation as was mentioned in the issue

## Related Issue
https://github.com/chef/supermarket/issues/1975

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
