### PR TITLE
Don't install berks now that it's in omnibus-toolchain

### DIFF
--- a/omnibus/config/software/supermarket-cookbooks.rb
+++ b/omnibus/config/software/supermarket-cookbooks.rb
@@ -23,7 +23,6 @@ build do
   cookbooks_path = "#{install_dir}/embedded/cookbooks"
   env = with_standard_compiler_flags(with_embedded_path)
 
-  gem "install berkshelf"
   command "berks vendor #{cookbooks_path}", env: env
 
   block do


### PR DESCRIPTION
The berks install is causing failures since it deps on chef/chef and
pulls in the latest which only works on Ruby 2.7+

Signed-off-by: Tim Smith <tsmith@chef.io>