### PR TITLE
Configure labeller to auto asign docs PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Order is important. The last matching pattern has the most precedence.
 
 *               @chef/supermarket-reviewers @chef/supermarket-owners @chef/supermarket-approvers
-.expeditor/**   @chef/jex-team
-README.md       @chef/docs-team
+.expeditor/     @chef/releng-ops
+*.md            @chef/docs-team
+docs-chef-io/   @chef/docs-team

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+documentation:
+  - 'README.md'
+  - 'CODE_OF_CONDUCT.md'
+  - 'CONTRIBUTING.md'
+  - 'docs-chef-io/**/*'
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@main
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Make sure the docs team always knows when a docs thing changes

Signed-off-by: Tim Smith <tsmith@chef.io>