### PR TITLE
Add a cleanup definition for all the gem cache junk

### DIFF
--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -48,6 +48,7 @@ dependency "version-manifest"
 
 # remove lots of ruby clutter we don't need
 dependency "ruby-cleanup"
+dependency "more-ruby-cleanup-supermarket"
 
 exclude "**/.git"
 exclude "**/bundler/git"

--- a/omnibus/config/software/more-ruby-cleanup-supermarket.rb
+++ b/omnibus/config/software/more-ruby-cleanup-supermarket.rb
@@ -1,0 +1,36 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "more-ruby-cleanup-supermarket"
+
+skip_transitive_dependency_licensing true
+license :project_license
+
+source path: "#{project.files_path}/#{name}"
+
+dependency "ruby"
+
+build do
+  block "Delete bundler git cache, docs, and build info" do
+    vendor_dir = File.expand_path("#{install_dir}/embedded/service/supermarket/vendor/")
+
+    remove_directory "#{vendor_dir}/bundle/ruby/*/build_info"
+    remove_directory "#{vendor_dir}/bundle/ruby/*/cache"
+    remove_directory "#{vendor_dir}/bundle/ruby/*/doc"
+    remove_directory "#{vendor_dir}/cache"
+  end
+end


### PR DESCRIPTION
This should drop the install size by 70 megs

Signed-off-by: Tim Smith <tsmith@chef.io>