### PR TITLE
Restore will not work without the username

### DIFF
--- a/docs-chef-io/content/supermarket/supermarket_backup_restore.md
+++ b/docs-chef-io/content/supermarket/supermarket_backup_restore.md
@@ -95,5 +95,5 @@ The restore does not support transferring backups across different versions of S
 For example, to restore a backup in a .dump format, run:
 
 ```bash
-pg_restore --host localhost --port 15432 --clean --no-acl --no-owner --dbname supermarket_production --verbose supermarket_database_backup.dump
+/opt/supermarket/embedded/bin/pg_restore -U supermarket --host localhost --port 15432 --clean --no-acl --no-owner --dbname supermarket --verbose supermarket_database_backup.dump
 ```

--- a/docs-chef-io/content/supermarket/supermarket_backup_restore.md
+++ b/docs-chef-io/content/supermarket/supermarket_backup_restore.md
@@ -95,5 +95,5 @@ The restore does not support transferring backups across different versions of S
 For example, to restore a backup in a .dump format, run:
 
 ```bash
-/opt/supermarket/embedded/bin/pg_restore -U supermarket --host localhost --port 15432 --clean --no-acl --no-owner --dbname supermarket --verbose supermarket_database_backup.dump
+/opt/supermarket/embedded/bin/pg_restore --username supermarket --host localhost --port 15432 --clean --no-acl --no-owner --dbname supermarket --verbose ~/supermarket_database_backup.dump
 ```


### PR DESCRIPTION

Signed-off-by: Sean Horn <sean_horn@opscode.com>

### Description

Always asks for a password without the proper username specified.

We specify the supermarket username so that the pg_hba.conf allows us through with no password

### Issues Resolved

Unable to restore, asks for the password for a user we will not know

### Check List

- [ ] New functionality includes tests. Only docs
- [ ] All buildkite tests pass. Only docs
- [ ] Full omnibus build and tests in buildkite pass. Only docs
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
