### PR TITLE
Created provision to enable or disable protection from host header attacks

### DIFF
--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -54,6 +54,14 @@ This configuration file has the following general settings:
 
 : The fully qualified domain name for the Supermarket server. Defaults to using the current FQDN for the machine.
 
+`default['supermarket']['disable_host_header_attack']`
+
+: This flag is to allow/restrict injection of arbitrary host headers in the API calls to supermarket. The scenarios in which this flag will be useful is e.g. if supermarket runs behind an AWS ELB (load balancer), the internal healthcheck API calls to supermarket invoked by the load balancer get responded with status code: 403 (forbidden) if this flag is set to `true`. So to unblock the healthcheck API calls invoked by the ELB we need to set this flag as `false`
+
+`default['supermarket']['allowed_host']`
+
+: This attribute is to set the Allowed Host for supermarket to block arbitrary [Host header injection](https://crashtest-security.com/invalid-host-header/) in the API calls to supermarket. This is by default set as the value of the FQDN(`default['supermarket']['fqdn']`). You can also set this attribute explicitly as the the domain name of your supermarket website e.g. <https://supermarket.chef.io>. You also need to keep the flag: `disable_host_header_attack` as `true` to make this attribute effective. If `disable_host_header_attack` is set to `false` then this attribute will be ignored.
+
 `default['supermarket']['from_email']`
 
 : The default sender address of all Supermarket mailers. Default value: `nil`.

--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -56,7 +56,7 @@ This configuration file has the following general settings:
 
 `default['supermarket']['disable_host_header_attack']`
 
-: This flag is to allow/restrict injection of arbitrary host headers in the API calls to supermarket. The scenarios in which this flag will be useful is e.g. if supermarket runs behind an AWS ELB (load balancer), the internal healthcheck API calls to supermarket invoked by the load balancer get responded with status code: 403 (forbidden) if this flag is set to `true`. So to unblock the healthcheck API calls invoked by the ELB we need to set this flag as `false`
+: This flag is to allow/restrict injection of arbitrary host headers in the API calls to supermarket. The scenarios in which this flag will be useful is e.g. if supermarket runs behind an AWS ELB (load balancer), the internal health-check API calls to supermarket invoked by the load balancer get responded with status code: 403 (forbidden) if this flag is set to `true`. So to unblock the health-check API calls invoked by the ELB we need to set this flag as `false`
 
 `default['supermarket']['allowed_host']`
 

--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -359,12 +359,16 @@ default['supermarket']['github_client_option_access_token_url'] = nil
 # recommend false; set to true as default for backward compatibility
 default['supermarket']['owners_can_remove_artifacts'] = true
 
-# The below flag is to allow arbitrary host headers. The scenarios
-# in which this flag needs to be set to false is e.g. if supermarket
-# runs behind an AWS ELB load balancer.
+# The below flag is to allow/disallow injection of arbitrary host headers in the API calls.
+# The scenarios in which this flag will be useful is e.g.
+# if supermarket runs behind an AWS ELB (load balancer), the internal healthcheck
+# calls invoked by the load balancer get responded with status code 403 (forbidden) if this flag is set to true.
+# So to unblock the healthcheck API we need to set this flag as false
 default['supermarket']['disable_host_header_attack'] = true
-# Setting allowed host for supermarket to avoid arbitrary "Host" header injection
+# Setting allowed_host for supermarket to avoid arbitrary "Host" header injection
 # Set this value to the domain name of your supermarket website e.g. supermarket.chef.io
+# You also need to keep the flag: disable_host_header_attack as true to make it effective
+# If disable_host_header_attack is false then this flag will be ignored.
 default['supermarket']['allowed_host'] = node['supermarket']['fqdn']
 
 # ### Chef URL Settings

--- a/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/attributes/default.rb
@@ -359,6 +359,10 @@ default['supermarket']['github_client_option_access_token_url'] = nil
 # recommend false; set to true as default for backward compatibility
 default['supermarket']['owners_can_remove_artifacts'] = true
 
+# The below flag is to allow arbitrary host headers. The scenarios
+# in which this flag needs to be set to false is e.g. if supermarket
+# runs behind an AWS ELB load balancer.
+default['supermarket']['disable_host_header_attack'] = true
 # Setting allowed host for supermarket to avoid arbitrary "Host" header injection
 # Set this value to the domain name of your supermarket website e.g. supermarket.chef.io
 default['supermarket']['allowed_host'] = node['supermarket']['fqdn']

--- a/src/supermarket/.env
+++ b/src/supermarket/.env
@@ -30,4 +30,5 @@ FIERI_SUPERMARKET_ENDPOINT=http://localhost:13000
 ROBOTS_ALLOW=/
 ENFORCE_PRIVACY=true
 COOKSTYLE_COPS=Chef/Deprecations,Chef/Correctness,Chef/Sharing,Chef/RedundantCode,Chef/Modernize,Chef/Security,InSpec/Deprecations
+DISABLE_HOST_HEADER_ATTACK=true
 ALLOWED_HOST=YOUR_SUPERMARKET_DOMAIN_NAME

--- a/src/supermarket/config/environments/production.rb
+++ b/src/supermarket/config/environments/production.rb
@@ -115,5 +115,7 @@ Rails.application.configure do
 
   # The value of ENV["DISABLE_HOST_HEADER_ATTACK"] will be parsed as string.
   # Hence we need to convert string to boolean.
-  config.hosts << ENV["ALLOWED_HOST"] if ActiveModel::Type::Boolean.new.cast(ENV["DISABLE_HOST_HEADER_ATTACK"]) && ENV["ALLOWED_HOST"].present?
+  if ActiveModel::Type::Boolean.new.cast(ENV["DISABLE_HOST_HEADER_ATTACK"]) && ENV["ALLOWED_HOST"].present?
+    config.hosts << ENV["ALLOWED_HOST"]
+  end
 end

--- a/src/supermarket/config/environments/production.rb
+++ b/src/supermarket/config/environments/production.rb
@@ -113,5 +113,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.hosts << ENV["ALLOWED_HOST"] if ENV["ALLOWED_HOST"].present?
+  # The value of ENV["DISABLE_HOST_HEADER_ATTACK"] will be parsed as string.
+  # Hence we need to convert string to boolean.
+  config.hosts << ENV["ALLOWED_HOST"] if ActiveModel::Type::Boolean.new.cast(ENV["DISABLE_HOST_HEADER_ATTACK"]) && ENV["ALLOWED_HOST"].present?
 end


### PR DESCRIPTION
### Description

This PR is to create a provision for the customers of supermarket to either allow/disallow the protection against host header injection attack. This is to resolve the issue where supermarket runs behind an AWS ELB and when the ELB performs the healthcheck against the target instance the healthcheck API responds with status code 403 (forbidden). Now this flag will allow the customers to disable the protection and allow arbitrary host headers in the API calls thus allowing the ELB healthcheck operation.

### Issues Resolved

https://github.com/chef/supermarket/issues/2628

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [X] PR title is a worthy inclusion in the CHANGELOG
