### PR TITLE
Added clause to ignore cop UnlessDefinedRequire in rubocop.yml

### DIFF
--- a/src/supermarket/engines/fieri/.rubocop.yml
+++ b/src/supermarket/engines/fieri/.rubocop.yml
@@ -14,3 +14,5 @@ Layout/MultilineOperationIndentation:
   EnforcedStyle: aligned
 Style/SymbolArray:
   EnforcedStyle: brackets
+Chef/Ruby/UnlessDefinedRequire:
+  Enabled: false

--- a/src/supermarket/engines/fieri/lib/quality_metric/cookstyle_helpers.rb
+++ b/src/supermarket/engines/fieri/lib/quality_metric/cookstyle_helpers.rb
@@ -1,7 +1,7 @@
-require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
+require "mixlib/shellout"
 require "dotenv-rails"
 Dotenv.load(".env")
-require "shellwords" unless defined?(Shellwords)
+require "shellwords"
 
 module CookstyleHelpers
   def self.process_artifact(path)
@@ -19,11 +19,10 @@ module CookstyleHelpers
     offenses_arr = JSON.parse(cookstyle_output)["files"].map { |h|
       h["offenses"]\
         .each { |a| a.merge!("file" => h["path"]) }
-    }                   \
-      .flatten.sort_by { |hsh| hsh["cop_name"] }\
+    }.flatten.sort_by { |hsh| hsh["cop_name"] }\
       .each { |a|
         status << "#{[a["cop_name"], a["message"],\
-    a["file"], a["location"]["line"]].join(": ")}\n"
+        a["file"], a["location"]["line"]].join(": ")}\n"
       }
 
     [status, offenses_arr.size > 0]


### PR DESCRIPTION
### Description

Rubocop cop - `Chef/Ruby/UnlessDefinedRequire` , stops the file from loading a module in case its already loaded. 

This is causing issues since rails zeitwerk tries to autoload all the dependencies beforehand but in few cases the dependencies are not loaded properly and hence need to be re-loaded on the run time. This was breaking the execution of cookstyle and hence the cop is disabled.

### Issues Resolved

chefstyle autocorrection in engines directory broke the running cookstyle metric feature.

### Check List

- [x] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
