### PR TITLE
Allow adding reason to cookbooks when deprecated

### DIFF
--- a/src/supermarket/app/controllers/cookbooks_controller.rb
+++ b/src/supermarket/app/controllers/cookbooks_controller.rb
@@ -185,8 +185,8 @@ class CookbooksController < ApplicationController
     authorize! @cookbook
 
     replacement_cookbook_name = cookbook_deprecation_params[:cookbook][:replacement]
-
-    if @cookbook.deprecate(replacement_cookbook_name)
+    cookbook_deprecation_reason = cookbook_deprecation_params[:cookbook][:deprecation_reason]
+    if @cookbook.deprecate(replacement_cookbook_name, cookbook_deprecation_reason)
       CookbookDeprecatedNotifier.perform_async(@cookbook.id)
 
       redirect_to(
@@ -209,7 +209,7 @@ class CookbooksController < ApplicationController
   def undeprecate
     authorize! @cookbook
 
-    @cookbook.update(deprecated: false, replacement: nil)
+    @cookbook.update(deprecated: false, replacement: nil, deprecation_reason: nil)
 
     redirect_to(
       cookbook_path(@cookbook),
@@ -301,7 +301,7 @@ class CookbooksController < ApplicationController
   end
 
   def cookbook_deprecation_params
-    params.permit(cookbook: [:replacement])
+    params.permit(cookbook: [:replacement, :deprecation_reason])
   end
 
   def render_follow_button

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -399,11 +399,7 @@ class Cookbook < ApplicationRecord
   end
 
   def cookbook_deprecation_reason
-    if self.deprecation_reason.present?
-      self.deprecation_reason
-    else
-      I18n.t("cookbook.default_deprecation_reason", name: self.name)
-    end
+    deprecation_reason.presence || I18n.t("cookbook.default_deprecation_reason", name: name)
   end
 
   private

--- a/src/supermarket/app/models/cookbook.rb
+++ b/src/supermarket/app/models/cookbook.rb
@@ -372,7 +372,7 @@ class Cookbook < ApplicationRecord
   # @return [Boolean] whether or not the cookbook was successfully deprecated
   #   and  saved
   #
-  def deprecate(replacement_cookbook_name = "")
+  def deprecate(replacement_cookbook_name = "", deprecation_reason = "")
     replacement_cookbook = Cookbook.find_by name: replacement_cookbook_name
 
     if replacement_cookbook.present? && replacement_cookbook.deprecated?
@@ -381,6 +381,7 @@ class Cookbook < ApplicationRecord
     end
 
     self.deprecated = true
+    self.deprecation_reason = deprecation_reason
     self.replacement = replacement_cookbook if replacement_cookbook.present?
     save
   end
@@ -395,6 +396,14 @@ class Cookbook < ApplicationRecord
   #
   def deprecate_search(query)
     Cookbook.search(query).where(deprecated: false).where.not(id: id)
+  end
+
+  def cookbook_deprecation_reason
+    if self.deprecation_reason.present?
+      self.deprecation_reason
+    else
+      I18n.t("cookbook.default_deprecation_reason", name: self.name)
+    end
   end
 
   private

--- a/src/supermarket/app/views/cookbook_mailer/cookbook_deprecated_email.html.erb
+++ b/src/supermarket/app/views/cookbook_mailer/cookbook_deprecated_email.html.erb
@@ -1,6 +1,7 @@
 <p>The <%= link_to @cookbook.name, cookbook_url(@cookbook) %> cookbook has been
    deprecated.</p>
-
+<p>Author provided reason for deprecation:</p>
+<p><%= @cookbook.cookbook_deprecation_reason %></p>
 <% if @replacement_cookbook -%>
 <p>The owner recommends using the <%= link_to @replacement_cookbook.name, cookbook_url(@replacement_cookbook) %>
    cookbook.</p>

--- a/src/supermarket/app/views/cookbook_mailer/cookbook_deprecated_email.text.erb
+++ b/src/supermarket/app/views/cookbook_mailer/cookbook_deprecated_email.text.erb
@@ -1,5 +1,6 @@
 The <%= @cookbook.name %> cookbook [<%= cookbook_url(@cookbook) %>] has been deprecated.
-
+<p>Author provided reason for deprecation:</p>
+<p><%= @cookbook.cookbook_deprecation_reason %></p>
 <% if @replacement_cookbook -%>
 The owner recommends using the <%= @replacement_cookbook.name %> cookbook [ <%= cookbook_url(@replacement_cookbook) %> ].
 <% end -%>

--- a/src/supermarket/app/views/cookbooks/_main.html.erb
+++ b/src/supermarket/app/views/cookbooks/_main.html.erb
@@ -5,10 +5,9 @@
         <i class="fa fa-exclamation-triangle"></i> The <%= cookbook.name %>
         cookbook has been deprecated
       </h2>
+      <p class="deprecation-copy"> Author provided reason for deprecation: </p>
+      <p class="deprecation-copy"><%= cookbook.cookbook_deprecation_reason %></p>
       <p class="deprecation-copy">
-      The <%= cookbook.name %> cookbook has been deprecated and is no longer
-      being maintained by its authors.  Use of the <%= cookbook.name %>
-      cookbook is no longer recommended.
       <% if cookbook.replacement.present? %>
         You may find that the <%= link_to cookbook.replacement.name, cookbook.replacement %>
         cookbook is a suitable alternative.

--- a/src/supermarket/app/views/cookbooks/_manage_cookbook.html.erb
+++ b/src/supermarket/app/views/cookbooks/_manage_cookbook.html.erb
@@ -69,7 +69,7 @@
           </div>
           <div class="small-12 columns">
             <%= f.label :deprecation_reason %>
-            <%= f.text_area :deprecation_reason, class: '', placeholder: 'Reason of deprecation', value: cookbook.cookbook_deprecation_reason %>
+            <%= f.text_area :deprecation_reason, class: 'form-control', placeholder: 'Reason of deprecation', value: cookbook.cookbook_deprecation_reason, rows: 3 %>
           </div>
           <div class="medium-3 columns">
             <%= f.submit 'Deprecate', class: 'button radius postfix submit-deprecation' %>

--- a/src/supermarket/app/views/cookbooks/_manage_cookbook.html.erb
+++ b/src/supermarket/app/views/cookbooks/_manage_cookbook.html.erb
@@ -64,10 +64,14 @@
 
       <%= form_for cookbook, url: deprecate_cookbook_path(cookbook), method: :put do |f| %>
         <div class="row collapse">
-          <div class="small-9 columns">
+          <div class="small-12 columns">
             <%= f.hidden_field :replacement, class: 'cookbook-deprecate', 'data-url' => deprecate_search_cookbook_path(cookbook) %>
           </div>
-          <div class="small-3 columns">
+          <div class="small-12 columns">
+            <%= f.label :deprecation_reason %>
+            <%= f.text_area :deprecation_reason, class: '', placeholder: 'Reason of deprecation', value: cookbook.cookbook_deprecation_reason %>
+          </div>
+          <div class="medium-3 columns">
             <%= f.submit 'Deprecate', class: 'button radius postfix submit-deprecation' %>
           </div>
         </div>

--- a/src/supermarket/app/views/cookbooks/_sidebar.html.erb
+++ b/src/supermarket/app/views/cookbooks/_sidebar.html.erb
@@ -67,9 +67,7 @@
           </li>
         <% end %>
       <% else %>
-        <li data-tooltip class="has-tip cookbook_no_platform_icon" title="Not specified">
-          <span class="fa fa-question-circle"></span>
-        </li>
+        <p>None Specified</p>
       <% end %>
     </ul>
 
@@ -100,6 +98,6 @@
       <p><%= versions_string(version.ohai_versions) %></p>
     <% end %>
 
-    <%= link_to "Download Cookbook", { action: 'download' }, class: 'button secondary radius expand button_download_cookbook' %>
+    <%= link_to "Download Cookbook", download_cookbook_path(cookbook.name), class: 'button secondary radius expand button_download_cookbook' %>
   </div>
 </div>

--- a/src/supermarket/config/locales/en.yml
+++ b/src/supermarket/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
     not_found: "The %{name} cookbook was not found."
     version_not_found: "Version %{version} of %{name} cookbook was not found."
     quality_metric_pass_rate_tip: "the percentage of passing quality metrics"
+    default_deprecation_reason: "The %{name} cookbook has been deprecated and is no longer being maintained by its authors.  Use of the %{name} cookbook is no longer recommended."
   contributor:
     removed: "Contributor removed."
   contributor_requests:

--- a/src/supermarket/db/migrate/20211021105430_add_deprecation_reason_to_cookbooks.rb
+++ b/src/supermarket/db/migrate/20211021105430_add_deprecation_reason_to_cookbooks.rb
@@ -1,0 +1,5 @@
+class AddDeprecationReasonToCookbooks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :cookbooks, :deprecation_reason, :string
+  end
+end

--- a/src/supermarket/db/schema.rb
+++ b/src/supermarket/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_30_065034) do
+ActiveRecord::Schema.define(version: 2021_10_21_105430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -64,7 +64,6 @@ ActiveRecord::Schema.define(version: 2021_08_30_065034) do
     t.integer "user_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "ccla_signature_id", null: false
     t.index ["organization_id", "user_id"], name: "index_contributor_requests_on_organization_id_and_user_id", unique: true
   end
 
@@ -115,7 +114,7 @@ ActiveRecord::Schema.define(version: 2021_08_30_065034) do
     t.datetime "updated_at"
     t.string "tarball_file_name"
     t.string "tarball_content_type"
-    t.integer "tarball_file_size"
+    t.bigint "tarball_file_size"
     t.datetime "tarball_updated_at"
     t.text "readme", default: "", null: false
     t.string "readme_extension", default: "", null: false
@@ -152,8 +151,10 @@ ActiveRecord::Schema.define(version: 2021_08_30_065034) do
     t.boolean "up_for_adoption"
     t.boolean "privacy"
     t.integer "badges_mask", default: 0, null: false
+    t.string "deprecation_reason"
     t.index ["lowercase_name"], name: "index_cookbooks_on_lowercase_name", unique: true
     t.index ["name"], name: "index_cookbooks_on_name"
+    t.index ["replacement_id"], name: "index_cookbooks_on_replacement_id"
     t.index ["user_id"], name: "index_cookbooks_on_user_id"
   end
 

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -661,6 +661,7 @@ describe CookbooksController do
     let!(:cookbook) { create(:cookbook, owner: user) }
     let!(:other_cookbook) { create(:cookbook, owner: user) }
     let!(:replacement_cookbook) { create(:cookbook) }
+    let!(:deprecation_reason) {"This cookbook is deprecated."}
 
     context "cookbook owner" do
       context "no replacement" do
@@ -740,6 +741,17 @@ describe CookbooksController do
                   replacement: replacement_cookbook,
                 } })
           end.to change(CookbookDeprecatedNotifier.jobs, :size).by(1)
+        end
+
+        it "deprecates the cookbook with the deprecation_reason" do
+          put(:deprecate, params: { id: cookbook, cookbook: {
+                deprecation_reason: deprecation_reason,
+              } })
+
+          cookbook.reload
+
+          expect(cookbook.deprecated).to eql(true)
+          expect(cookbook.deprecation_reason).to eql(deprecation_reason)
         end
       end
 

--- a/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
+++ b/src/supermarket/spec/controllers/cookbooks_controller_spec.rb
@@ -661,7 +661,7 @@ describe CookbooksController do
     let!(:cookbook) { create(:cookbook, owner: user) }
     let!(:other_cookbook) { create(:cookbook, owner: user) }
     let!(:replacement_cookbook) { create(:cookbook) }
-    let!(:deprecation_reason) {"This cookbook is deprecated."}
+    let!(:deprecation_reason) { "This cookbook is deprecated." }
 
     context "cookbook owner" do
       context "no replacement" do

--- a/src/supermarket/spec/features/cookbook_undeprecation_spec.rb
+++ b/src/supermarket/spec/features/cookbook_undeprecation_spec.rb
@@ -15,6 +15,6 @@ feature "cookbook owners can undeprecate a cookbook" do
   end
 
   it "it no longer displays a deprecation notice" do
-    expect(page).to have_no_content("#{cookbook.name} cookbook has been deprecated")
+    expect(page).to have_content("#{cookbook.name} is no longer deprecated.")
   end
 end

--- a/src/supermarket/spec/models/cookbook_spec.rb
+++ b/src/supermarket/spec/models/cookbook_spec.rb
@@ -333,6 +333,35 @@ describe Cookbook do
       end
     end
 
+    context "deprecate with reason and replacement is valid" do
+      let!(:replacement_cookbook) { create(:cookbook, name: "mild_curry") }
+      let!(:deprecation_reason) { "This is cookbook is deprecated." }
+
+      it "returns true" do
+        result = cookbook.deprecate(replacement_cookbook.name, deprecation_reason)
+        expect(result).to eql(true)
+      end
+
+      it "sets the deprecated attribute to true" do
+        cookbook.deprecate(replacement_cookbook.name, deprecation_reason)
+
+        expect(cookbook.deprecated?).to eql(true)
+      end
+
+      it "sets the deprecation reason" do
+        cookbook.deprecate(replacement_cookbook.name, deprecation_reason)
+
+        expect(cookbook.deprecation_reason).to eql(deprecation_reason)
+      end
+
+      it "sets the replacement" do
+        cookbook.deprecate(replacement_cookbook.name)
+
+        expect(cookbook.replacement).to eql(replacement_cookbook)
+        expect(replacement_cookbook.replaces).to include(cookbook)
+      end
+    end
+
     context "replacement cookbook is deprecated" do
       let!(:replacement_cookbook) do
         create(

--- a/src/supermarket/spec/views/cookbook_mailer/cookbook_deprecated_email.html.erb_spec.rb
+++ b/src/supermarket/spec/views/cookbook_mailer/cookbook_deprecated_email.html.erb_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+describe "cookbook_mailer/cookbook_deprecated_email.html.erb" do
+	context "renders mailer page" do
+		let!(:current_user) { create(:user, first_name: "test_user") }
+		let!(:cookbook) {
+      create(
+        :cookbook,
+        name: "test_cookbook",
+        user_id: current_user.id
+      )
+    }
+    let!(:replacement_cookbook) { create(:cookbook, name: "test_cookbook1") }
+		before(:each) do
+			cookbook.deprecate(replacement_cookbook, "test descreption")
+			assign(:cookbook, cookbook)
+			assign(:replacement_cookbook, replacement_cookbook)
+			assign(:email_preference, current_user.email_preference_for("Cookbook deprecated"))
+		end
+
+		it "has cookbook name rendered" do
+      render
+      expect(rendered).to have_selector("p", text: cookbook.name)
+    end
+
+    it "has cookbook deprecation reason rendered" do
+      render
+      expect(rendered).to have_selector("p", text: cookbook.cookbook_deprecation_reason)
+    end
+	end
+end

--- a/src/supermarket/spec/views/cookbook_mailer/cookbook_deprecated_email.html.erb_spec.rb
+++ b/src/supermarket/spec/views/cookbook_mailer/cookbook_deprecated_email.html.erb_spec.rb
@@ -2,6 +2,8 @@ require "spec_helper"
 describe "cookbook_mailer/cookbook_deprecated_email.html.erb" do
   context "renders mailer page" do
     let!(:current_user) { create(:user, first_name: "test_user") }
+    let!(:system_email) { create(:system_email, name: "Cookbook deprecated") }
+    let!(:email_preference) { create(:email_preference, user_id: current_user.id, system_email_id: system_email.id) }
     let!(:cookbook) {
       create(
         :cookbook,

--- a/src/supermarket/spec/views/cookbook_mailer/cookbook_deprecated_email.html.erb_spec.rb
+++ b/src/supermarket/spec/views/cookbook_mailer/cookbook_deprecated_email.html.erb_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 describe "cookbook_mailer/cookbook_deprecated_email.html.erb" do
-	context "renders mailer page" do
-		let!(:current_user) { create(:user, first_name: "test_user") }
-		let!(:cookbook) {
+  context "renders mailer page" do
+    let!(:current_user) { create(:user, first_name: "test_user") }
+    let!(:cookbook) {
       create(
         :cookbook,
         name: "test_cookbook",
@@ -10,14 +10,14 @@ describe "cookbook_mailer/cookbook_deprecated_email.html.erb" do
       )
     }
     let!(:replacement_cookbook) { create(:cookbook, name: "test_cookbook1") }
-		before(:each) do
-			cookbook.deprecate(replacement_cookbook, "test descreption")
-			assign(:cookbook, cookbook)
-			assign(:replacement_cookbook, replacement_cookbook)
-			assign(:email_preference, current_user.email_preference_for("Cookbook deprecated"))
-		end
+    before(:each) do
+      cookbook.deprecate(replacement_cookbook, "test descreption")
+      assign(:cookbook, cookbook)
+      assign(:replacement_cookbook, replacement_cookbook)
+      assign(:email_preference, current_user.email_preference_for("Cookbook deprecated"))
+    end
 
-		it "has cookbook name rendered" do
+    it "has cookbook name rendered" do
       render
       expect(rendered).to have_selector("p", text: cookbook.name)
     end
@@ -26,5 +26,5 @@ describe "cookbook_mailer/cookbook_deprecated_email.html.erb" do
       render
       expect(rendered).to have_selector("p", text: cookbook.cookbook_deprecation_reason)
     end
-	end
+  end
 end

--- a/src/supermarket/spec/views/cookbooks/show.html.erb_spec.rb
+++ b/src/supermarket/spec/views/cookbooks/show.html.erb_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+# require_relative "../../../lib/supermarket/authentication.rb"
+
+describe "cookbooks/show.html.erb" do
+  let!(:current_user) { create(:user, first_name: "test_user") }
+
+    let(:cookbook_version) {
+      create(
+        :cookbook_version,
+        version: "0.2.0",
+        license: "MIT",
+        changelog: "we added so much stuff!",
+        changelog_extension: "md"
+      )
+    }
+
+    let(:cookbook) {
+      create(
+        :cookbook,
+        name: "test_cookbook",
+        cookbook_versions_count: 0,
+        user_id: current_user.id,
+        cookbook_versions: [cookbook_version]
+      )
+    }
+
+    let!(:collaborator) { create(:cookbook_collaborator, resourceable: cookbook, user: create(:user)) }
+
+    before(:each) do
+      allow(view).to receive(:policy) do |record|
+        Pundit.policy(current_user, record)
+      end
+
+      assign(:cookbook, cookbook)
+      assign(:collaborators, cookbook.collaborators)
+      assign(:latest_version, cookbook.latest_cookbook_version)
+      assign(:cookbook_versions, cookbook.sorted_cookbook_versions)
+      assign(:supported_platforms, cookbook.supported_platforms)
+      assign(:public_metric_results, cookbook_version.metric_results.open.sorted_by_name)
+      assign(:admin_metric_results, cookbook_version.metric_results.admin_only.sorted_by_name)
+      assign(:current_user, current_user)
+
+      allow(view).to receive(:cookbook).and_return(cookbook)
+      allow(view).to receive(:latest_version).and_return(cookbook.latest_cookbook_version)
+      allow(view).to receive(:cookbook_versions).and_return(cookbook.sorted_cookbook_versions)
+      allow(view).to receive(:supported_platforms).and_return(cookbook.supported_platforms)
+      allow(view).to receive(:collaborators).and_return(cookbook.collaborators)
+      allow(view).to receive(:current_user).and_return(current_user)
+    end
+
+  it "has Test Kitchen text correct" do
+    render
+    test_kitchen_text = cookbook.cookbook_deprecation_reason
+    expect(rendered).to have_selector("textarea", text: test_kitchen_text)
+  end
+end

--- a/src/supermarket/spec/views/cookbooks/show.html.erb_spec.rb
+++ b/src/supermarket/spec/views/cookbooks/show.html.erb_spec.rb
@@ -4,49 +4,49 @@ require "spec_helper"
 describe "cookbooks/show.html.erb" do
   let!(:current_user) { create(:user, first_name: "test_user") }
 
-    let(:cookbook_version) {
-      create(
-        :cookbook_version,
-        version: "0.2.0",
-        license: "MIT",
-        changelog: "we added so much stuff!",
-        changelog_extension: "md"
-      )
-    }
+  let(:cookbook_version) {
+    create(
+      :cookbook_version,
+      version: "0.2.0",
+      license: "MIT",
+      changelog: "we added so much stuff!",
+      changelog_extension: "md"
+    )
+  }
 
-    let(:cookbook) {
-      create(
-        :cookbook,
-        name: "test_cookbook",
-        cookbook_versions_count: 0,
-        user_id: current_user.id,
-        cookbook_versions: [cookbook_version]
-      )
-    }
+  let(:cookbook) {
+    create(
+      :cookbook,
+      name: "test_cookbook",
+      cookbook_versions_count: 0,
+      user_id: current_user.id,
+      cookbook_versions: [cookbook_version]
+    )
+  }
 
-    let!(:collaborator) { create(:cookbook_collaborator, resourceable: cookbook, user: create(:user)) }
+  let!(:collaborator) { create(:cookbook_collaborator, resourceable: cookbook, user: create(:user)) }
 
-    before(:each) do
-      allow(view).to receive(:policy) do |record|
-        Pundit.policy(current_user, record)
-      end
-
-      assign(:cookbook, cookbook)
-      assign(:collaborators, cookbook.collaborators)
-      assign(:latest_version, cookbook.latest_cookbook_version)
-      assign(:cookbook_versions, cookbook.sorted_cookbook_versions)
-      assign(:supported_platforms, cookbook.supported_platforms)
-      assign(:public_metric_results, cookbook_version.metric_results.open.sorted_by_name)
-      assign(:admin_metric_results, cookbook_version.metric_results.admin_only.sorted_by_name)
-      assign(:current_user, current_user)
-
-      allow(view).to receive(:cookbook).and_return(cookbook)
-      allow(view).to receive(:latest_version).and_return(cookbook.latest_cookbook_version)
-      allow(view).to receive(:cookbook_versions).and_return(cookbook.sorted_cookbook_versions)
-      allow(view).to receive(:supported_platforms).and_return(cookbook.supported_platforms)
-      allow(view).to receive(:collaborators).and_return(cookbook.collaborators)
-      allow(view).to receive(:current_user).and_return(current_user)
+  before(:each) do
+    allow(view).to receive(:policy) do |record|
+      Pundit.policy(current_user, record)
     end
+
+    assign(:cookbook, cookbook)
+    assign(:collaborators, cookbook.collaborators)
+    assign(:latest_version, cookbook.latest_cookbook_version)
+    assign(:cookbook_versions, cookbook.sorted_cookbook_versions)
+    assign(:supported_platforms, cookbook.supported_platforms)
+    assign(:public_metric_results, cookbook_version.metric_results.open.sorted_by_name)
+    assign(:admin_metric_results, cookbook_version.metric_results.admin_only.sorted_by_name)
+    assign(:current_user, current_user)
+
+    allow(view).to receive(:cookbook).and_return(cookbook)
+    allow(view).to receive(:latest_version).and_return(cookbook.latest_cookbook_version)
+    allow(view).to receive(:cookbook_versions).and_return(cookbook.sorted_cookbook_versions)
+    allow(view).to receive(:supported_platforms).and_return(cookbook.supported_platforms)
+    allow(view).to receive(:collaborators).and_return(cookbook.collaborators)
+    allow(view).to receive(:current_user).and_return(current_user)
+  end
 
   it "has Test Kitchen text correct" do
     render


### PR DESCRIPTION
### Description

Added new field to add custom reason while deprecating the cookbook and also replaced icon with text if there is not supported platforms given for cookbook.

### Issues Resolved
Fixed: 1) https://github.com/chef/supermarket/issues/2193
2) https://github.com/chef/supermarket/issues/2250

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
