### PR TITLE
Updated the log directory permission

### DIFF
--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -76,7 +76,7 @@ This configuration file has the following general settings:
 
 `default['supermarket']['log_mode']`
 
-: The Supermarket log directory permission which can be configured. Default value: `700`.
+: The Supermarket log directory file permissions. Default value: `0700`.
 
 `default['supermarket']['sysvinit_id']`
 

--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -74,6 +74,10 @@ This configuration file has the following general settings:
 
 : The directory that Supermarket will use to store logs. Default value: `'/var/log/supermarket'`.
 
+`default['supermarket']['log_mode']`
+
+: The Supermarket log directory permission which can be configured. Default value: `700`.
+
 `default['supermarket']['sysvinit_id']`
 
 : Use to specify 1-4 characters that define a unique identifier for the file located in `/etc/inittab`. Default value: `SUP`.

--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -72,6 +72,7 @@ default['supermarket']['config_directory'] = '/etc/supermarket'
 default['supermarket']['install_directory'] = '/opt/supermarket'
 default['supermarket']['app_directory'] = "#{node['supermarket']['install_directory']}/embedded/service/supermarket"
 default['supermarket']['log_directory'] = '/var/log/supermarket'
+default['supermarket']['log_mode'] = '0700'
 default['supermarket']['var_directory'] = '/var/opt/supermarket'
 default['supermarket']['data_directory'] = '/var/opt/supermarket/data'
 default['supermarket']['user'] = 'supermarket'

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
@@ -70,7 +70,7 @@ end
 directory node['supermarket']['log_directory'] do
   owner node['supermarket']['user']
   group node['supermarket']['group']
-  mode '0700'
+  mode node['supermarket']['log_mode']
   recursive true
 end
 

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/sidekiq.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/sidekiq.rb
@@ -20,7 +20,7 @@
 directory "#{node['supermarket']['log_directory']}/sidekiq" do
   owner node['supermarket']['user']
   group node['supermarket']['group']
-  mode '0700'
+  mode node['supermarket']['log_mode']
 end
 
 if node['supermarket']['sidekiq']['enable']


### PR DESCRIPTION
Signed-off-by: saghoshprogress <saghosh@progress.com>

Added option to modify the log directory permission, default will remain the same.

### Issues Resolved

[Issues](https://app.zenhub.com/workspaces/sustaining-engineering-progress-60c9e8f0307f65000e50585a/issues/chef/supermarket/1856)

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
        https://buildkite.com/chef/chef-supermarket-main-omnibus-adhoc/builds/264#1c7d3371-3a9e-4019-a442-831b6b23c7a2
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
