### PR TITLE
Added prompt before delete action for collaborator

### DIFF
--- a/src/supermarket/app/views/profile/edit.html.erb
+++ b/src/supermarket/app/views/profile/edit.html.erb
@@ -76,7 +76,12 @@
               <tr>
                 <td><%= link_to collaborator.resourceable.name, collaborator.resourceable %></td>
                 <td><%= collaborator.resourceable.class.name %></td>
-                <td class="text-right"><%= link_to 'Remove Myself as a Collaborator', collaborator_path(collaborator), remote: true, method: :delete, class: 'button tiny alert radius', rel: 'remove_collaboration' %></td>
+                <td class="text-right"><%= link_to 'Remove Myself as a Collaborator',
+                collaborator_path(collaborator), remote: true, method: :delete,
+                data: {confirm: "Are you sure you want to remove yourself as a collaborator "\
+                "from the cookbook #{collaborator.resourceable.name} ? You will not be able to add yourself back without the help of the "\
+                "cookbook owner."},
+                class: 'button tiny alert radius', rel: 'remove_collaboration' %></td>
               </tr>
             <% end %>
           <% end %>


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

### Description

There was a need to show a prompt to user for confirmation before he goes ahead and delete himself as collaborator from Edit profile page

### Issues Resolved

https://github.com/chef/supermarket/issues/2140

### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
