### PR TITLE
Remove requirements since these are bundled

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ This repository has the code for the **Supermarket** application and the omnibus
 
 * [chef-cookbooks/supermarket-omnibus-cookbook](https://github.com/chef-cookbooks/supermarket-omnibus-cookbook): This cookbook is used to deploy Supermarket through the Supermarket omnibus package. For details on using this cookbook to install Supermarket omnibus, check out [this webinar by the Supermarket Engineering team](https://www.chef.io/webinars/?commid=164925).
 
-## Requirements
-
-* Ruby 2.7.5
-* PostgreSQL 13.4
-* Redis 6.2.5
-
 ## Development
 
 ### Configuration


### PR DESCRIPTION
It doesn't make much sense to call these out as requirements since this is all packages. If we want to call out the currently packaged tools and what you would need for development that should live elsewhere.

Signed-off-by: Tim Smith <tsmith@chef.io>