### PR TITLE
Policyfile change to default and first tab in cookbook page

### DIFF
--- a/src/supermarket/app/views/cookbooks/_installs.html.erb
+++ b/src/supermarket/app/views/cookbooks/_installs.html.erb
@@ -29,12 +29,12 @@
 
   <div class="tabs-content">
     <% if current_user && current_user.install_preference.present? %>
-      <div class="content <%= %w(berkshelf librarian).include? current_user.install_preference ? 'active' : '' %>" id="berkshelf">
-        <pre class="install">cookbook '<%= cookbook.name %>', <% if version == cookbook.latest_cookbook_version %>'~&gt;<% else %>'=<% end %> <%= version.version %>'</pre>
-      </div>
-
       <div class="content <%= current_user.install_preference == 'policyfile' ? 'active' : '' %>" id="policyfile">
         <pre class="install">cookbook '<%= cookbook.name %>', <% if version == cookbook.latest_cookbook_version %>'~&gt;<% else %>'=<% end %> <%= version.version %>', :supermarket</pre>
+      </div>
+
+      <div class="content <%= %w(berkshelf librarian).include? current_user.install_preference ? 'active' : '' %>" id="berkshelf">
+        <pre class="install">cookbook '<%= cookbook.name %>', <% if version == cookbook.latest_cookbook_version %>'~&gt;<% else %>'=<% end %> <%= version.version %>'</pre>
       </div>
 
       <div class="content <%= current_user.install_preference == 'knife' ? 'active' : '' %>" id="knife">
@@ -42,12 +42,12 @@
         <pre class="install">knife supermarket download <%= cookbook.name %></pre>
       </div>
     <% else %>
-      <div class="content active" id="berkshelf">
-        <pre class="install">cookbook '<%= cookbook.name %>', <% if version == cookbook.latest_cookbook_version %>'~&gt;<% else %>'=<% end %> <%= version.version %>'</pre>
+      <div class="content active" id="policyfile">
+        <pre class="install">cookbook '<%= cookbook.name %>', <% if version == cookbook.latest_cookbook_version %>'~&gt;<% else %>'=<% end %> <%= version.version %>', :supermarket</pre>
       </div>
 
-      <div class="content" id="policyfile">
-        <pre class="install">cookbook '<%= cookbook.name %>', <% if version == cookbook.latest_cookbook_version %>'~&gt;<% else %>'=<% end %> <%= version.version %>', :supermarket</pre>
+      <div class="content" id="berkshelf">
+        <pre class="install">cookbook '<%= cookbook.name %>', <% if version == cookbook.latest_cookbook_version %>'~&gt;<% else %>'=<% end %> <%= version.version %>'</pre>
       </div>
 
       <div class="content" id="knife">

--- a/src/supermarket/app/views/cookbooks/_installs.html.erb
+++ b/src/supermarket/app/views/cookbooks/_installs.html.erb
@@ -1,12 +1,12 @@
 <div class="installs" data-update-url="<%= update_install_preference_profile_url %>">
   <dl data-tab data-options="deep_linking:true; scroll_to_content: false;" class="<%= 'persist-install-method' if current_user %>">
     <% if current_user && current_user.install_preference.present? %>
-      <dd class="<%= %w(berkshelf librarian).include? current_user.install_preference ? 'active' : '' %>">
-        <a href="#berkshelf" class="button tiny secondary">Berkshelf</a>
-      </dd>
-
       <dd class="<%= current_user.install_preference == 'policyfile' ? 'active' : '' %>">
         <a href="#policyfile" class="button tiny secondary">Policyfile</a>
+      </dd>
+
+      <dd class="<%= %w(berkshelf librarian).include? current_user.install_preference ? 'active' : '' %>">
+        <a href="#berkshelf" class="button tiny secondary">Berkshelf</a>
       </dd>
 
       <dd class="<%= current_user.install_preference == 'knife' ? 'active' : '' %>">
@@ -14,11 +14,11 @@
       </dd>
     <% else %>
       <dd class="active">
-        <a href="#berkshelf" class="button tiny secondary">Berkshelf</a>
+        <a href="#policyfile" class="button tiny secondary">Policyfile</a>
       </dd>
 
       <dd>
-        <a href="#policyfile" class="button tiny secondary">Policyfile</a>
+        <a href="#berkshelf" class="button tiny secondary">Berkshelf</a>
       </dd>
 
       <dd>

--- a/src/supermarket/spec/views/cookbooks/show.html.erb_spec.rb
+++ b/src/supermarket/spec/views/cookbooks/show.html.erb_spec.rb
@@ -67,7 +67,7 @@ describe "cookbooks/show.html.erb" do
       expect(rendered).to have_selector("textarea", text: test_kitchen_text)
     end
 
-     it "has policyfile, berkshelf and knife tabs rendered" do
+    it "has policyfile, berkshelf and knife tabs rendered" do
       render
       expect(rendered).to have_selector("div", id: "policyfile")
       expect(rendered).to have_selector("div", id: "berkshelf")

--- a/src/supermarket/spec/views/cookbooks/show.html.erb_spec.rb
+++ b/src/supermarket/spec/views/cookbooks/show.html.erb_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-# require_relative "../../../lib/supermarket/authentication.rb"
 
 describe "cookbooks/show.html.erb" do
 
@@ -67,7 +66,13 @@ describe "cookbooks/show.html.erb" do
       test_kitchen_text = cookbook.cookbook_deprecation_reason
       expect(rendered).to have_selector("textarea", text: test_kitchen_text)
     end
+
+     it "has policyfile, berkshelf and knife tabs rendered" do
+      render
+      expect(rendered).to have_selector("div", id: 'policyfile')
+      expect(rendered).to have_selector("div", id: 'berkshelf')
+      expect(rendered).to have_selector("div", id: 'knife')
+    end
   end
 
 end
-

--- a/src/supermarket/spec/views/cookbooks/show.html.erb_spec.rb
+++ b/src/supermarket/spec/views/cookbooks/show.html.erb_spec.rb
@@ -69,9 +69,9 @@ describe "cookbooks/show.html.erb" do
 
      it "has policyfile, berkshelf and knife tabs rendered" do
       render
-      expect(rendered).to have_selector("div", id: 'policyfile')
-      expect(rendered).to have_selector("div", id: 'berkshelf')
-      expect(rendered).to have_selector("div", id: 'knife')
+      expect(rendered).to have_selector("div", id: "policyfile")
+      expect(rendered).to have_selector("div", id: "berkshelf")
+      expect(rendered).to have_selector("div", id: "knife")
     end
   end
 


### PR DESCRIPTION
Signed-off-by: Manick Vel <mkumaravel@msystechnologies.com>

### Description

This issue requires Policyfile tab to be placed at first and by default ahead of Berkshelf in the cookbooks directory - cookbook page. Before this change, Bershelf was meant to be the default and first tab. 

### Issues Resolved

https://github.com/chef/supermarket/issues/2252

### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [] PR title is a worthy inclusion in the CHANGELOG
