### PR TITLE
Update mixlib-archive requirement from ~> 0.4 to >= 0.4, < 2.0 in /sr…

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         working-directory: src/supermarket
-        ruby-version: 2.6
+        ruby-version: 2.7
         bundler-cache: true
     - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
     - name: run chefstyle
@@ -28,7 +28,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         working-directory: src/supermarket/engines/fieri
-        ruby-version: 2.6
+        ruby-version: 2.7
         bundler-cache: true
     - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
     - name: run chefstyle

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up ruby 2.6
+      - name: Set up ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
           working-directory: src/supermarket
-          ruby-version: 2.6
+          ruby-version: 2.7
           bundler-cache: true
       - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
       - name: create database schema
@@ -65,11 +65,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up ruby 2.6
+      - name: Set up ruby 2.7
         uses: ruby/setup-ruby@v1
         with:
           working-directory: src/supermarket/engines/fieri
-          ruby-version: 2.6
+          ruby-version: 2.7
           bundler-cache: true
       - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
       - name: run specs

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     fieri (0.0.1)
       dotenv-rails
       foodcritic (~> 16.3)
-      mixlib-archive (~> 0.4)
+      mixlib-archive (>= 0.4, < 2.0)
       octokit (~> 4.16)
       rails (>= 6.1, < 7)
       ruby-filemagic
@@ -864,4 +864,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-  2.1.4
+   2.1.4

--- a/src/supermarket/engines/fieri/Gemfile.lock
+++ b/src/supermarket/engines/fieri/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     fieri (0.0.1)
       dotenv-rails
       foodcritic (~> 16.3)
-      mixlib-archive (~> 0.4)
+      mixlib-archive (>= 0.4, < 2.0)
       octokit (~> 4.16)
       rails (>= 6.1, < 7)
       ruby-filemagic

--- a/src/supermarket/engines/fieri/fieri.gemspec
+++ b/src/supermarket/engines/fieri/fieri.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "dotenv-rails"
   s.add_dependency "foodcritic", "~> 16.3"
-  s.add_dependency "mixlib-archive", "~> 0.4"
+  s.add_dependency "mixlib-archive", ">= 0.4", "< 2.0"
   s.add_dependency "octokit", "~> 4.16" # 4.16+ fixes deprecations in auth
   s.add_dependency "rails", [">= 6.1", "< 7"]
   s.add_dependency "ruby-filemagic"


### PR DESCRIPTION
…c/supermarket/engines/fieri

Signed-off-by: Dheeraj Singh Dubey <dhsingh@progress.com>

### Description

- Update mixlib-archive requirement from ~> 0.4 to >= 0.4, < 2.0 in /src/supermarket/engines/fieri
- Update ruby from 2.6 to 2.7

### Issues Resolved

Dependabot PR https://github.com/chef/supermarket/pull/1926

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
