### PR TITLE
Changes for Content security policy to allow inline css

### DIFF
--- a/src/supermarket/config/initializers/content_security_policy.rb
+++ b/src/supermarket/config/initializers/content_security_policy.rb
@@ -10,7 +10,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.img_src     :self, :https, :data
   policy.object_src  :none
   policy.script_src  :self, :https
-  policy.style_src   :self, :https
+  policy.style_src   :self, :https, :unsafe_inline
 
   # Specify URI for violation reports
   # policy.report_uri "/csp-violation-report-endpoint"


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

### Description

Constent security policy is stopping inline css to function. We need to allow usage of inline css for the app UI to work , dropdowns were not rendering due to the same error 

### Issues Resolved
https://github.com/chef/supermarket/issues/2254

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
