### PR TITLE
Hide nginx server header from response

### DIFF
--- a/omnibus/config/software/supermarket.rb
+++ b/omnibus/config/software/supermarket.rb
@@ -21,7 +21,8 @@ source path: File.expand_path('../../../../src/supermarket', project.filepath)
 
 dependency "cacerts"
 dependency "git"
-dependency "nginx"
+# dependency "nginx"
+dependency "openresty"
 dependency "postgresql"
 dependency "redis"
 dependency "ruby"

--- a/omnibus/config/software/supermarket.rb
+++ b/omnibus/config/software/supermarket.rb
@@ -21,7 +21,6 @@ source path: File.expand_path('../../../../src/supermarket', project.filepath)
 
 dependency "cacerts"
 dependency "git"
-# dependency "nginx"
 dependency "openresty"
 dependency "postgresql"
 dependency "redis"

--- a/omnibus/cookbooks/omnibus-supermarket/templates/nginx.conf.erb
+++ b/omnibus/cookbooks/omnibus-supermarket/templates/nginx.conf.erb
@@ -37,6 +37,7 @@ http {
   <% end %>
 
   server_tokens off;
+  more_clear_headers Server;
   add_header X-Clacks-Overhead "GNU Terry Pratchett";
 
   sendfile <%= @nginx['sendfile'] %>;

--- a/omnibus/cookbooks/omnibus-supermarket/test/integration/default/inspec/controls/install-check.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/test/integration/default/inspec/controls/install-check.rb
@@ -85,7 +85,7 @@ control 'proxy' do
   describe "http GET to Port #{property['supermarket']['nginx']['non_ssl_port']}" do
     subject { http("http://localhost:#{property['supermarket']['nginx']['non_ssl_port']}") }
     it 'should not include server version number in response headers' do
-      expect(subject.headers.server).to.be_nil
+      expect(subject.headers.server).to be_nil
     end
   end
 
@@ -97,7 +97,7 @@ control 'proxy' do
 
     describe http("https://#{property['supermarket']['fqdn']}:#{property['supermarket']['nginx']['ssl_port']}", ssl_verify: false) do
       it 'should not include server version number in response headers' do
-        expect(subject.headers.server).to.be_nil
+        expect(subject.headers.server).to be_nil
       end
 
       its('headers.keys') { should include('strict-transport-security') }

--- a/omnibus/cookbooks/omnibus-supermarket/test/integration/default/inspec/controls/install-check.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/test/integration/default/inspec/controls/install-check.rb
@@ -85,7 +85,7 @@ control 'proxy' do
   describe "http GET to Port #{property['supermarket']['nginx']['non_ssl_port']}" do
     subject { http("http://localhost:#{property['supermarket']['nginx']['non_ssl_port']}") }
     it 'should not include server version number in response headers' do
-      expect(subject.headers.server).to cmp('nginx')
+      expect(subject.headers.server).to cmp(nil)
     end
   end
 
@@ -97,7 +97,7 @@ control 'proxy' do
 
     describe http("https://#{property['supermarket']['fqdn']}:#{property['supermarket']['nginx']['ssl_port']}", ssl_verify: false) do
       it 'should not include server version number in response headers' do
-        expect(subject.headers.server).to cmp('nginx')
+        expect(subject.headers.server).to cmp(nil)
       end
 
       its('headers.keys') { should include('strict-transport-security') }

--- a/omnibus/cookbooks/omnibus-supermarket/test/integration/default/inspec/controls/install-check.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/test/integration/default/inspec/controls/install-check.rb
@@ -85,7 +85,7 @@ control 'proxy' do
   describe "http GET to Port #{property['supermarket']['nginx']['non_ssl_port']}" do
     subject { http("http://localhost:#{property['supermarket']['nginx']['non_ssl_port']}") }
     it 'should not include server version number in response headers' do
-      expect(subject.headers.server).to cmp(nil)
+      expect(subject.headers.server).to.be_nil
     end
   end
 
@@ -97,7 +97,7 @@ control 'proxy' do
 
     describe http("https://#{property['supermarket']['fqdn']}:#{property['supermarket']['nginx']['ssl_port']}", ssl_verify: false) do
       it 'should not include server version number in response headers' do
-        expect(subject.headers.server).to cmp(nil)
+        expect(subject.headers.server).to.be_nil
       end
 
       its('headers.keys') { should include('strict-transport-security') }


### PR DESCRIPTION
### Description

- Removed nginx and added openresty
- Hide server header from API response

### Issues Resolved

- Removed nginx header from API response([#1978](https://app.zenhub.com/workspaces/sustaining-engineering-progress-60c9e8f0307f65000e50585a/issues/chef/supermarket/1978))

### Check List

- [X] New functionality includes tests
- [X] All buildkite tests pass
- [X] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
