### PR TITLE
Omniauth update gemfile and config changes to allow create session in dev env

### DIFF
--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -3,9 +3,9 @@ source "https://rubygems.org"
 gem "fieri", path: "engines/fieri"
 gem "rails", "~> 6.1.4"
 
-gem "omniauth"
+gem "omniauth", "~> 2.0.0"
 gem "omniauth-chef-oauth2"
-gem "omniauth-github"
+gem "omniauth-github", "~> 2.0.0"
 gem "omniauth-oauth2", "~> 1.7.1"
 gem "omniauth-rails_csrf_protection"
 

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -455,21 +455,22 @@ GEM
       plist (~> 3.1)
       train-core
       wmi-lite (~> 1.0)
-    omniauth (1.9.1)
+    omniauth (2.0.4)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
-    omniauth-chef-oauth2 (1.0.3)
-      omniauth (~> 1.0)
+      rack-protection
+    omniauth-chef-oauth2 (1.1.0)
+      omniauth (>= 1.9, < 3)
       omniauth-oauth2 (~> 1.0)
-    omniauth-github (1.1.2)
-      omniauth (~> 1.0)
-      omniauth-oauth2 (~> 1.1)
+    omniauth-github (2.0.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.7.1)
     omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
-    omniauth-rails_csrf_protection (0.1.2)
+    omniauth-rails_csrf_protection (1.0.0)
       actionpack (>= 4.2)
-      omniauth (>= 1.3.1)
+      omniauth (~> 2.0)
     paperclip (6.1.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
@@ -814,9 +815,9 @@ DEPENDENCIES
   newrelic_rpm
   nokogiri
   octokit (~> 4.16)
-  omniauth
+  omniauth (~> 2.0.0)
   omniauth-chef-oauth2
-  omniauth-github
+  omniauth-github (~> 2.0.0)
   omniauth-oauth2 (~> 1.7.1)
   omniauth-rails_csrf_protection
   paperclip
@@ -862,4 +863,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.1.4
+   2.2.15

--- a/src/supermarket/config/initializers/session_store.rb
+++ b/src/supermarket/config/initializers/session_store.rb
@@ -2,4 +2,5 @@
 
 Rails.application.config.session_store :cookie_store,
                                        key: "_supermarket_session",
-                                       secure: Supermarket::Host.secure_session_cookie?
+                                       secure: Rails.env.production? && \
+                                               Supermarket::Host.secure_session_cookie?


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

### Description

Upgraded Omniauth gem to 2.0.0 and related gem upgrade - omniauth-github and omniauth-oauth2
Changed the config file to allow session creation in dev mode as well. When session is not created in dev mode, its impossible to get through omniauth token verification

### Issues Resolved

https://github.com/chef/supermarket/issues/1903

### Check List

- [] New functionality includes tests
- [x] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
