### PR TITLE
Rajeshpaul38/remove omnibus artifact vendor cache dir/1951

### DIFF
--- a/omnibus/config/software/more-ruby-cleanup-supermarket.rb
+++ b/omnibus/config/software/more-ruby-cleanup-supermarket.rb
@@ -32,7 +32,14 @@ build do
     vendor_ruby_dir = File.expand_path("#{install_dir}/embedded/service/supermarket/vendor/bundle/ruby/*")
 
     remove_directory "#{vendor_ruby_dir}/build_info"
-    remove_directory "#{vendor_ruby_dir}/bundle/ruby/*/cache"
-    remove_directory "#{vendor_ruby_dir}/bundle/ruby/*/doc"
+    # scanning for individual ruby version directory and
+    # then deleting the target folders under that as
+    # remove_directory doesn't work for wildcards
+    Dir.glob("#{vendor_ruby_dir}/bundle/ruby/*").each do |ruby_version_dir|
+      puts "removing cache under: #{ruby_version_dir}"
+      remove_directory "#{ruby_version_dir}/cache"
+      puts "removing doc under: #{ruby_version_dir}"
+      remove_directory "#{ruby_version_dir}/doc"
+    end
   end
 end

--- a/omnibus/config/software/more-ruby-cleanup-supermarket.rb
+++ b/omnibus/config/software/more-ruby-cleanup-supermarket.rb
@@ -35,7 +35,7 @@ build do
     # scanning for individual ruby version directory and
     # then deleting the target folders under that as
     # remove_directory doesn't work for wildcards
-    Dir.glob("#{vendor_ruby_dir}/bundle/ruby/*").each do |ruby_version_dir|
+    Dir.glob(vendor_ruby_dir).each do |ruby_version_dir|
       puts "removing cache under: #{ruby_version_dir}"
       remove_directory "#{ruby_version_dir}/cache"
       puts "removing doc under: #{ruby_version_dir}"


### PR DESCRIPTION
### Description

- Fixed the way cache directory can be deleted under ruby version directory in omnibus artifact.

Wildcard(*) doesn't work with `remove_directory`. Hence iterating over the directory to identify individual ruby version directory to delete specific folders under each ruby version.

### Issues Resolved

#1951 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
