### PR TITLE
Fix fieri engine rubocop scanning

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,5 +35,5 @@ jobs:
         bundler-cache: true
     - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
     - name: run chefstyle
-      run: bundle exec chefstyle
+      run: bundle exec chefstyle --ignore-parent-exclusion
       working-directory: src/supermarket/engines/fieri


### PR DESCRIPTION
Make sure it actually scans the files

Signed-off-by: Tim Smith <tsmith@chef.io>