### PR TITLE
Added headers for avoiding auto reply mails wherever we are sending m…

### DIFF
--- a/src/supermarket/app/mailers/application_mailer.rb
+++ b/src/supermarket/app/mailers/application_mailer.rb
@@ -1,3 +1,8 @@
 class ApplicationMailer < ActionMailer::Base
   layout "mailer"
+
+  def auto_reply_headers_off
+    headers("Auto-Submitted" => "auto-generated")
+    headers("X-Auto-Response-Suppress" => "OOF")
+  end
 end

--- a/src/supermarket/app/mailers/collaborator_mailer.rb
+++ b/src/supermarket/app/mailers/collaborator_mailer.rb
@@ -9,6 +9,8 @@ class CollaboratorMailer < ApplicationMailer
     @resource = collaborator.resourceable
     @to = collaborator.user.email
 
+    auto_reply_headers_off
+
     mail(to: @to, subject: "You have been added as a collaborator to the #{@resource.name} #{@resource.class.name}")
   end
 end

--- a/src/supermarket/app/mailers/cookbook_mailer.rb
+++ b/src/supermarket/app/mailers/cookbook_mailer.rb
@@ -14,6 +14,8 @@ class CookbookMailer < ApplicationMailer
     @email_preference = user.email_preference_for("New cookbook version")
     @to = user.email
 
+    auto_reply_headers_off
+
     mail(to: @to, subject: "A new version of the #{@cookbook_version.name} cookbook has been released")
   end
 
@@ -28,6 +30,8 @@ class CookbookMailer < ApplicationMailer
     @name = name
     @email_preference = user.email_preference_for("Cookbook deleted")
     @to = user.email
+
+    auto_reply_headers_off
 
     mail(to: @to, subject: "The #{name} cookbook has been deleted")
   end
@@ -51,6 +55,8 @@ class CookbookMailer < ApplicationMailer
     if @replacement_cookbook
       subject += " in favor of the #{@replacement_cookbook.name} cookbook"
     end
+
+    auto_reply_headers_off
 
     mail(to: @to, subject: subject)
   end


### PR DESCRIPTION
…ails in bulk

Signed-off-by: smriti <sgarg@msystechnologies.com>

Have added mail headers so that no auto-reply is sent in case of automated emails from supermarket

### Issues Resolved

https://github.com/chef/supermarket/issues/2169

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
