### PR TITLE
Remove the private supermarket source link

### DIFF
--- a/docs-chef-io/content/supermarket/_index.md
+++ b/docs-chef-io/content/supermarket/_index.md
@@ -28,9 +28,3 @@ To interact with the public Chef Supermarket, use [knife supermarket](/workstati
 ## Private Supermarket
 
 {{% supermarket_private %}}
-
-{{< note >}}
-
-{{% supermarket_private_source_code %}}
-
-{{< /note >}}


### PR DESCRIPTION
This makes no sense. We should be linking to the package download instead.

Signed-off-by: Tim Smith <tsmith@chef.io>