### PR TITLE
Changes for progress url being picked from wrong ENV variable

### DIFF
--- a/src/supermarket/app/helpers/custom_url_helper.rb
+++ b/src/supermarket/app/helpers/custom_url_helper.rb
@@ -23,7 +23,7 @@ module CustomUrlHelper
   end
 
   def progress_www_url(extra = nil)
-    url = ENV["CHEF_WWW_URL"] || "https://www.#{progress_domain}"
+    url = ENV["PROGRESS_WWW_URL"] || "https://www.#{progress_domain}"
     extra_dispatch(url, extra)
   end
 

--- a/src/supermarket/spec/helpers/custom_url_helper_spec.rb
+++ b/src/supermarket/spec/helpers/custom_url_helper_spec.rb
@@ -36,6 +36,18 @@ describe CustomUrlHelper do
     it_should_behave_like "a url with extra pieces"
   end
 
+  describe "prgress www url" do
+    let(:meth) { :progress_www_url }
+    let(:url) { "https://www.progress.com" }
+
+    it "should have a www url that uses the default domain" do
+      expect(ENV["PROGRESS_WWW_URL"]).to be_nil
+      expect(helper.send(meth)).to eql(url)
+    end
+
+    it_should_behave_like "a url with extra pieces"
+
+  end
   describe "blog url" do
     let(:meth) { :chef_blog_url }
     let(:url) { "https://blog.chef.io/" }


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

### Description

Supermarket production env is setting value for this env variable ENV[CHEF_WWW_URL] to `chef.io`. Since this env variable is getting used at some other place in application too, I am introducing a new env variable - ENV[PROGRESS_WWW_URL] which will have a value as `www.progress.com`  and will resolve error we are getting in footer url

### Issues Resolved
https://github.com/chef/supermarket/issues/2155

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
