### PR TITLE
Improve markdown rendering is changelogs / readmes

### DIFF
--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -8,6 +8,7 @@ gem "omniauth-chef-oauth2"
 gem "omniauth-github"
 gem "omniauth-oauth2", "~> 1.7.1"
 gem "omniauth-rails_csrf_protection"
+gem "coderay" #markdown doc - syntax highlighting
 
 gem "sidekiq", "~> 4.2"
 gem "sidekiq-cron"

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -790,6 +790,7 @@ DEPENDENCIES
   capybara-screenshot
   chef (~> 16.13)
   chefstyle
+  coderay
   compass-rails
   database_cleaner
   ddtrace

--- a/src/supermarket/app/helpers/markdown_helper.rb
+++ b/src/supermarket/app/helpers/markdown_helper.rb
@@ -2,14 +2,31 @@ module MarkdownHelper
   #
   # Make auto-links target=_blank
   #
+
   class SupermarketRenderer < Redcarpet::Render::Safe
     include ActionView::Helpers::TagHelper
 
     def initialize(extensions = {})
       super extensions.merge(
         link_attributes: { target: "_blank", rel: "noopener" },
-        with_toc_data: true
+        with_toc_data: true,
+        hard_wrap: true,
+        xhtml: true
       )
+    end
+
+    #Syntax highlighting using CodeRay library
+    def block_code(code, language)
+      if language.present?
+        CodeRay.scan(code, language).div
+      else
+        "<pre><code>#{code}</code></pre>"
+      end
+    end
+
+    #process doc to remove markdown comments as the same is not supported by RedCarpet
+    def remove_comments(raw_html)
+      raw_html.gsub(/&lt;!--(.*?)--&gt;/, "")
     end
 
     #
@@ -25,7 +42,7 @@ module MarkdownHelper
       # should be considered
       doc = Nokogiri::HTML::DocumentFragment.parse(html_document)
       doc = make_img_src_urls_protocol_relative(doc)
-      doc.to_s
+      remove_comments(doc.to_s)
     end
 
     private

--- a/src/supermarket/spec/helpers/markdown_helper_spec.rb
+++ b/src/supermarket/spec/helpers/markdown_helper_spec.rb
@@ -13,7 +13,20 @@ describe MarkdownHelper do
         ```
       CODEBLOCK
 
-      expect(helper.render_markdown(codeblock)).to match(/<pre><code>/)
+      expect(helper.render_markdown(codeblock)).to include("<div class=\"CodeRay\">\n  "\
+                                                            "<div class=\"code\"><pre>"\
+                                                            "$ bundle exec rake spec:all\n</pre>")
+    end
+
+    it "renders code block with syntax highlighting" do
+      codeblock = <<-CODEBLOCK.strip_heredoc
+        ```ruby
+        require 'redcarpet'
+        ```
+      CODEBLOCK
+
+      expect(helper.render_markdown(codeblock)).to include("<div class=\"CodeRay\">\n  "\
+                                                            "<div class=\"code\"><pre>require")
     end
 
     it "auto renders links with target blank" do
@@ -33,13 +46,13 @@ describe MarkdownHelper do
     expect(helper.render_markdown(table)).to match(/<table>/)
   end
 
-  it "doesn't adds br tags on hard wraps" do
+  it "adds br tags on hard wraps" do
     markdown = <<-HARDWRAP.strip_heredoc
       There is no hard
       wrap.
     HARDWRAP
 
-    expect(helper.render_markdown(markdown)).to_not match(/<br>/)
+    expect(helper.render_markdown(markdown)).to match(/<br>/)
   end
 
   it "doesn't emphasize underscored words" do
@@ -58,6 +71,10 @@ describe MarkdownHelper do
     expect(helper.render_markdown("Supermarket^2")).to match(/<sup>/)
   end
 
+  it "removes escaped comments" do
+    expect(helper.render_markdown("<!-- Comment --><p>Hello</p>")).to_not include("&lt;!-- Comment --&gt;")
+  end
+
   context "protocol in URLs for images get converted" do
     it "HTTP -> protocol-relative" do
       html = helper.render_markdown("![](http://img.example.com)")
@@ -68,6 +85,7 @@ describe MarkdownHelper do
       html = helper.render_markdown("![](https://img.example.com)")
       expect(html).to include('<img src="//img.example.com" alt="">')
     end
+
   end
 
   describe "to prevent XSS attacks" do


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

### Description

substituting html comments with blank string in changelog text for a cookbook. 

Updated RedCarpet implementation to match the github markdown rendering standards. Mainly focussed on below two points : - 
1. Syntax highlighting ( used Code-ray for same ) 
2. Delete html comments <!-- --> from the markdown content 

The above two points are also highlighted by @robbkidd  here -> https://github.com/chef/supermarket/issues/1321 

HTMLpipeline implementation could never be successfull. As its requiring a lot many behavioural changes as application is behaving as of now .. with some serious XSS attacks getting open like injection of javascript via href tag

### Issues Resolved

https://github.com/chef/supermarket/issues/1831

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
