### PR TITLE
Rajeshpaul38/dependabot pr merge/2436

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 2c309fa8df525e57f3c234fe23e47fb5133f0370
+  revision: 2bf77bb5515a13bb0ce745f3d4c074ee50a6bf24
   branch: main
   specs:
-    omnibus (8.2.6)
+    omnibus (8.2.7)
       aws-sdk-s3 (~> 1)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)
@@ -34,7 +34,7 @@ GEM
     ast (2.4.2)
     awesome_print (1.9.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.537.0)
+    aws-partitions (1.540.0)
     aws-sdk-core (3.124.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
@@ -277,7 +277,7 @@ GEM
     parslet (1.8.2)
     pastel (0.8.0)
       tty-color (~> 0.5)
-    pedump (0.6.2)
+    pedump (0.6.3)
       awesome_print
       iostruct (>= 0.0.4)
       multipart-post (>= 2.0.0)
@@ -357,7 +357,7 @@ GEM
     toml-rb (2.1.0)
       citrus (~> 3.0, > 3.0)
     tomlrb (1.3.0)
-    train-core (3.8.1)
+    train-core (3.8.5)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)

--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -14,7 +14,7 @@ gem "sidekiq", "~> 6.3"
 gem "sidekiq-cron"
 
 gem "aws-sdk-s3"
-gem "chef", "~> 17.7", require: false
+gem "chef", "~> 17.8", require: false
 gem "compass-rails"
 gem "ddtrace", "0.53.0", require: false
 gem "dotenv"

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -677,7 +677,7 @@ GEM
     simplecov_json_formatter (0.1.3)
     sitemap_generator (6.1.2)
       builder (~> 3.0)
-    spring (3.1.1)
+    spring (4.0.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
     sprockets (4.0.2)

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     and_feathers-gzipped_tarball (1.0.0.pre)
     ast (2.4.2)
     aws-eventstream (1.2.0)
-    aws-partitions (1.537.0)
+    aws-partitions (1.540.0)
     aws-sdk-core (3.124.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
@@ -91,7 +91,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.122.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
-    aws-sdk-secretsmanager (1.52.0)
+    aws-sdk-secretsmanager (1.53.0)
       aws-sdk-core (~> 3, >= 3.122.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.4.0)
@@ -111,12 +111,12 @@ GEM
     capybara-screenshot (1.0.25)
       capybara (>= 1.0, < 4)
       launchy
-    chef (17.7.29)
+    chef (17.8.25)
       addressable
       aws-sdk-s3 (~> 1.91)
       aws-sdk-secretsmanager (~> 1.46)
-      chef-config (= 17.7.29)
-      chef-utils (= 17.7.29)
+      chef-config (= 17.8.25)
+      chef-utils (= 17.8.25)
       chef-vault
       chef-zero (>= 14.0.11)
       corefoundation (~> 0.3.4)
@@ -142,9 +142,9 @@ GEM
       train-winrm (>= 0.2.5)
       uuidtools (>= 2.1.5, < 3.0)
       vault (~> 0.16)
-    chef-config (17.7.29)
+    chef-config (17.8.25)
       addressable
-      chef-utils (= 17.7.29)
+      chef-utils (= 17.8.25)
       fuzzyurl
       mixlib-config (>= 2.2.12, < 4.0)
       mixlib-shellout (>= 2.0, < 4.0)
@@ -152,7 +152,7 @@ GEM
     chef-telemetry (1.1.1)
       chef-config
       concurrent-ruby (~> 1.0)
-    chef-utils (17.7.29)
+    chef-utils (17.8.25)
       concurrent-ruby
     chef-vault (4.1.4)
     chef-zero (15.0.11)
@@ -455,7 +455,7 @@ GEM
     octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    ohai (17.7.8)
+    ohai (17.7.12)
       chef-config (>= 14.12, < 18)
       chef-utils (>= 16.0, < 18)
       ffi (~> 1.9)
@@ -703,7 +703,7 @@ GEM
     thor (1.0.1)
     tilt (2.0.10)
     tomlrb (1.3.0)
-    train-core (3.8.1)
+    train-core (3.8.5)
       addressable (~> 2.5)
       ffi (!= 1.13.0)
       json (>= 1.8, < 3.0)
@@ -806,7 +806,7 @@ DEPENDENCIES
   brakeman
   capybara
   capybara-screenshot
-  chef (~> 17.7)
+  chef (~> 17.8)
   chefstyle
   coderay
   compass-rails


### PR DESCRIPTION
### Description
Merge these PRs:
Bump spring from 3.1.1 to 4.0.0 in /src/supermarket -> https://github.com/chef/supermarket/pull/2435
Bump omnibus from 2c309fa to 2bf77bb in /omnibus -> https://github.com/chef/supermarket/pull/2434
Bump chef from 17.7.29 to 17.8.25 in /src/supermarket -> https://github.com/chef/supermarket/pull/2421

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
