### PR TITLE
Fix S3_BUCKET validation failures in buildkite + improve error messages

### DIFF
--- a/omnibus/config/software/supermarket.rb
+++ b/omnibus/config/software/supermarket.rb
@@ -35,7 +35,6 @@ dependency "libarchive"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env.delete("S3_BUCKET") # s3 caching in buildkite includes this
 
   bundle "package --all --no-install"
 
@@ -45,8 +44,15 @@ build do
          " --path=vendor/bundle" \
          " --without development doc",
          env: env
+
+  # tas50 7/20/2021 note: Why do we set S3_REGION us-west-2 here?
+  # supermarket includes validation for s3 configurations set by the user to ensure that if either S3_BUCKET or S3_REGION
+  # are set that the other is also set. Currently buildkite sets S3_BUCKET and the workaround is to set this var that doesn't
+  # get used. I tried removing the var from the env above, but it's not actually set at that point :shrug:. Feel free
+  # to solve this in a better way.
+
   # This fails because we're installing Ruby C extensions in the wrong place!
-  bundle "exec rake assets:precompile", env: env.merge('RAILS_ENV' => 'production')
+  bundle "exec rake assets:precompile", env: env.merge('RAILS_ENV' => 'production', 'S3_REGION' => 'us-west-2')
 
   sync project_dir, "#{install_dir}/embedded/service/supermarket/",
     exclude: %w( .cookbooks .direnv .envrc .env.* .gitignore .kitchen*

--- a/omnibus/config/software/supermarket.rb
+++ b/omnibus/config/software/supermarket.rb
@@ -35,6 +35,7 @@ dependency "libarchive"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  env.delete("S3_BUCKET") # s3 caching in buildkite includes this
 
   bundle "package --all --no-install"
 

--- a/src/supermarket/app/lib/supermarket/s3_config.rb
+++ b/src/supermarket/app/lib/supermarket/s3_config.rb
@@ -17,7 +17,7 @@ module Supermarket
       all_s3_settings = REQUIRED_S3_VARS.all? { |key| environment[key].present? }
 
       if any_s3_settings && !all_s3_settings
-        raise IncompleteConfig.new "Got some, but not all, of the required S3 configs. Must provide #{REQUIRED_S3_VARS} to configure cookbook storage in an S3 bucket."
+        raise IncompleteConfig.new "Got some, but not all, of the required S3 configs. You provided: #{REQUIRED_S3_VARS & environment.keys}. You must provide #{REQUIRED_S3_VARS} to configure cookbook storage in an S3 bucket."
       end
       return true if all_s3_settings
 


### PR DESCRIPTION
Our buildkite pipeline sets this now for the s3 caching of artifacts.
This is new and is causing the logic that makes sure that we have all
the necessary S3 env vars set to fail. Nuke that env var during the
build so the logic doesn't fire.

Signed-off-by: Tim Smith <tsmith@chef.io>