### PR TITLE
Make cookstyle a runtime dep for Fieri

### DIFF
--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: engines/fieri
   specs:
     fieri (0.0.1)
+      cookstyle (>= 7.30)
       dotenv-rails
       mixlib-archive (>= 0.4, < 2.0)
       octokit (~> 4.16)

--- a/src/supermarket/engines/fieri/Gemfile
+++ b/src/supermarket/engines/fieri/Gemfile
@@ -13,7 +13,7 @@ gemspec
 # To use debugger
 # gem 'debugger'
 group :development, :test do
-  gem "chefstyle", "2.2.2"
+  gem "chefstyle"
   gem "pry"
   gem "rspec-rails", "~> 5.1"
   gem "rubocop-rails", require: false
@@ -21,6 +21,4 @@ group :development, :test do
   gem "webmock"
   gem "mixlib-shellout", "~> 3.2"
   gem "mixlib-archive", ">= 0.4", "< 2.0"
-  gem "cookstyle", "7.32.1"
-  gem "rubocop", "1.25.1"
 end

--- a/src/supermarket/engines/fieri/Gemfile.lock
+++ b/src/supermarket/engines/fieri/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     fieri (0.0.1)
+      cookstyle (>= 7.30)
       dotenv-rails
       mixlib-archive (>= 0.4, < 2.0)
       octokit (~> 4.16)
@@ -251,14 +252,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  chefstyle (= 2.2.2)
-  cookstyle (= 7.32.1)
+  chefstyle
   fieri!
   mixlib-archive (>= 0.4, < 2.0)
   mixlib-shellout (~> 3.2)
   pry
   rspec-rails (~> 5.1)
-  rubocop (= 1.25.1)
   rubocop-rails
   sqlite3
   webmock

--- a/src/supermarket/engines/fieri/fieri.gemspec
+++ b/src/supermarket/engines/fieri/fieri.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency "octokit", "~> 4.16" # 4.16+ fixes deprecations in auth
   s.add_dependency "rails", [">= 6.1", "< 7"]
   s.add_dependency "sidekiq", ">= 6.4", "< 7.0"
+  s.add_dependency "cookstyle", ">= 7.30"
 end

--- a/src/supermarket/engines/fieri/spec/models/cookstyle_worker_spec.rb
+++ b/src/supermarket/engines/fieri/spec/models/cookstyle_worker_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "cookstyle"
 
 describe CookstyleWorker do
   let(:valid_params) do
@@ -37,7 +38,6 @@ describe CookstyleWorker do
 
   it "sends a post request to the results endpoint" do
     subject.perform(valid_params)
-
     assert_requested(:post, test_evaluation_endpoint) do |req|
       req.body =~ /cookstyle_failure=true/
       req.body =~ %r{Chef/Deprecations/ResourceWithoutUnifiedTrue:}


### PR DESCRIPTION
This is required for the cookbook quality metrics. Also unppin chefstyle and remove rubocop. Let the gemfile.lock do what it does best here.

Signed-off-by: Tim Smith <tsmith@chef.io>