### PR TITLE
Move shortcodes used in supermarket docs to supermarket repo.

### DIFF
--- a/docs-chef-io/Makefile
+++ b/docs-chef-io/Makefile
@@ -3,9 +3,11 @@
 SHELL=bash
 
 preview_netlify: chef_web_docs
-	cp -R content/* chef-web-docs/_vendor/github.com/chef/supermarket/docs-chef-io/content
+	rm -rf chef-web-docs/_vendor/github.com/chef/supermarket/docs-chef-io/*
+	cp -R content chef-web-docs/_vendor/github.com/chef/supermarket/docs-chef-io/content
+	cp -R layouts chef-web-docs/_vendor/github.com/chef/supermarket/docs-chef-io/layouts
 	cp -R config.toml chef-web-docs/_vendor/github.com/chef/supermarket/docs-chef-io/config.toml
-	pushd chef-web-docs && make bundle; hugo --buildFuture --gc --minify && popd
+	pushd chef-web-docs && make bundle; hugo --buildFuture --gc --minify --environment development && popd
 
 serve: chef_web_docs
 	echo "replace github.com/chef/supermarket/docs-chef-io => ../" >> chef-web-docs/go.mod

--- a/docs-chef-io/content/supermarket/_index.md
+++ b/docs-chef-io/content/supermarket/_index.md
@@ -15,7 +15,7 @@ aliases = ["/supermarket.html"]
     weight = 10
 +++
 
-{{% supermarket_summary %}}
+{{% supermarket/supermarket_summary %}}
 
 ## Public Supermarket
 
@@ -27,4 +27,4 @@ To interact with the public Chef Supermarket, use [knife supermarket](/workstati
 
 ## Private Supermarket
 
-{{% supermarket_private %}}
+{{% supermarket/supermarket_private %}}

--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -12,7 +12,13 @@ aliases = ["/config_rb_supermarket.html", "/config_rb_supermarket/"]
     weight = 30
 +++
 
-{{% config_rb_supermarket_summary %}}
+The supermarket.rb file contains all of the non-default configuration
+settings used by the Chef Supermarket. The default settings are built-in
+to the Chef Supermarket configuration, and should only be added to the
+supermarket.rb file to apply non-default values. These configuration
+settings are processed when the `supermarket-ctl reconfigure` command is
+run. The supermarket.rb file is a Ruby file, which means that
+conditional statements can be used in the configuration file.
 
 ## Settings
 

--- a/docs-chef-io/content/supermarket/ctl_supermarket.md
+++ b/docs-chef-io/content/supermarket/ctl_supermarket.md
@@ -12,7 +12,11 @@ aliases = ["/ctl_supermarket.html", "/ctl_supermarket/"]
     weight = 10
 +++
 
-{{% ctl_supermarket_summary %}}
+The Chef Supermarket installations that are done using the Chef
+installer include a command-line utility named supermarket-ctl. This
+command-line tool is used to start and stop individual services,
+reconfigure the Chef Supermarket server, run smoke tests, and tail the
+Chef Supermarket log files.
 
 ## make-admin
 
@@ -220,7 +224,7 @@ To revert the `uninstall` subcommand, run the `reconfigure` subcommand (because 
 
 ## Service Subcommands
 
-{{% ctl_common_service_subcommands %}}
+{{% chef-server/ctl_common_service_subcommands %}}
 
 ### hup
 

--- a/docs-chef-io/content/supermarket/install_supermarket.md
+++ b/docs-chef-io/content/supermarket/install_supermarket.md
@@ -12,7 +12,13 @@ aliases = ["/install_supermarket.html", "/install_supermarket/"]
     weight = 20
 +++
 
-{{% supermarket_private_source_code %}}
+The source code for Chef Supermarket is located at the following URLs:
+
+- The application itself: <https://github.com/chef/supermarket>.
+    Report issues to: <https://github.com/chef/supermarket/issues>.
+- The cookbook that is run by the `supermarket-ctl reconfigure`
+    command:
+    <https://github.com/chef/supermarket/tree/main/omnibus/cookbooks/omnibus-supermarket>
 
 ## Requirements
 
@@ -51,7 +57,7 @@ To configure Chef Supermarket to use Chef Identity, do the following:
 
 2. Update the `/etc/opscode/chef-server.rb` configuration file.
 
-    {{< readFile_shortcode file="config_ocid_application_hash_supermarket.md" >}}
+    {{< readfile file="layouts/shortcodes/chef-server/config_ocid_application_hash_supermarket.md" >}}
 
 3. Reconfigure the Chef Infra Server.
 

--- a/docs-chef-io/content/supermarket/supermarket_api.md
+++ b/docs-chef-io/content/supermarket/supermarket_api.md
@@ -17,7 +17,7 @@ aliases = ["/supermarket_api.html", "/supermarket_api/"]
 In general, using knife (and the `knife supermarket` subcommand) to manage cookbooks that are located on the Cookbooks site is more efficient than using the Supermarket API and is the recommended approach for managing cookbooks on that site. This document provides information about the Supermarket API in the event that using the API is necessary.
 {{< /note >}}
 
-{{% supermarket_api_summary %}}
+{{% supermarket/supermarket_api_summary %}}
 
 ## Endpoints
 

--- a/docs-chef-io/content/supermarket/supermarket_private.md
+++ b/docs-chef-io/content/supermarket/supermarket_private.md
@@ -12,8 +12,8 @@ aliases = ["/supermarket.html", "/supermarket_private/"]
     weight = 10
 +++
 
-{{% supermarket_summary %}}
+{{% supermarket/supermarket_summary %}}
 
 ## Private Supermarket
 
-{{% supermarket_private %}}
+{{% supermarket/supermarket_private %}}

--- a/docs-chef-io/layouts/shortcodes/supermarket/supermarket_api_summary.md
+++ b/docs-chef-io/layouts/shortcodes/supermarket/supermarket_api_summary.md
@@ -1,0 +1,7 @@
+The Supermarket API is used to provide access to cookbooks, tools, and
+users on the [Chef Supermarket](https://supermarket.chef.io). All of the
+cookbooks, tools, and users on the Supermarket are accessible through a
+RESTful API by accessing `supermarket.chef.io/api/v1/` using the supported
+endpoints. In most cases, knife is the best way to interact with the
+Supermarket; however in some cases, direct use of the Supermarket API is
+necessary.

--- a/docs-chef-io/layouts/shortcodes/supermarket/supermarket_private.md
+++ b/docs-chef-io/layouts/shortcodes/supermarket/supermarket_private.md
@@ -1,0 +1,4 @@
+The private Chef Supermarket is installed behind the firewall on the
+internal network. Outside of changing the location from which community
+cookbooks are maintained, it otherwise behaves the same as the public
+Chef Supermarket.

--- a/docs-chef-io/layouts/shortcodes/supermarket/supermarket_summary.md
+++ b/docs-chef-io/layouts/shortcodes/supermarket/supermarket_summary.md
@@ -1,0 +1,14 @@
+Chef Supermarket is the site for community cookbooks. It provides a searchable cookbook repository and a friendly web UI. Cookbooks
+that are part of the Chef Supermarket are accessible by any Chef user.
+
+There are two ways to use Chef Supermarket:
+
+- The public Chef Supermarket is hosted by Chef Software and is
+    located at [Chef Supermarket](https://supermarket.chef.io/).
+- A private Chef Supermarket may be installed on-premise behind the
+    firewall on the internal network. Cookbook retrieval from a private
+    Chef Supermarket is often faster than from the public Chef
+    Supermarket because of closer proximity and fewer cookbooks to
+    resolve. A private Chef Supermarket can also help formalize internal
+    cookbook release management processes (e.g. "a cookbook is not
+    released until it is published on the private Chef Supermarket").


### PR DESCRIPTION
### Description

- Move shortcodes that belong in supermarket from `chef-web-docs` to `supermarket`.
- Delete shortcodes used only once and place text in page.
- Replace any use of `readFile_shortcode` shortcode with `readfile` shortcode.
- Update any shortcodes moved from `chef-web-docs` to other repositories.
- Update/improve docs makefile used by Netlify.


### Issues Resolved

https://chefio.atlassian.net/browse/CHEFDOCS-199

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
