### PR TITLE
"Chef versions" in cookbook view should be "Required Chef Infra Client".

### DIFF
--- a/src/supermarket/app/views/cookbooks/_sidebar.html.erb
+++ b/src/supermarket/app/views/cookbooks/_sidebar.html.erb
@@ -91,7 +91,7 @@
     <p><%= version.license %></p>
 
     <% if version.chef_versions.present? %>
-      <h4><i class="fa fa-key"></i> Chef Versions</h4>
+      <h4><i class="fa fa-key"></i> Required Chef Infra Client</h4>
       <p><%= versions_string(version.chef_versions) %></p>
     <% end %>
 


### PR DESCRIPTION
Signed-off-by: antima-gupta <agupta@msystechnologies.com>

### Description

- Updated Chef Versions text to Required Chef Infra Client.

### Issues Resolved

#2251 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
