### PR TITLE
Changed name of allowed types to Chef Infra Handler

### DIFF
--- a/src/supermarket/app/models/tool.rb
+++ b/src/supermarket/app/models/tool.rb
@@ -1,7 +1,7 @@
 class Tool < ApplicationRecord
   include PgSearch::Model
 
-  ALLOWED_TYPES = %w{knife_plugin ohai_plugin chef_tool handler kitchen_driver powershell_module dsc_resource compliance_profile}.freeze
+  ALLOWED_TYPES = %w{knife_plugin ohai_plugin chef_tool chef_infra_handler kitchen_driver powershell_module dsc_resource compliance_profile}.freeze
 
   self.inheritance_column = nil
 


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

Renamed "handler" type to "Chef Infra Handler" 

## Description
This change will make sure user selects `Chef Infra Handler` while creating a tool

## Related Issue
https://github.com/chef/supermarket/issues/1970

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
