### PR TITLE
Skip the test group when installing the ctl cookbook

### DIFF
--- a/omnibus/config/software/supermarket-ctl.rb
+++ b/omnibus/config/software/supermarket-ctl.rb
@@ -26,7 +26,7 @@ source path: "cookbooks/omnibus-supermarket"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 
-  bundle "install --binstubs", env: env
+  bundle "install --binstubs --without test", env: env
 
   block do
     erb source: "supermarket-ctl.erb",


### PR DESCRIPTION
This avoids bringing in a big pile of extra stuff

Signed-off-by: Tim Smith <tsmith@chef.io>