### PR TITLE
Allows dots in cookbook names

### DIFF
--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -115,7 +115,7 @@ class Cookbook < ApplicationRecord
 
   # Validations
   # --------------------
-  validates :name, presence: true, uniqueness: { case_sensitive: false }, format: /\A[\w_-]+\z/i # rubocop:disable Rails/UniqueValidationWithoutIndex
+  validates :name, presence: true, uniqueness: { case_sensitive: false }, format: /\A[\w\._-]+\z/i # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates :lowercase_name, presence: true, uniqueness: true
   validates :cookbook_versions, presence: true
   validates :source_url, url: { allow_blank: true }

--- a/src/supermarket/spec/models/cookbook_spec.rb
+++ b/src/supermarket/spec/models/cookbook_spec.rb
@@ -111,8 +111,8 @@ describe Cookbook do
       expect(cookbook.errors[:name]).to be_empty
     end
 
-    it "allows letters, numbers, dashes, and underscores in cookbook names" do
-      cookbook = Cookbook.new(name: "Cookbook_-1")
+    it "allows letters, numbers, dashes, dots, and underscores in cookbook names" do
+      cookbook = Cookbook.new(name: "Cookbook_.-1")
       cookbook.valid?
 
       expect(cookbook.errors[:name]).to be_empty


### PR DESCRIPTION
### Description

Creating a cookbook with a dot in the name is totally fine, and having a dot in a URL on the web is totally fine too. This commit allows dots in name in the supermarket.

A very good example of a usecase for this is the netplan packages in Ubuntu: There are two packages, one named 'netplan', and another one named 'netplan.io'. Both aren't addressing the same purpose so a dedicated cookbook for each of those packages is required. Reflecting the package names in the supermarket will avoid confusions to the users

With this commit, a cookbook URL like https://supermarket.chef.io/cookbooks/netplan.io will be allowed.

### Issues Resolved

None

### Check List

- [x] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
