### PR TITLE
Changed rails autoloader version from 5.1 to 6.0

### DIFF
--- a/src/supermarket/config/application.rb
+++ b/src/supermarket/config/application.rb
@@ -28,7 +28,7 @@ Bundler.require(*Rails.groups)
 module Supermarket
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1
+    config.load_defaults 6.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers


### PR DESCRIPTION
Signed-off-by: Rajesh Paul <rajesh.paul@progress.com>

### Description

Changed  rails autoloader version from 5.1 to 6.0

With the older version it was failing to autoload namesapced classes under app/model. Hence running **reload!** in rails console doesn't reload such classes. With this change the auto-reloading works perfectly. This doesn't add any feature but will help developers test their changes seamlessly without being needed to restart rails console every time for testing  any changes.

### Issues Resolved

#2378 

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
