### PR TITLE
Chefstyle failures corrected for fieri engine

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,5 +35,5 @@ jobs:
         bundler-cache: true
     - uses: r7kamura/rubocop-problem-matchers-action@v1 # this shows the failures in the PR
     - name: run chefstyle
-      run: bundle exec chefstyle
+      run: bundle exec chefstyle --ignore-parent-exclusion
       working-directory: src/supermarket/engines/fieri

--- a/src/supermarket/engines/fieri/Gemfile
+++ b/src/supermarket/engines/fieri/Gemfile
@@ -19,7 +19,7 @@ group :development, :test do
   gem "rubocop-rails", require: false
   gem "sqlite3"
   gem "webmock"
-  gem 'mixlib-shellout', '~> 2.2', '>= 2.2.6'
+  gem "mixlib-shellout", "~> 2.2", ">= 2.2.6"
   gem "mixlib-archive", ">= 0.4", "< 2.0"
   gem "cookstyle", "7.25.10"
   gem "rubocop", "1.23.0"

--- a/src/supermarket/engines/fieri/app/controllers/fieri/jobs_controller.rb
+++ b/src/supermarket/engines/fieri/app/controllers/fieri/jobs_controller.rb
@@ -4,8 +4,7 @@ module Fieri
   class JobsController < ApplicationController
     before_action :check_authorization
     skip_before_action :verify_authenticity_token, \
-      if: proc { request.format.json? }, \
-      only: [ :create ], raise: false
+      if: proc { request.format.json? || action_name == "create" }, raise: false
 
     def create
       MetricsRunner.perform_async(job_params.to_h)

--- a/src/supermarket/engines/fieri/app/models/cookbook_artifact.rb
+++ b/src/supermarket/engines/fieri/app/models/cookbook_artifact.rb
@@ -17,7 +17,7 @@ class CookbookArtifact
   # SSL cert. This check can be escaped if we are sure app will always have a
   # a valid SSL cert
   if ENV["CHEF_OAUTH2_VERIFY_SSL"].present? &&
-    ENV["CHEF_OAUTH2_VERIFY_SSL"] == "false"
+     ENV["CHEF_OAUTH2_VERIFY_SSL"] == "false"
     OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
   end
 
@@ -47,9 +47,9 @@ class CookbookArtifact
   # work_dir here represents the path where cookbook is uploaded
   def criticize
     prep
-    result, _status = CookstyleHelpers.process_artifact(work_dir)
+    result, status = CookstyleHelpers.process_artifact(work_dir)
     feedback = result.to_s.gsub("#{work_dir}/", "")
-    [feedback, _status]
+    [feedback, status]
   end
 
   #

--- a/src/supermarket/engines/fieri/app/models/cookstyle_worker.rb
+++ b/src/supermarket/engines/fieri/app/models/cookstyle_worker.rb
@@ -18,7 +18,6 @@ class CookstyleWorker
   end
 
   def make_post(params, feedback, status)
-
     response = Net::HTTP.post_form(
       URI.parse("#{ENV["FIERI_SUPERMARKET_ENDPOINT"]}/api/v1/quality_metrics/cookstyle_evaluation"),
       fieri_key: ENV["FIERI_KEY"],

--- a/src/supermarket/engines/fieri/lib/quality_metric/cookstyle_helpers.rb
+++ b/src/supermarket/engines/fieri/lib/quality_metric/cookstyle_helpers.rb
@@ -1,29 +1,31 @@
-require 'mixlib/shellout'
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 require "dotenv-rails"
 Dotenv.load(".env")
-require 'shellwords'
+require "shellwords" unless defined?(Shellwords)
 
 module CookstyleHelpers
   def self.process_artifact(path)
-    begin
-      path = path.shellescape
-      shell_out = Mixlib::ShellOut.new("cookstyle #{path} --only #{ENV["COOKSTYLE_COPS"]} --format json")
-      shell_out.run_command
-      parse_cookstyle_output(shell_out.stdout)
-    rescue StandardError=>e
-      raise "Error in processing Artifact #{e.message}"
-    end
+    path = path.shellescape
+    shell_out = Mixlib::ShellOut.new("cookstyle #{path} --only #{ENV["COOKSTYLE_COPS"]} --format json")
+    shell_out.run_command
+    parse_cookstyle_output(shell_out.stdout)
+  rescue StandardError => e
+    raise "Error in processing Artifact #{e.message}"
   end
 
-  #"COP_NAME":"MESSAGE":"file_name:line=line_no,col=col_no"
+  # "COP_NAME":"MESSAGE":"file_name:line=line_no,col=col_no"
   def self.parse_cookstyle_output(cookstyle_output)
     status = ""
-    offenses_arr = JSON.parse(cookstyle_output)["files"].map { |h| h["offenses"]\
-    .each {|a| a.merge!("file"=> h["path"]) } }\
-    .flatten.sort_by { |hsh| hsh["cop_name"] }\
-    .each{ |a| status << "#{[a["cop_name"], a["message"],\
-    a["file"],a["location"]["line"]].join(": ")}\n" }
+    offenses_arr = JSON.parse(cookstyle_output)["files"].map { |h|
+      h["offenses"]\
+        .each { |a| a.merge!("file" => h["path"]) }
+    }                   \
+      .flatten.sort_by { |hsh| hsh["cop_name"] }\
+      .each { |a|
+        status << "#{[a["cop_name"], a["message"],\
+    a["file"], a["location"]["line"]].join(": ")}\n"
+      }
 
-    return [status, offenses_arr.size > 0]
+    [status, offenses_arr.size > 0]
   end
 end

--- a/src/supermarket/engines/fieri/spec/models/cookbook_artifact_spec.rb
+++ b/src/supermarket/engines/fieri/spec/models/cookbook_artifact_spec.rb
@@ -34,7 +34,7 @@ describe CookbookArtifact do
       it "returns the feedback and status from the Cookstyle run" do
         feedback, status = artifact.criticize
 
-        expect(feedback).to match(/Chef\/Deprecations\/NodeSet/)
+        expect(feedback).to match(%r{Chef/Deprecations/NodeSet})
         expect(status).to be true
       end
 

--- a/src/supermarket/engines/fieri/spec/models/cookstyle_worker_spec.rb
+++ b/src/supermarket/engines/fieri/spec/models/cookstyle_worker_spec.rb
@@ -40,10 +40,10 @@ describe CookstyleWorker do
 
     assert_requested(:post, test_evaluation_endpoint) do |req|
       req.body =~ /cookstyle_failure=true/
-      req.body =~ /Chef\/Deprecations\/ResourceWithoutUnifiedTrue:/
+      req.body =~ %r{Chef/Deprecations/ResourceWithoutUnifiedTrue:}
       req.body =~ /#{Cookstyle::VERSION}/
       ENV["COOKSTYLE_COPS"].split(/\s|,/).each do |tag|
-        expect(req.body).to include(tag.gsub("/","%2F"))
+        expect(req.body).to include(tag.gsub("/", "%2F"))
       end
 
     end

--- a/src/supermarket/engines/fieri/spec/rails_helper.rb
+++ b/src/supermarket/engines/fieri/spec/rails_helper.rb
@@ -11,8 +11,8 @@ require "sidekiq/testing"
 require "webmock/rspec"
 require "sidekiq/api"
 require "quality_metric/cookstyle_helpers"
-require 'mixlib/shellout'
-require 'fileutils'
+require "mixlib/shellout"
+require "fileutils"
 
 Sidekiq::Testing.fake!
 


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

Fieri chefstyle was not getting executed due to /engines folder being excluded in rubocop.yml  for main src directory.

Ran chefstyle using 
`bundle exec chefstyle --ignore-parent-exclusion` 
and also updated chefstyle command in workflow configuration


### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
