### PR TITLE
Changes for jobs controller to not to throw CSRF token authentication error

### DIFF
--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -176,7 +176,7 @@ As a Supermarket feature, Fieri must be enabled via the `default['supermarket'][
 
 `default['supermarket']['fieri_key']`
 
-: A string that is used as a key to authenticate Fieri. Default value: `nil`
+: A string that is used as a key to authenticate Fieri. Default value: `nil`. This value should be set to a random string for fieri feature to work properly. One example to generate random string - `openssl rand -base64 32`
 
 ### GitHub
 

--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -318,7 +318,7 @@ default['supermarket']['database']['extensions'] = { 'plpgsql' => true, 'pg_trgm
 # than nil to change them.
 
 default['supermarket']['fieri_url'] = 'http://localhost:13000/fieri/jobs'
-default['supermarket']['fieri_supermarket_endpoint'] = 'https://localhost:13000'
+default['supermarket']['fieri_supermarket_endpoint'] = 'http://localhost:13000'
 default['supermarket']['fieri_key'] = nil
 default['supermarket']['from_email'] = nil
 default['supermarket']['github_access_token'] = nil

--- a/src/supermarket/config/environments/production.rb
+++ b/src/supermarket/config/environments/production.rb
@@ -47,7 +47,10 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # For running quality metrics we need to stop rails from redirecting all requests to https
   config.force_ssl = (ENV["FORCE_SSL"] == "true")
+
+  config.ssl_options = { redirect: { exclude: ->(request) { request.host =~ /localhost/ } } }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/src/supermarket/engines/fieri/app/controllers/fieri/jobs_controller.rb
+++ b/src/supermarket/engines/fieri/app/controllers/fieri/jobs_controller.rb
@@ -3,6 +3,10 @@ require_dependency "fieri/application_controller"
 module Fieri
   class JobsController < ApplicationController
     before_action :check_authorization
+    skip_before_action :verify_authenticity_token, \
+      if: proc { request.format.json? }, \
+      only: [ :create ], raise: false
+
 
     def create
       MetricsRunner.perform_async(job_params.to_h)
@@ -18,7 +22,7 @@ module Fieri
     end
 
     def check_authorization
-      unless fieri_key == params.require(:fieri_key)
+      unless fieri_key == params.require(:fieri_key) && !fieri_key.empty?
         error = {
           error_code: t("api.error_codes.unauthorized"),
           error_messages: [t("api.error_messages.unauthorized_post_error")],


### PR DESCRIPTION
### Description

In current setup quality metrics job is not running, A CSRF authentication token error is throws in from the controller when worker tries to make an http request there. 

Also rails default configuration in `production.rb` is redirecting `http://localhost` to`https://localhost` and hence its not served by the application either

### Issues Resolved
https://github.com/chef/supermarket/issues/2400

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
