### PR TITLE
Add .bundle back to the supermarket install as possible

### DIFF
--- a/omnibus/config/software/supermarket.rb
+++ b/omnibus/config/software/supermarket.rb
@@ -50,6 +50,6 @@ build do
   sync project_dir, "#{install_dir}/embedded/service/supermarket/",
     exclude: %w( .cookbooks .direnv .envrc .env.* .gitignore .kitchen*
                  app/assets/**/branding coverage log node_modules pkg
-                 public/system spec tmp docs .bundle .rubocop.yml Berksfile
+                 public/system spec tmp docs .rubocop.yml Berksfile
                  docker-compose.yml Guardfile )
 end


### PR DESCRIPTION
See if this fixes the build

https://buildkite.com/chef/chef-supermarket-master-omnibus-adhoc/builds/146#3c1ba9e2-d573-4ff7-8802-6b5666c528e7

Signed-off-by: Tim Smith <tsmith@chef.io>