### PR TITLE
Adding Habitat Configuration files to Rubocop exclude

### DIFF
--- a/src/supermarket/.rubocop.yml
+++ b/src/supermarket/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - engines/**/*
     - vendor/**/*
     - node_modules/**/*
+    - habitat-*/config/*
 Layout/MultilineOperationIndentation:
   EnforcedStyle: aligned
 Lint/UselessAssignment:


### PR DESCRIPTION
Signed-off-by: Siraj Rauff <sirajrauff@gmail.com>
