### PR TITLE
Change chef downloads url

### DIFF
--- a/src/supermarket/app/helpers/custom_url_helper.rb
+++ b/src/supermarket/app/helpers/custom_url_helper.rb
@@ -38,7 +38,7 @@ module CustomUrlHelper
   end
 
   def chef_downloads_url(extra = nil)
-    url = ENV["CHEF_DOWNLOADS_URL"] || "https://downloads.#{chef_domain}"
+    url = ENV["CHEF_DOWNLOADS_URL"] || "https://#{chef_domain}/downloads"
     extra_dispatch(url, extra)
   end
 

--- a/src/supermarket/app/helpers/custom_url_helper.rb
+++ b/src/supermarket/app/helpers/custom_url_helper.rb
@@ -38,7 +38,7 @@ module CustomUrlHelper
   end
 
   def chef_downloads_url(extra = nil)
-    url = ENV["CHEF_DOWNLOADS_URL"] || "https://#{chef_domain}/downloads"
+    url = ENV["CHEF_DOWNLOADS_URL"] || "https://www.#{chef_domain}/downloads"
     extra_dispatch(url, extra)
   end
 

--- a/src/supermarket/spec/helpers/custom_url_helper_spec.rb
+++ b/src/supermarket/spec/helpers/custom_url_helper_spec.rb
@@ -74,7 +74,7 @@ describe CustomUrlHelper do
 
   describe "downloads url" do
     let(:meth) { :chef_downloads_url }
-    let(:url) { "https://chef.io/downloads" }
+    let(:url) { "https://www.chef.io/downloads" }
 
     it "should have a downloads url that uses the default domain" do
       expect(ENV["CHEF_DOWNLOADS_URL"]).to be_nil

--- a/src/supermarket/spec/helpers/custom_url_helper_spec.rb
+++ b/src/supermarket/spec/helpers/custom_url_helper_spec.rb
@@ -74,7 +74,7 @@ describe CustomUrlHelper do
 
   describe "downloads url" do
     let(:meth) { :chef_downloads_url }
-    let(:url) { "https://downloads.chef.io" }
+    let(:url) { "https://chef.io/downloads" }
 
     it "should have a downloads url that uses the default domain" do
       expect(ENV["CHEF_DOWNLOADS_URL"]).to be_nil


### PR DESCRIPTION
Signed-off-by: Manick Vel <mkumaravel@msystechnologies.com>

### Description

Change chef downloads url from downloads.chef.io to https://www.chef.io/downloads

### Issues Resolved
https://github.com/chef/supermarket/issues/2350

### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
