### PR TITLE
SPDX-CTL command documentation and cookbook_upload change

### DIFF
--- a/docs-chef-io/content/supermarket/ctl_supermarket.md
+++ b/docs-chef-io/content/supermarket/ctl_supermarket.md
@@ -29,6 +29,45 @@ sudo -u supermarket supermarket-ctl make-admin USER_NAME
 where `USER_NAME` represents the name of the user to be granted
 administrator privileges.
 
+## SPDX license update
+
+For a cookbook which has a license and is a known license according to SPDX listing the link to spdx-license details can be updated using this command. This link will be displayed on cookbook details page along with other information.
+
+### spdx-all
+
+The `spdx-all` command is used to make sure spdx license linking happens for all the cookbooks in system.
+
+This subcommand has the following syntax:
+
+```bash
+sudo -u supermaket supermarket-ctl spdx-all
+```
+
+### spdx-latest
+
+The `spdx-latest` command is used to make sure spdx license linking happens for the cookbook specified
+
+This subcommand has the following syntax:
+
+```bash
+sudo -u supermarket supermarket-ctl spdx-latest COOKBOOK_NAME
+```
+
+Where COOKBOOK_NAME is the name of cookbook for which spdx linking will happen. It will happen on the latest version of the cookbook
+
+### spdx-on-version
+
+The `spdx-on-version` command is used to make sure spdx license linking happens for the version of cookbook specified
+
+This subcommand has the following syntax:
+
+```bash
+sudo -u supermarket supermarket-ctl spdx-on-version COOKBOOK_NAME VERSION
+```
+
+Where COOKBOOK_NAME is the name of cookbook for which spdx linking will happen and VERSION is the version for which SPDX license linking needs to be done
+
+
 ## Quality Metrics
 
 ### qm-flip-admin-only

--- a/docs-chef-io/content/supermarket/ctl_supermarket.md
+++ b/docs-chef-io/content/supermarket/ctl_supermarket.md
@@ -29,13 +29,17 @@ sudo -u supermarket supermarket-ctl make-admin USER_NAME
 where `USER_NAME` represents the name of the user to be granted
 administrator privileges.
 
-## SPDX license update
+## spdx
 
-For a cookbook which has a license and is a known license according to SPDX listing the link to spdx-license details can be updated using this command. This link will be displayed on cookbook details page along with other information.
+The `spdx` subcommands are used to manage SPDX license information in cookbooks. Linked SPDX licenses appear on the cookbook information page.
+
+[The Software Package Data Exchange](https://spdx.dev/) (SPDX) is an open standard for software manifests, including components, licenses, copyrights, and security content.
+
+SPDX maintains a [License List](https://spdx.org/licenses/) of common licenses and exceptions used in open source development. Changes to the SPDX License List are not automatically reflected in your cookbooks. to To apply changes made by SPDX, rescan your cookbooks with the `spdx` subcommands.
 
 ### spdx-all
 
-The `spdx-all` command is used to make sure spdx license linking happens for all the cookbooks in system.
+The `spdx-all` command links the licenses known to SPDX for all cookbooks in your system.
 
 This subcommand has the following syntax:
 
@@ -45,7 +49,7 @@ sudo -u supermaket supermarket-ctl spdx-all
 
 ### spdx-latest
 
-The `spdx-latest` command is used to make sure spdx license linking happens for the cookbook specified
+The `spdx-latest` command links the licenses known to SPDX for the specified cookbook.
 
 This subcommand has the following syntax:
 
@@ -53,11 +57,11 @@ This subcommand has the following syntax:
 sudo -u supermarket supermarket-ctl spdx-latest COOKBOOK_NAME
 ```
 
-Where COOKBOOK_NAME is the name of cookbook for which spdx linking will happen. It will happen on the latest version of the cookbook
+Where COOKBOOK_NAME is the name of cookbook for SPDX linking. The latest version of the cookbook receives SPDX linking.
 
 ### spdx-on-version
 
-The `spdx-on-version` command is used to make sure spdx license linking happens for the version of cookbook specified
+The `spdx-on-version` command links the licenses known to SPDX for the specified cookbook version.
 
 This subcommand has the following syntax:
 
@@ -65,8 +69,7 @@ This subcommand has the following syntax:
 sudo -u supermarket supermarket-ctl spdx-on-version COOKBOOK_NAME VERSION
 ```
 
-Where COOKBOOK_NAME is the name of cookbook for which spdx linking will happen and VERSION is the version for which SPDX license linking needs to be done
-
+Where COOKBOOK_NAME is the name of cookbook and VERSION is the version of the cookbook that receives SPDX linking.
 
 ## Quality Metrics
 

--- a/src/supermarket/app/controllers/api/v1/cookbook_uploads_controller.rb
+++ b/src/supermarket/app/controllers/api/v1/cookbook_uploads_controller.rb
@@ -67,7 +67,7 @@ class Api::V1::CookbookUploadsController < Api::V1Controller
           UniverseCache.flush
 
           # fetch spdx license
-          SpdxLicenseUpdateWorker.perform_async(FetchSpdxLicenseJson.spdx_license_json, cookbook_version.version)
+          SpdxLicenseUpdateWorker.perform_async(FetchSpdxLicenseJson.spdx_license_json, cookbook_version.id)
 
           render :create, status: 201
         end


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

### Description

SPDX license linking ctl commands need to have related documentation as well. 

### Issues Resolved

https://github.com/chef/supermarket/issues/2188

### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
