### PR TITLE
Switch from inspec to inspec-core

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/Gemfile
+++ b/omnibus/cookbooks/omnibus-supermarket/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 # Why is it here? Great question. This needs to get refactored away with the
 # ctl command have its own gemspec.
 
-gem 'inspec'
+gem 'inspec-core'
 gem 'inspec-bin'
 gem 'mini_racer', '~> 0.3.1', platforms: :ruby
 


### PR DESCRIPTION
This reduces our install size by over 100 megs by removing
azure/google/aws sdks that we're not actually using

Signed-off-by: Tim Smith <tsmith@chef.io>