### PR TITLE
Fixed redirection errors identified by Brakeman

### DIFF
--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -63,6 +63,7 @@ group :development do
   gem "license_finder"
   gem "spring"
   gem "spring-commands-rspec"
+  gem "brakeman"
 end
 
 group :test do

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     bcrypt_pbkdf (1.1.0.rc1)
+    brakeman (5.1.1)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (2.18.0)
@@ -704,6 +705,7 @@ DEPENDENCIES
   and_feathers (>= 1.0.0.pre)
   and_feathers-gzipped_tarball (>= 1.0.0.pre)
   aws-sdk-s3
+  brakeman
   capybara
   capybara-screenshot
   chef

--- a/src/supermarket/app/controllers/api/v1/cookbook_versions_controller.rb
+++ b/src/supermarket/app/controllers/api/v1/cookbook_versions_controller.rb
@@ -27,6 +27,8 @@ class Api::V1::CookbookVersionsController < Api::V1Controller
     Cookbook.increment_counter(:api_download_count, @cookbook.id)
     Supermarket::Metrics.increment("cookbook.downloads.api")
 
+    # Ignore brakeman error: "Possible unprotected redirect"
+    # as this might be an external URL that needs to be considered along with the host URL
     redirect_to @cookbook_version.cookbook_artifact_url
   end
 end

--- a/src/supermarket/app/controllers/cookbook_versions_controller.rb
+++ b/src/supermarket/app/controllers/cookbook_versions_controller.rb
@@ -11,6 +11,8 @@ class CookbookVersionsController < ApplicationController
     Cookbook.increment_counter(:web_download_count, @cookbook.id)
     Supermarket::Metrics.increment("cookbook.downloads.web")
 
+    # Ignore brakeman error: "Possible unprotected redirect"
+    # as this might be an external URL that needs to be considered along with the host URL
     redirect_to @version.cookbook_artifact_url
   end
 

--- a/src/supermarket/app/controllers/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/cookbooks_controller.rb
@@ -137,7 +137,7 @@ class CookbooksController < ApplicationController
             "cookbook.updated"
           end
 
-    redirect_to @cookbook, notice: t(key, name: @cookbook.name)
+    redirect_to cookbook_path(@cookbook), notice: t(key, name: @cookbook.name)
   end
 
   #
@@ -183,14 +183,14 @@ class CookbooksController < ApplicationController
       CookbookDeprecatedNotifier.perform_async(@cookbook.id)
 
       redirect_to(
-        @cookbook,
+        cookbook_path(@cookbook),
         notice: t(
           "cookbook.deprecated",
           cookbook: @cookbook.name
         )
       )
     else
-      redirect_to @cookbook, notice: @cookbook.errors.full_messages.join(", ")
+      redirect_to cookbook_path(@cookbook), notice: @cookbook.errors.full_messages.join(", ")
     end
   end
 
@@ -205,7 +205,7 @@ class CookbooksController < ApplicationController
     @cookbook.update(deprecated: false, replacement: nil)
 
     redirect_to(
-      @cookbook,
+      cookbook_path(@cookbook),
       notice: t(
         "cookbook.undeprecated",
         cookbook: @cookbook.name
@@ -223,7 +223,7 @@ class CookbooksController < ApplicationController
     AdoptionMailer.delay.interest_email(@cookbook, current_user)
 
     redirect_to(
-      @cookbook,
+      cookbook_path(@cookbook),
       notice: t(
         "adoption.email_sent",
         cookbook_or_tool: @cookbook.name
@@ -243,7 +243,7 @@ class CookbooksController < ApplicationController
     @cookbook.update(featured: !@cookbook.featured)
 
     redirect_to(
-      @cookbook,
+      cookbook_path(@cookbook),
       notice: t(
         "cookbook.featured",
         cookbook: @cookbook.name,

--- a/src/supermarket/app/controllers/transfer_ownership_controller.rb
+++ b/src/supermarket/app/controllers/transfer_ownership_controller.rb
@@ -13,7 +13,7 @@ class TransferOwnershipController < ApplicationController
     recipient = User.find(transfer_ownership_params[:user_id])
 
     msg = @cookbook.transfer_ownership(current_user, recipient, add_owner_as_collaborator?)
-    redirect_to @cookbook, notice: t(msg, cookbook: @cookbook.name, user: recipient.username)
+    redirect_to cookbook_path(@cookbook), notice: t(msg, cookbook: @cookbook.name, user: recipient.username)
   end
 
   #

--- a/src/supermarket/config/brakeman.ignore
+++ b/src/supermarket/config/brakeman.ignore
@@ -1,0 +1,86 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "5151f802b89ff8ddb6226eddcff9095c7ca2a3564f37f3eb881e9531d1bca4c1",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/irc_logs_controller.rb",
+      "line": 44,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to((((\"https://botbot.me/freenode/\" + params[:channel]) + \"/\") + params.fetch(:date, nil)))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "IrcLogsController",
+        "method": "show"
+      },
+      "user_input": "params.fetch(:date, nil)",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "6ca20351e1a6bb8a70147de1124661cf42e7d0de7c3fe421affb5b193f30dc32",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/api/v1/cookbook_versions_controller.rb",
+      "line": 32,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Cookbook.with_name(params[:cookbook]).first!.get_version!(params[:version]).cookbook_artifact_url)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Api::V1::CookbookVersionsController",
+        "method": "download"
+      },
+      "user_input": "Cookbook.with_name(params[:cookbook]).first!.get_version!(params[:version]).cookbook_artifact_url",
+      "confidence": "High",
+      "note": ""
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "8bd00293b526f062a8591f1f50f1af66e1acfb8522bf5734b0377fcc8eba8146",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/irc_logs_controller.rb",
+      "line": 42,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to((\"https://botbot.me/freenode/\" + params[:channel]))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "IrcLogsController",
+        "method": "show"
+      },
+      "user_input": "params[:channel]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "ace2d27e7a1866cead6fabfebcf7eaa0202456a5b848a736d4e47b7d79707a93",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/cookbook_versions_controller.rb",
+      "line": 16,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Cookbook.with_name(params[:cookbook_id]).first!.get_version!(params[:version]).cookbook_artifact_url)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CookbookVersionsController",
+        "method": "download"
+      },
+      "user_input": "Cookbook.with_name(params[:cookbook_id]).first!.get_version!(params[:version]).cookbook_artifact_url",
+      "confidence": "High",
+      "note": ""
+    }
+  ],
+  "updated": "2021-08-03 17:58:38 +0530",
+  "brakeman_version": "5.1.1"
+}


### PR DESCRIPTION
Fixed vulnerable redirection errors by Brakeman. Added non vulnerabilities in brakeman ignore list.

Signed-off-by: Rajesh Paul <rajesh.paul@progress.com>

### Description

Have fixed the real vulnerabilities of redirection by adding only path instead of complete URL with host. Also identified the non vulnerabilities and added them to the Brakeman ignore list.

### Issues Resolved

[https://github.com/chef/supermarket/issues/2016](https://github.com/chef/supermarket/issues/2016)

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
