### PR TITLE
Set product in search to supermarket

### DIFF
--- a/docs-chef-io/content/supermarket/_index.md
+++ b/docs-chef-io/content/supermarket/_index.md
@@ -3,7 +3,9 @@ title = "Chef Supermarket"
 draft = false
 gh_repo = "supermarket"
 aliases = ["/supermarket.html"]
-product = ["client", "server", "workstation"]
+
+[cascade]
+  product = ["supermarket"]
 
 [menu]
   [menu.supermarket]

--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -3,7 +3,6 @@ title = "supermarket.rb Settings"
 draft = false
 gh_repo = "supermarket"
 aliases = ["/config_rb_supermarket.html", "/config_rb_supermarket/"]
-product = ["client", "server", "workstation"]
 
 [menu]
   [menu.supermarket]

--- a/docs-chef-io/content/supermarket/ctl_supermarket.md
+++ b/docs-chef-io/content/supermarket/ctl_supermarket.md
@@ -3,7 +3,6 @@ title = "supermarket-ctl (executable)"
 draft = false
 gh_repo = "supermarket"
 aliases = ["/ctl_supermarket.html", "/ctl_supermarket/"]
-product = ["client", "server", "workstation"]
 
 [menu]
   [menu.supermarket]

--- a/docs-chef-io/content/supermarket/install_supermarket.md
+++ b/docs-chef-io/content/supermarket/install_supermarket.md
@@ -3,7 +3,6 @@ title = "Install Private Supermarket"
 draft = false
 gh_repo = "supermarket"
 aliases = ["/install_supermarket.html", "/install_supermarket/"]
-product = ["client", "server", "workstation"]
 
 [menu]
   [menu.supermarket]

--- a/docs-chef-io/content/supermarket/supermarket_api.md
+++ b/docs-chef-io/content/supermarket/supermarket_api.md
@@ -3,7 +3,6 @@ title = "Supermarket API"
 draft = false
 gh_repo = "supermarket"
 aliases = ["/supermarket_api.html", "/supermarket_api/"]
-product = ["client", "server", "workstation"]
 
 [menu]
   [menu.supermarket]

--- a/docs-chef-io/content/supermarket/supermarket_backup_restore.md
+++ b/docs-chef-io/content/supermarket/supermarket_backup_restore.md
@@ -3,7 +3,6 @@ title = "Supermarket Backup and Restore"
 draft = false
 gh_repo = "supermarket"
 aliases = ["/supermarket_backup_restore.html", "/supermarket_backup_restore/"]
-product = ["client", "server", "workstation"]
 
 [menu]
   [menu.supermarket]

--- a/docs-chef-io/content/supermarket/supermarket_logs.md
+++ b/docs-chef-io/content/supermarket/supermarket_logs.md
@@ -3,7 +3,6 @@ title = "Supermarket Logs"
 draft = false
 gh_repo = "supermarket"
 aliases = ["/supermarket_logs.html", "/supermarket_logs/"]
-product = ["client", "server", "workstation"]
 
 [menu]
   [menu.supermarket]

--- a/docs-chef-io/content/supermarket/supermarket_monitor.md
+++ b/docs-chef-io/content/supermarket/supermarket_monitor.md
@@ -3,7 +3,6 @@ title = "Monitor Supermarket"
 draft = false
 gh_repo = "supermarket"
 aliases = ["/supermarket_monitor.html", "/supermarket_monitor/"]
-product = ["client", "server", "workstation"]
 
 [menu]
   [menu.supermarket]

--- a/docs-chef-io/content/supermarket/supermarket_private.md
+++ b/docs-chef-io/content/supermarket/supermarket_private.md
@@ -3,7 +3,6 @@ title = "Chef Supermarket"
 draft = false
 gh_repo = "supermarket"
 aliases = ["/supermarket.html", "/supermarket_private/"]
-product = ["client", "server", "workstation"]
 
 [menu]
   [menu.supermarket]

--- a/docs-chef-io/content/supermarket/supermarket_share_cookbook.md
+++ b/docs-chef-io/content/supermarket/supermarket_share_cookbook.md
@@ -3,7 +3,6 @@ title = "Share Cookbooks on the Chef Supermarket"
 draft = false
 gh_repo = "supermarket"
 aliases = ["/supermarket_share_cookbook.html", "/supermarket_share_cookbook/"]
-product = ["client", "server", "workstation"]
 
 [menu]
   [menu.supermarket]


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

### Description

Set product to "supermarket" so we can filter pages in Swiftype search results by Supermarket.

### Issues Resolved

See  chef/chef-web-docs#3625

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
