### PR TITLE
Changes for removing .html from docs links

### DIFF
--- a/src/supermarket/app/views/cookbooks/directory.html.erb
+++ b/src/supermarket/app/views/cookbooks/directory.html.erb
@@ -61,13 +61,13 @@
       <h3>How do I use a cookbook?</h3>
       <p>Interact with cookbooks by using the <code>knife cookbook</code> commands.
       With <code>knife cookbook</code>, you can create, delete, show, list,
-      download and upload cookbooks. Read the <%= link_to 'knife cookbook commands documentation', chef_docs_url('knife_cookbook.html') %> for more information.</p>
+      download and upload cookbooks. Read the <%= link_to 'knife cookbook commands documentation', chef_docs_url('workstation/knife_cookbook') %> for more information.</p>
 
       <h3>How do I share a cookbook?</h3>
       <p>In order to share and interact with cookbooks on Supermarket, use the
-      <code>knife supermarket</code> commands. <%= link_to 'The documentation', chef_docs_url('knife_supermarket.html') %> for <code>knife supermarket</code> explains how to
+      <code>knife supermarket</code> commands. <%= link_to 'The documentation', chef_docs_url('workstation/knife_supermarket') %> for <code>knife supermarket</code> explains how to
       download, share, unshare, search, install and list cookbooks on Supermarket.
-      You can also interact with the <%= link_to 'Supermarket API', chef_docs_url('supermarket_api.html') %> directly.</p>
+      You can also interact with the <%= link_to 'Supermarket API', chef_docs_url('supermarket_api') %> directly.</p>
 
       <h3>How do I adopt a cookbook?</h3>
       <!-- <p><%#= link_to 'Click here', available_for_adoption_path %> to view the list of adoptable cookbooks.</p> -->
@@ -79,27 +79,27 @@
 
       <ul>
         <li>
-          <%= link_to 'About cookbooks', chef_docs_url('cookbooks.html') %>
+          <%= link_to 'About cookbooks', chef_docs_url('cookbooks') %>
         </li>
 
         <li>
-          <%= link_to 'About recipes', chef_docs_url('recipes.html') %>
+          <%= link_to 'About recipes', chef_docs_url('recipes') %>
         </li>
 
         <li>
-          <%= link_to 'Supermarket cookbooks API documentation', chef_docs_url('supermarket_api.html') %>
+          <%= link_to 'Supermarket cookbooks API documentation', chef_docs_url('supermarket_api') %>
         </li>
 
         <li>
-          <%= link_to 'Berkshelf documentation', chef_docs_url('berkshelf.html') %>
+          <%= link_to 'Berkshelf documentation', chef_docs_url('workstation/berkshelf') %>
         </li>
 
         <li>
-          <%= link_to 'knife documentation', chef_docs_url('knife.html') %>
+          <%= link_to 'knife documentation', chef_docs_url('workstation/knife') %>
         </li>
 
         <li>
-          <%= link_to 'Test Kitchen documentation', chef_docs_url('kitchen.html') %>
+          <%= link_to 'Test Kitchen documentation', chef_docs_url('workstation/kitchen') %>
         </li>
 
         <li>

--- a/src/supermarket/app/views/pages/dashboard.html.erb
+++ b/src/supermarket/app/views/pages/dashboard.html.erb
@@ -53,7 +53,7 @@
         <li>Share your cookbook with <code>knife supermarket share COOKBOOK_NAME CATEGORY (options)</code></li>
       </ol>
 
-      <p><%= link_to 'Read the full share docs.', chef_docs_url('knife_supermarket.html#share'), target: '_blank', rel: 'noopener' %></p>
+      <p><%= link_to 'Read the full share docs.', chef_docs_url('workstation/knife_supermarket#share'), target: '_blank', rel: 'noopener' %></p>
     <% end %>
 
     <h3>Cookbooks You Collaborate On</h3>

--- a/src/supermarket/app/views/pages/documentation.html.erb
+++ b/src/supermarket/app/views/pages/documentation.html.erb
@@ -11,7 +11,9 @@
       <li><a href="https://www.chef.io/blog/2015/03/16/using-chef-supermarket-a-guided-tour/">Using Chef Supermarket: A Guided Tour</a></li>
       <li><a href="https://www.chef.io/blog/2015/05/15/public-supermarket-the-insiders-tour/">Public Supermarket: The Insider's Tour</a></li>
       <li><a href="https://www.chef.io/blog/2015/12/31/a-supermarket-of-your-own-running-a-private-supermarket/">A Supermarket of Your Own: Running a Private Supermarket</a></li>
-      <li><a href="https://docs.chef.io/supermarket.html">Supermarket Docs</a></li>
+      <li>
+        <%= link_to 'Supermarket Docs', chef_docs_url('supermarket') %>
+      </li>
     </ul>
   </div>
 </div>

--- a/src/supermarket/app/views/pages/welcome.html.erb
+++ b/src/supermarket/app/views/pages/welcome.html.erb
@@ -40,10 +40,10 @@
           <%= link_to 'Read the Chef Docs', chef_docs_url, target: '_blank', rel: 'noopener' %>
         </li>
         <li>
-          <%= link_to 'Community Guidelines', chef_docs_url('community_guidelines.html'), target: '_blank', rel: 'noopener' %>
+          <%= link_to 'Community Guidelines', chef_docs_url('community_guidelines'), target: '_blank', rel: 'noopener' %>
         </li>
         <li>
-          <%= link_to 'How to Contribute', chef_docs_url('community_contributions.html'), target: '_blank', rel: 'noopener' %>
+          <%= link_to 'How to Contribute', chef_docs_url('community_contributions'), target: '_blank', rel: 'noopener' %>
         </li>
       </ul>
     </div>
@@ -51,7 +51,7 @@
       <h2>Share</h2>
       <ul>
         <li>
-          <%= link_to 'Share your cookbooks', chef_docs_url('knife_supermarket.html#share'), target: '_blank', rel: 'noopener' %>
+          <%= link_to 'Share your cookbooks', chef_docs_url('workstation/knife_supermarket#share'), target: '_blank', rel: 'noopener' %>
         </li>
         <li>
           <a href="http://community-slack.chef.io/">Join Chef Community Slack</a>


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Removed the .html from the docs links all over the app. 
Updated redirects such as /knife -> /workstation/knife as well.

## Related Issue
https://github.com/chef/supermarket/issues/1965

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
