### PR TITLE
Switch to the binary install of nodejs and install yarn

### DIFF
--- a/omnibus/config/software/supermarket.rb
+++ b/omnibus/config/software/supermarket.rb
@@ -24,7 +24,7 @@ dependency "cacerts"
 dependency "chef-gem"
 dependency "git"
 dependency "nginx"
-dependency "nodejs"
+dependency "nodejs-binary"
 dependency "postgresql"
 dependency "redis"
 dependency "ruby"
@@ -35,6 +35,7 @@ dependency "libarchive"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  env['PATH'] = "#{env['PATH']}:#{install_dir}/embedded/nodejs/bin"
 
   bundle "package --all --no-install"
 
@@ -44,6 +45,8 @@ build do
          " --path=vendor/bundle" \
          " --without development doc",
          env: env
+
+  command "npm install yarn -g", env: env
 
   # This fails because we're installing Ruby C extensions in the wrong place!
   bundle "exec rake assets:precompile", env: env.merge('RAILS_ENV' => 'production')

--- a/omnibus/cookbooks/omnibus-supermarket/Gemfile
+++ b/omnibus/cookbooks/omnibus-supermarket/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # This gemfile is currently used in the omnibus build for the -ctl command
 # Why is it here? Great question. This needs to get refactored away with the
@@ -13,4 +13,5 @@ gem 'inspec-bin'
 group :test do
   gem 'chefspec'
   gem 'chef', '< 17'
+  gem 'berkshelf'
 end

--- a/omnibus/cookbooks/omnibus-supermarket/Gemfile
+++ b/omnibus/cookbooks/omnibus-supermarket/Gemfile
@@ -1,3 +1,5 @@
+source "https://rubygems.org"
+
 # This gemfile is currently used in the omnibus build for the -ctl command
 # Why is it here? Great question. This needs to get refactored away with the
 # ctl command have its own gemspec.
@@ -10,4 +12,5 @@ gem 'inspec-bin'
 # including this group here
 group :test do
   gem 'chefspec'
+  gem 'chef', '< 17'
 end

--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -1,8 +1,5 @@
 source "https://rubygems.org"
 
-# Ruby version isn't specified here anymore, as it's pinned in Omnibus
-# https://github.com/chef/omnibus-supermarket/blob/master/config/projects/supermarket.rb
-
 gem "fieri", path: "engines/fieri"
 gem "rails", "~> 5.2.6"
 
@@ -45,7 +42,6 @@ gem "sass-globbing"
 gem "sass-rails"
 gem "sentry-raven", require: false
 gem "sitemap_generator"
-gem "sprockets"
 gem "statsd-ruby"
 gem "tomlrb"
 gem "uglifier"

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -763,7 +763,6 @@ DEPENDENCIES
   sitemap_generator
   spring
   spring-commands-rspec
-  sprockets
   statsd-ruby
   tomlrb
   uglifier


### PR DESCRIPTION
- nodejs-binary is newer, faster to install, and easier to remove
- install yarn to prevent the rake job from failing
- remove sprockets which is what this was all for since it's built into rails now and we don't need double dep declarations
- further fix the cookbook gemfile so the ctl command can install

Signed-off-by: Tim Smith <tsmith@chef.io>