### PR TITLE
Fixed Error with Permissions-Policy header: Parse of permissions policy

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/templates/nginx.conf.erb
+++ b/omnibus/cookbooks/omnibus-supermarket/templates/nginx.conf.erb
@@ -39,7 +39,7 @@ http {
   server_tokens off;
   more_clear_headers Server;
   add_header X-Clacks-Overhead "GNU Terry Pratchett";
-  add_header Permissions-Policy "camera=(); payment=(); microphone=(); gyroscope=(); magnetometer=(); midi=(); geolocation=()";
+  add_header Permissions-Policy "camera=(), payment=(), microphone=(), gyroscope=(), magnetometer=(), midi=(), geolocation=()";
   <% if @nginx['force_hsts'] && @nginx['force_ssl'] != true %>
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains;";
   <% end %>


### PR DESCRIPTION


Signed-off-by: antima-gupta <agupta@msystechnologies.com>

### Description

- Fixed Error with Permissions-Policy header: Parse of permissions policy failed because of errors reported by structured header parser.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
