### PR TITLE
Remove provisioning driver from tools directory

### DIFF
--- a/src/supermarket/app/models/tool.rb
+++ b/src/supermarket/app/models/tool.rb
@@ -1,7 +1,7 @@
 class Tool < ApplicationRecord
   include PgSearch::Model
 
-  ALLOWED_TYPES = %w{knife_plugin ohai_plugin chef_tool handler provisioning_driver kitchen_driver powershell_module dsc_resource compliance_profile}.freeze
+  ALLOWED_TYPES = %w{knife_plugin ohai_plugin chef_tool handler kitchen_driver powershell_module dsc_resource compliance_profile}.freeze
 
   self.inheritance_column = nil
 


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dhsingh@progress.com>

## Description
- This change removes "Provisioning Driver" from tools directory from https://supermarket.chef.io/tools-directory
- Tested the change in my local dev setup
## Related Issue
Fixes https://github.com/chef/supermarket/issues/1968

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
