### PR TITLE
Changes for sorting cookbooks with deprecated flag

### DIFF
--- a/src/supermarket/app/controllers/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/cookbooks_controller.rb
@@ -19,7 +19,7 @@ class CookbooksController < ApplicationController
   #   GET /cookbooks?order=recently_updated
   #
   def index
-    @cookbooks = Cookbook.includes(:cookbook_versions)
+    @cookbooks = Cookbook.includes(:cookbook_versions).order(:deprecated)
 
     @current_params = cookbook_index_params
 

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -26,11 +26,11 @@ class Cookbook < ApplicationRecord
   }
 
   ORDER_OPTIONS = {
-    "recently_updated" => Arel.sql("cookbooks.updated_at DESC"),
-    "recently_added" => Arel.sql("cookbooks.id DESC"),
-    "most_downloaded" => Arel.sql("(cookbooks.web_download_count + cookbooks.api_download_count) DESC, cookbooks.id ASC"),
-    "most_followed" => Arel.sql("cookbook_followers_count DESC, cookbooks.id ASC"),
-    "by_name" => Arel.sql("cookbooks.name ASC"),
+    "recently_updated" => Arel.sql("cookbooks.deprecated, cookbooks.updated_at DESC"),
+    "recently_added" => Arel.sql("cookbooks.deprecated, cookbooks.id DESC"),
+    "most_downloaded" => Arel.sql("cookbooks.deprecated, (cookbooks.web_download_count + cookbooks.api_download_count) DESC, cookbooks.id ASC"),
+    "most_followed" => Arel.sql("cookbooks.deprecated, cookbook_followers_count DESC, cookbooks.id ASC"),
+    "by_name" => Arel.sql("cookbooks.deprecated, cookbooks.name ASC"),
   }.freeze
 
   scope :ordered_by, lambda { |option|

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -5,6 +5,7 @@ describe CookbooksController do
     context "there are no parameters" do
       let!(:postgresql) { create(:cookbook, name: "postgresql") }
       let!(:mysql) { create(:cookbook, name: "mysql") }
+      let!(:dep_cookbook) { create(:cookbook, name: "dep_cookbook", deprecated: :true) }
 
       it "assigns @cookbooks" do
         get :index
@@ -20,6 +21,13 @@ describe CookbooksController do
       it "assigns @number_of_cookbooks" do
         get :index
         expect(assigns[:number_of_cookbooks]).to_not be_nil
+      end
+
+      it "orders @cookbooks by deprecated flag" do
+        get :index
+        expect(assigns[:cookbooks][0]).to eql(mysql)
+        expect(assigns[:cookbooks][1]).to eql(postgresql)
+        expect(assigns[:cookbooks][2]).to eql(dep_cookbook)
       end
     end
 

--- a/src/supermarket/spec/models/cookbook_spec.rb
+++ b/src/supermarket/spec/models/cookbook_spec.rb
@@ -725,16 +725,16 @@ describe Cookbook do
   describe ".ordered_by" do
     let!(:great) { create(:cookbook, name: "great") }
     let!(:cookbook) { create(:cookbook, name: "cookbook") }
+    let!(:deprecated_cookbook) { create(:cookbook, name: "deprecated_cookbook", deprecated: "true") }
 
     it "orders by name ascending by default" do
-      expect(Cookbook.ordered_by(nil).map(&:name)).to eql(%w{cookbook great})
+      expect(Cookbook.ordered_by(nil).map(&:name)).to eql(%w{cookbook great deprecated_cookbook})
     end
 
     it 'orders by updated_at descending when given "recently_updated"' do
       great.touch
-
       expect(Cookbook.ordered_by("recently_updated").map(&:name))
-        .to eql(%w{great cookbook})
+        .to eql(%w{great cookbook deprecated_cookbook})
     end
 
     it 'orders by created_at descending when given "recently_added"' do
@@ -748,31 +748,34 @@ describe Cookbook do
       cookbook.update(web_download_count: 5, api_download_count: 70)
 
       expect(Cookbook.ordered_by("most_downloaded").map(&:name))
-        .to eql(%w{great cookbook})
+        .to eql(%w{great cookbook deprecated_cookbook})
     end
 
     it 'orders by cookbook_followers_count when given "most_followed"' do
       great.update(cookbook_followers_count: 100)
       cookbook.update(cookbook_followers_count: 50)
+      deprecated_cookbook.update( cookbook_followers_count: 50)
 
       expect(Cookbook.ordered_by("most_followed").map(&:name))
-        .to eql(%w{great cookbook})
+        .to eql(%w{great cookbook deprecated_cookbook})
     end
 
     it "orders secondarily by id when cookbook follower counts are equal" do
       great.update(cookbook_followers_count: 100)
       cookbook.update(cookbook_followers_count: 100)
+      deprecated_cookbook.update(cookbook_followers_count: 100)
 
       expect(Cookbook.ordered_by("most_followed").map(&:name))
-        .to eql(%w{great cookbook})
+        .to eql(%w{great cookbook deprecated_cookbook})
     end
 
     it "orders secondarily by id when download counts are equal" do
       great.update(web_download_count: 5, api_download_count: 100)
       cookbook.update(web_download_count: 5, api_download_count: 100)
+      deprecated_cookbook.update(web_download_count: 5, api_download_count: 100)
 
       expect(Cookbook.ordered_by("most_followed").map(&:name))
-        .to eql(%w{great cookbook})
+        .to eql(%w{great cookbook deprecated_cookbook})
     end
   end
 


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

### Description

We are sorting cookbooks with deprecated boolean field. Which will make sure, cookbooks which are deprecated are always shown at the end of the list on view

### Issues Resolved
https://github.com/chef/supermarket/issues/1838

### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
