### PR TITLE
Update the ruby release in the rubocop configs to 2.7

### DIFF
--- a/src/supermarket/.rubocop.yml
+++ b/src/supermarket/.rubocop.yml
@@ -5,7 +5,7 @@ Rails:
   Enabled: true
 AllCops:
   NewCops: disable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     - db/**/*
     - engines/**/*

--- a/src/supermarket/engines/fieri/.rubocop.yml
+++ b/src/supermarket/engines/fieri/.rubocop.yml
@@ -5,7 +5,7 @@ Rails:
   Enabled: true
 AllCops:
   NewCops: disable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     - db/**/*
     - vendor/**/*


### PR DESCRIPTION
We're on Ruby 2.7 now so we should target Ruby 2.7

Signed-off-by: Tim Smith <tsmith@chef.io>