### PR TITLE
Added new url helper for progress.com and updated footer links

### DIFF
--- a/src/supermarket/app/helpers/custom_url_helper.rb
+++ b/src/supermarket/app/helpers/custom_url_helper.rb
@@ -9,12 +9,21 @@ module CustomUrlHelper
     ENV["CHEF_DOMAIN"] || "chef.io"
   end
 
+  def progress_domain
+    ENV["PROGRESS_DOMAIN"] || "progress.com"
+  end
+
   def chef_server_url
     ENV["CHEF_SERVER_URL"] || "https://api.chef.io"
   end
 
   def chef_www_url(extra = nil)
     url = ENV["CHEF_WWW_URL"] || "https://www.#{chef_domain}"
+    extra_dispatch(url, extra)
+  end
+
+  def progress_www_url(extra = nil)
+    url = ENV["CHEF_WWW_URL"] || "https://www.#{progress_domain}"
     extra_dispatch(url, extra)
   end
 

--- a/src/supermarket/app/views/layouts/application.html.erb
+++ b/src/supermarket/app/views/layouts/application.html.erb
@@ -69,9 +69,9 @@
         <footer class="footer">
           &copy; 2008&thinsp;&ndash;&thinsp;<%= Time.new.year %> Chef Software, Inc. All Rights Reserved.
           <br><br><%= link_to 'Code of Conduct', chef_docs_url('community_guidelines.html') %>
-          <%= link_to 'Terms and Conditions of Use', chef_www_url('terms-of-service') %>
-          <%= link_to 'Privacy Policy', chef_www_url('privacy-policy') %>
-          <%= link_to 'Trademark Policy', chef_www_url('trademark-policy') %>
+          <%= link_to 'Terms and Conditions of Use', progress_www_url('legal/terms-of-use') %>
+          <%= link_to 'Privacy Policy', progress_www_url('legal/privacy-policy') %>
+          <%= link_to 'Trademark Policy', progress_www_url('legal/trademarks') %>
           <%= link_to 'Status', chef_status_url %>
         </footer>
 

--- a/src/supermarket/spec/helpers/custom_url_helper_spec.rb
+++ b/src/supermarket/spec/helpers/custom_url_helper_spec.rb
@@ -14,6 +14,11 @@ describe CustomUrlHelper do
     expect(helper.chef_domain).to eql("chef.io")
   end
 
+  it "should have a default progress domain" do
+    expect(ENV["PROGRESS_DOMAIN"]).to be_nil
+    expect(helper.progress_domain).to eql("progress.com")
+  end
+
   it "should have a server url" do
     expect(ENV["CHEF_SERVER_URL"]).to be_nil
     expect(helper.chef_server_url).to eql("https://api.chef.io")


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

Updated the links in footer which were redirects to progress.com earlier

## Description
Footer links are currently pointing to chef.io which are re-directed to progress.com later. I updated the link address to point to progress ip only

## Related Issue
https://github.com/chef/supermarket/issues/1967

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
