### PR TITLE
Use Chef Infra Client 16.14 in supermarket-ctl

### DIFF
--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -30,9 +30,7 @@ build_iteration 1
 
 override :postgresql, version: '9.3.25'
 override :ruby, version: "2.7.4"
-override :rubygems, version: "3.1.2" # rubygems ships its own bundler which may differ from bundler defined below and then we get double bundler which makes the omnibus environment unhappy. Make sure these versions match before bumping either.
-override :bundler, version: "2.1.2" # this must match the BUNDLED WITH in all the repo's Gemfile.locks
-override :'chef-gem', version: '14.14.29'
+override :'chef-gem', version: '16.14.1'
 override :'openssl-fips', version: '2.0.16'
 override :'omnibus-ctl', version: 'master'
 override :openssl, version: '1.0.2y'

--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -28,9 +28,9 @@ install_dir "#{default_root}/#{name}"
 build_version   IO.read(File.expand_path("../../../../VERSION", __FILE__)).strip
 build_iteration 1
 
+# NOTE: see the omnibus-supermarket cookbook gemfile for controlling the infra client version
 override :postgresql, version: '9.3.25'
 override :ruby, version: "2.7.4"
-override :'chef-gem', version: '16.14.1'
 override :'openssl-fips', version: '2.0.16'
 override :'omnibus-ctl', version: 'master'
 override :openssl, version: '1.0.2y'

--- a/omnibus/config/software/supermarket-ctl.rb
+++ b/omnibus/config/software/supermarket-ctl.rb
@@ -18,7 +18,6 @@ name "supermarket-ctl"
 license :project_license
 
 dependency "omnibus-ctl"
-dependency "chef-gem"
 dependency "runit"
 
 source path: "cookbooks/omnibus-supermarket"

--- a/omnibus/cookbooks/omnibus-supermarket/Gemfile
+++ b/omnibus/cookbooks/omnibus-supermarket/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 # Why is it here? Great question. This needs to get refactored away with the
 # ctl command have its own gemspec.
 
+gem 'chef', '~> 16.14'
+gem 'chef-bin', '~> 16.14'
 gem 'inspec-core'
 gem 'inspec-bin'
 gem 'mini_racer', '~> 0.3.1', platforms: :ruby
@@ -13,6 +15,5 @@ gem 'mini_racer', '~> 0.3.1', platforms: :ruby
 # including this group here
 group :test do
   gem 'chefspec'
-  gem 'chef', '< 17'
   gem 'berkshelf'
 end


### PR DESCRIPTION
This avoids EOL warnings in the ctl commands.

Signed-off-by: Tim Smith <tsmith@chef.io>