### PR TITLE
Kg/postgres update

### DIFF
--- a/docs-chef-io/content/supermarket/supermarket_upgrade.md
+++ b/docs-chef-io/content/supermarket/supermarket_upgrade.md
@@ -1,7 +1,7 @@
 +++
 title = "Upgrade Supermarket"
 date = 2021-12-28T11:04:48-08:00
-draft = false
+draft = true
 gh_repo = "supermarket"
 publishDate = 2022-01-03
 
@@ -67,15 +67,15 @@ The External PostgreSQL upgrade steps are provided as a courtesy. It is the resp
 
 Follow these steps to upgrade the PostgreSQL major version.
 
-### Run PostgreSQL
+### Run PostgreSQL 13
 
-1. Stop the Supermarket application
+1. Stop the Supermarket application.
 
 ```bash
 sudo supermarket-ctl stop
 ```
 
-1. Start the Supermarket PostgreSQL service
+1. Start the Supermarket PostgreSQL service. This starts the newly-installed PostgreSQL 13 server.
 
 ```bash
 sudo supermarket-ctl start postgresql
@@ -85,7 +85,7 @@ sudo supermarket-ctl start postgresql
 
 Database migrations carry inherent risk. A best practice to mitigate risk is to create an archival copy and save it to a secondary location before proceeding with any actions that touch the data. The archival copy is your failsafe for restoring the database. Do not use it as a working copy.
 
-1. Back up the Database
+1. Back up the database
 
 `pg_dumpall` is a utility for writing out ("dumping") all PostgreSQL databases of a cluster into one script file. The script file contains SQL commands that can be used as input to psql to restore the databases.
 
@@ -103,15 +103,18 @@ For more information on upgrading using `pg_dumpall` see the PostgreSQL 13 docum
 
 `vacuumdb --all --full` rewrites the entire contents of all tables into a disk files with no extra space, and returns unused space to the operating system.
 
-For more information on upgrading using `vacuumdb` see the PostgreSQL 13 documentation for [vacuumdb](https://www.postgresql.org/docs/13/app-vacuumdb.html).
+Vacuum the database:
 
 ```bash
 /opt/supermarket/embedded/bin/vacuumdb --all --full -p 15432
 ```
 
+For more information on upgrading using `vacuumdb` see the PostgreSQL 13 documentation for [vacuumdb](https://www.postgresql.org/docs/13/app-vacuumdb.html).
 #### Option 2: Vacuum and Analyze the PostgreSQL database
 
-`vacuumdb --all --full --analyze` rewrites the entire contents of all tables into a disk files with no extra space, returns unused space to the operating system, and collects statistics about the database. It stores the results in the `pg_statistic` system catalog, which is useful for planning efficient queries.
+`vacuumdb --all --full --analyze` rewrites the entire contents of all tables into a disk files with no extra space, returns unused space to the operating system, and collects statistics about the database. It stores the results in the `pg_statistic` system catalog, which is useful for planning efficient queries. This command takes considerably more time to run.
+
+Vacuume and analyze the database:
 
 ```bash
 /opt/supermarket/embedded/bin/vacuumdb --all --full --analyze -p 15432
@@ -121,6 +124,8 @@ For more information on upgrading using `vacuumdb` see the PostgreSQL 13 documen
 
 This is an optional step for the sufficiently paranoid. Estimate the time needed for a second (the 'working') backup based as the same amount of time used in the first backup. The working backup provides a closer restore point than the archival copy if the next step of reindexing fails.
 
+Create a 'working' copy of the cleaned database:
+
 ```bash
 /opt/supermarket/embedded/bin/pg_dumpall -U supermarket -p 15432 > /tmp/supermarket-dump-working.sql
 ```
@@ -129,17 +134,17 @@ This is an optional step for the sufficiently paranoid. Estimate the time needed
 
 `reindexdb` is a utility for rebuilding indexes in a PostgreSQL database.
 
-For more information on upgrading using `reindexdb` see the PostgreSQL 13 documentation for [vacuumdb](https://www.postgresql.org/docs/13/app-reindexdb.html).
-
-1. Reindex the PostgreSQL database:
+Reindex the PostgreSQL database:
 
 ```bash
 /opt/supermarket/embedded/bin/reindexdb --all -p 15432
 ```
 
+For more information on upgrading using `reindexdb` see the PostgreSQL 13 documentation for [reindexdb](https://www.postgresql.org/docs/13/app-reindexdb.html).
+
 ### Restart Supermarket
 
-1. Restart the Supermarket application
+Restart the Supermarket application:
 
 ```bash
 supermarket-ctl restart

--- a/docs-chef-io/content/supermarket/supermarket_upgrade.md
+++ b/docs-chef-io/content/supermarket/supermarket_upgrade.md
@@ -13,32 +13,61 @@ publishDate = 2022-01-03
     weight = 25
 +++
 
+Chef Supermarket uses the PostgreSQL database. [PostgreSQL 9.6 is EOL](https://endoflife.date/postgresql) and Private Supermarket users should upgrade to [Supermarket 4.x](https://www.chef.io/downloads/tools/supermarket) and migrate to [Postgres 13](https://www.postgresql.org/about/news/postgresql-13-released-2077/).
 
-## Upgrade Matrix
+## Upgrade a Private Supermarket
 
-Running Version| Upgrade Version | Supported Version
----------|----------|---------
- A1 | B1 | C1
- A2 | B2 | C2
- A3 | B3 | C3
+1. Shut down the server running Private Supermarket.
+1. Backup the `/var/opt/supermarket` directory.
+1. Download the [Chef Supermarket](https://www.chef.io/downloads/tools/supermarket) package.
+1. Upgrade your system with the new package using the appropriate package manager for your distribution:
 
-## Upgrade Supermarket
+    - For Ubuntu:
 
-### Database Preparation
+        ```bash
+        dpkg -i /path/to/package/supermarket*.deb
+        ```
 
-### Upgrade Steps
+    - For RHEL / CentOS:
 
-## External PostgreSQL
+        ```bash
+        rpm -Uvh /path/to/package/supermarket*.rpm
+        ```
+
+1. [Reconfigure](/ctl_supermarket/#reconfigure) the server that Chef Supermarket is installed on:
+
+    ```bash
+    sudo supermarket-ctl reconfigure
+    ```
+
+Private Supermarket is updated on your server now. We recommend restarting the services that run Chef Supermarket to ensure that the old installation of Chef Supermarket doesn't persist in the server memory.
+
+1. Get the name of the active unit:
+
+    ```bash
+    systemctl list-units | grep runsvdir
+    ```
+
+1. Restart the unit:
+
+    ```bash
+    systemctl restart UNIT_NAME
+    ```
+
+    This will restart the `runsvdir`, `runsv`, and `svlogd` service processes that run Chef Supermarket.
+
+
+## Migrate to PostgreSQL 13
+
+TODO: What package SEMVER has the PostgreSQL update
+
+PostgreSQL 13.3 is installed with the Supermarket 4.X.X upgrade package.
 
 The External PostgreSQL upgrade steps are provided as a courtesy. It is the responsibility of the user to upgrade and maintain any External PostgreSQL configurations.
 
 Follow these steps to upgrade the PostgreSQL major version.
 
-## Upgrade Supermarket
-
-Do we need to upgrade Supermarket first?
-
-### Backup PostgreSQL Database
+### Run PostgreSQL
 
 1. Stop the Supermarket application
 
@@ -52,17 +81,55 @@ sudo supermarket-ctl stop
 sudo supermarket-ctl start postgresql
 ```
 
-1. Back up the PostgreSQL database
+### Create an Archive Backup
+
+Database migrations carry inherent risk. A best practice to mitigate risk is to create an archival copy and save it to a secondary location before proceeding with any actions that touch the data. The archival copy is your failsafe for restoring the database. Do not use it as a working copy.
+
+1. Back up the Database
+
+`pg_dumpall` is a utility for writing out ("dumping") all PostgreSQL databases of a cluster into one script file. The script file contains SQL commands that can be used as input to psql to restore the databases.
+
+For more information on upgrading using `pg_dumpall` see the PostgreSQL 13 documentation, section [18.6.1 Upgrading Data via pg_dumpall](https://www.postgresql.org/docs/13/upgrading.html).
 
 ```bash
-/opt/supermarket/embedded/bin/pg_dumpall -U supermarket -p 15432 > /tmp/supermarket-dump.sql
+/opt/supermarket/embedded/bin/pg_dumpall -U supermarket -p 15432 > /tmp/supermarket-dump-archive.sql
 ```
 
-1. Vacuum the PostgreSQL database:
+1. Copy the backup to a separate disk, one that is not connected to the Supermarket.
+
+### Prepare the Database
+
+#### Option 1: Vacuum the PostgreSQL database
+
+`vacuumdb --all --full` rewrites the entire contents of all tables into a disk files with no extra space, and returns unused space to the operating system.
+
+For more information on upgrading using `vacuumdb` see the PostgreSQL 13 documentation for [vacuumdb](https://www.postgresql.org/docs/13/app-vacuumdb.html).
 
 ```bash
 /opt/supermarket/embedded/bin/vacuumdb --all --full -p 15432
 ```
+
+#### Option 2: Vacuum and Analyze the PostgreSQL database
+
+`vacuumdb --all --full --analyze` rewrites the entire contents of all tables into a disk files with no extra space, returns unused space to the operating system, and collects statistics about the database. It stores the results in the `pg_statistic` system catalog, which is useful for planning efficient queries.
+
+```bash
+/opt/supermarket/embedded/bin/vacuumdb --all --full --analyze -p 15432
+```
+
+### Backup the Cleaned Database (optional)
+
+This is an optional step for the sufficiently paranoid. Estimate the time needed for a second (the 'working') backup based as the same amount of time used in the first backup. The working backup provides a closer restore point than the archival copy if the next step of reindexing fails.
+
+```bash
+/opt/supermarket/embedded/bin/pg_dumpall -U supermarket -p 15432 > /tmp/supermarket-dump-working.sql
+```
+
+### Reindex the Database
+
+`reindexdb` is a utility for rebuilding indexes in a PostgreSQL database.
+
+For more information on upgrading using `reindexdb` see the PostgreSQL 13 documentation for [vacuumdb](https://www.postgresql.org/docs/13/app-reindexdb.html).
 
 1. Reindex the PostgreSQL database:
 
@@ -70,13 +137,15 @@ sudo supermarket-ctl start postgresql
 /opt/supermarket/embedded/bin/reindexdb --all -p 15432
 ```
 
+### Restart Supermarket
+
 1. Restart the Supermarket application
 
 ```bash
 supermarket-ctl restart
 ```
 
-### Recovering from Upgrade Failures
+## Recovering from Upgrade Failures
 
 If either the `vacuumdb` or `reindexdb` commands fail
 
@@ -95,7 +164,7 @@ If either the `vacuumdb` or `reindexdb` commands fail
 1. Restore Supermarket PostgreSQL database from the existing `dump.sql` file
 
   ```bash
-  /opt/supermarket/embedded/bin/psql -U supermarket -d supermarket -p 15432 -f /tmp/supermarket-dump.sql
+  /opt/supermarket/embedded/bin/psql -U supermarket -d supermarket -p 15432 -f /tmp/supermarket-dump-archive.sql
   ```
 
 1. Restart the Supermarket application
@@ -103,3 +172,5 @@ If either the `vacuumdb` or `reindexdb` commands fail
 ```bash
 supermarket-ctl restart
 ```
+
+1. Review the [PostgreSQL error logs](https://www.postgresql.org/docs/13/runtime-config-logging.html). Once you understand and resolve the failure, then repeat the upgrade steps.


### PR DESCRIPTION
Signed-off-by: kagarmoe <kgarmoe@chef.io>

### Description

Thicker description of the Supermarket Upgrade. I added more specific information on handling the backup (move it off-system) and also an optional post-vacuum 'working' backup step. It can be nice not to roll all the way back to the archive copy. Of course, this assumes that the 'working' copy is, well, working.

Having an 'archive' copy is simply best practice. The 'working' copy comes from experience with technical services in libraries. I have seen things. 🚒 

### Issues Resolved


### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
