### PR TITLE
Added missing include runit service in nginx

### DIFF
--- a/omnibus/cookbooks/omnibus-supermarket/recipes/nginx.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/nginx.rb
@@ -18,6 +18,7 @@
 #
 
 include_recipe 'omnibus-supermarket::config'
+include_recipe 'enterprise::runit'
 
 [node['supermarket']['nginx']['cache']['directory'],
  node['supermarket']['nginx']['log_directory'],


### PR DESCRIPTION
Signed-off-by: saghoshprogress <saghosh@progress.com>

### Description
"Added missing include runit service in Nginx, as in ruby 3+ we need to include the dependency.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [x] New functionality includes tests
- [ ] All buildkite tests pass https://buildkite.com/chef/chef-supermarket-main-omnibus-adhoc/builds/501
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
