### PR TITLE
Switch back to compiled nodejs but use 12.22.3

### DIFF
--- a/omnibus/Gemfile
+++ b/omnibus/Gemfile
@@ -5,7 +5,7 @@ gem 'omnibus', git: 'https://github.com/chef/omnibus.git'
 
 # Use Chef's software definitions. It is recommended that you write your own
 # software definitions, but you can clone/fork Chef's to get you started.
-gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software.git'
+gem 'omnibus-software', git: 'https://github.com/chef/omnibus-software.git', branch: "speedup_12"
 
 # Install artifactory. Used for publishing packages.
 gem 'artifactory'

--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: f6b11c27a4610070fc56e158550c3d470368f638
+  revision: 9fe2025b992b22bcad5135c9e61f209daea0d401
+  branch: speedup_12
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 8.0.0)
@@ -32,7 +33,7 @@ GEM
     ast (2.4.2)
     awesome_print (1.9.2)
     aws-eventstream (1.1.1)
-    aws-partitions (1.480.0)
+    aws-partitions (1.481.0)
     aws-sdk-core (3.118.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -143,7 +144,7 @@ GEM
     contracts (0.16.1)
     cookbook-omnifetch (0.11.1)
       mixlib-archive (>= 0.4, < 2.0)
-    cookstyle (7.15.2)
+    cookstyle (7.15.3)
       rubocop (= 1.18.4)
     diff-lcs (1.3)
     ed25519 (1.2.4)

--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -32,6 +32,7 @@ override :postgresql, version: '9.3.25'
 override :ruby, version: "2.6.8"
 override :rubygems, version: "3.1.2" # rubygems ships its own bundler which may differ from bundler defined below and then we get double bundler which makes the omnibus environment unhappy. Make sure these versions match before bumping either.
 override :bundler, version: "2.1.2" # this must match the BUNDLED WITH in all the repo's Gemfile.locks
+override :nodejs, version: "12.22.3"
 override :'chef-gem', version: '14.14.29'
 override :'openssl-fips', version: '2.0.16'
 override :'omnibus-ctl', version: 'master'

--- a/omnibus/config/software/supermarket.rb
+++ b/omnibus/config/software/supermarket.rb
@@ -24,7 +24,7 @@ dependency "cacerts"
 dependency "chef-gem"
 dependency "git"
 dependency "nginx"
-dependency "nodejs-binary"
+dependency "nodejs"
 dependency "postgresql"
 dependency "redis"
 dependency "ruby"
@@ -35,7 +35,6 @@ dependency "libarchive"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['PATH'] = "#{env['PATH']}:#{install_dir}/embedded/nodejs/bin"
 
   bundle "package --all --no-install"
 


### PR DESCRIPTION
Binary nodejs fails the supermarket-ctl reconfigure. This should work
there, but it will give us a nice new version and hopefully npm/yarn
work with that new version.

Signed-off-by: Tim Smith <tsmith@chef.io>