### PR TITLE
Corrected typo in spdx documentation

### DIFF
--- a/docs-chef-io/content/supermarket/ctl_supermarket.md
+++ b/docs-chef-io/content/supermarket/ctl_supermarket.md
@@ -41,7 +41,7 @@ The `spdx-all` command links the licenses known to SPDX for all cookbooks in you
 This subcommand has the following syntax:
 
 ```bash
-sudo -u supermaket supermarket-ctl spdx-all
+sudo -u supermarket supermarket-ctl spdx-all
 ```
 
 ### spdx-latest


### PR DESCRIPTION
### Description

Typo in spdx ctl command documentation fixed

### Issues Resolved

Issue was reported on slack - https://chefio.slack.com/archives/C0272A81LA1/p1640903043088700

### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
