### PR TITLE
made contributing.md file name check case insensitive in the cookbook source_url repo

### DIFF
--- a/src/supermarket/engines/fieri/app/models/contributing_file_worker.rb
+++ b/src/supermarket/engines/fieri/app/models/contributing_file_worker.rb
@@ -26,11 +26,11 @@ class ContributingFileWorker < SourceRepoWorker
     return true if repo.blank?
 
     begin
-      octokit_client.contents(repo, path: "CONTRIBUTING.md")
-      # if found, does not fail the metric
-      false
-    rescue Octokit::NotFound
-      # if not found, does fail the metric
+      repo_contents = octokit_client.contents(repo)
+      # if found then returns false, and does not fail the metric
+      return !repo_contents.any? {|file| file[:name] =~ /^contributing.md$/i}
+    rescue Octokit::InvalidRepository, Octokit::NotFound
+      # if repository not found, does fail the metric
       true
     end
   end


### PR DESCRIPTION


Signed-off-by: Rajesh Paul <rajesh.paul@progress.com>

### Description

made contributing.md file name check case insensitive in the repo given in source url of cookbooks for reflecting correctly in cookbook quality metric

### Issues Resolved

#1837 

### Check List

- [ ] New functionality includes tests
- [X] All buildkite tests pass
- [X] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
