### PR TITLE
Recipe change to create supermarket as system user

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
@@ -46,7 +46,10 @@ if node['supermarket']['chef_server_url'] && node['supermarket']['chef_oauth2_ur
   node.default['supermarket']['chef_oauth2_url'] = node['supermarket']['chef_server_url']
 end
 
-user node['supermarket']['user']
+user node['supermarket']['user'] do
+  system true
+  shell '/bin/false'
+end
 
 group node['supermarket']['group'] do
   members [node['supermarket']['user']]

--- a/omnibus/cookbooks/omnibus-supermarket/spec/recipes/config_spec.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/spec/recipes/config_spec.rb
@@ -5,7 +5,7 @@ describe 'omnibus-supermarket::config' do
   automatic_attributes['memory']['total'] = '16000MB'
 
   it 'creates the supermarket user' do
-    expect(chef_run).to create_user('supermarket')
+    expect(chef_run).to create_user('supermarket').with(shell: '/bin/false', system: true)
   end
 
   it 'creates the supermarket group' do


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

### Description

Supermarket user created as part of build installation has to be a system user. Changed the recipe in omnibus-supermarket cookbook to create user as system-user
[
![Screenshot from 2021-10-27 12-18-05](https://user-images.githubusercontent.com/78783383/139019566-cd864fdb-503b-43a2-be61-5006155f931a.png)
](url)

Recipe already throws error in case group `supermarket` exists on the system already. As per the issue that was also the concern

![Screenshot from 2021-10-27 12-16-27](https://user-images.githubusercontent.com/78783383/139019679-b9fd6214-d80b-4afa-9996-92f127da69ac.png)

### Issues Resolved

https://github.com/chef/supermarket/issues/1179

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
