### PR TITLE
Changes for Cookbook count to be included in total items search api

### DIFF
--- a/src/supermarket/app/controllers/api/v1/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/api/v1/cookbooks_controller.rb
@@ -69,7 +69,7 @@ class Api::V1::CookbooksController < Api::V1Controller
       params.fetch(:q, nil)
     ).offset(@start).limit(@items)
 
-    @total = @results.count(:all)
+    @total = Cookbook.count
   end
 
   #

--- a/src/supermarket/spec/api/cookbook_search_spec.rb
+++ b/src/supermarket/spec/api/cookbook_search_spec.rb
@@ -47,7 +47,7 @@ describe "GET /api/v1/search" do
   it "handles the start and items params" do
     search_response = {
       "items" => [redisio_test_signature],
-      "total" => 1,
+      "total" => 2,
       "start" => 1,
     }
 

--- a/src/supermarket/spec/controllers/api/v1/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/api/v1/cookbooks_controller_spec.rb
@@ -13,6 +13,11 @@ describe Api::V1::CookbooksController do
   it_behaves_like "an API v1 controller"
 
   describe "#index" do
+
+    before :each do
+      ENV["API_ITEM_LIMIT"] = "0"
+    end
+
     it "orders the cookbooks by their name by default" do
       get :index, format: :json
 
@@ -251,10 +256,10 @@ describe Api::V1::CookbooksController do
       expect(assigns[:results]).to include(redis)
     end
 
-    it "sends the total number of search results to the view" do
+    it "sends the total number of cookbooks present in system to the view" do
       get :search, params: { q: "redis", format: :json }
 
-      expect(assigns[:total]).to eql(2)
+      expect(assigns[:total]).to eql(5)
     end
 
     it "searches based on the query" do

--- a/src/supermarket/spec/controllers/api/v1/tools_controller_spec.rb
+++ b/src/supermarket/spec/controllers/api/v1/tools_controller_spec.rb
@@ -12,6 +12,10 @@ describe Api::V1::ToolsController do
       create(:tool, name: "berkshelf")
     end
 
+    before :each do
+      ENV["API_ITEM_LIMIT"] = "0"
+    end
+
     it "responds with a 200" do
       get :index, format: :json
 


### PR DESCRIPTION
…uery

Signed-off-by: smriti <sgarg@msystechnologies.com>

Currently total that is included as part of the search api call is the total number of records retrieved as part of search. I have changed it to return total number of cookbooks in the system. 

### Issues Resolved

https://github.com/chef/supermarket/issues/1827

### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
