### PR TITLE
Revert "Bump ddtrace from 1.0.0 to 1.1.0 in /src/supermarket"

### DIFF
--- a/src/supermarket/Gemfile
+++ b/src/supermarket/Gemfile
@@ -16,7 +16,7 @@ gem "sidekiq-cron"
 gem "aws-sdk-s3"
 gem "chef", "~> 17.10", require: false
 gem "compass-rails"
-gem "ddtrace", "1.1.0", require: false
+gem "ddtrace", "1.0.0", require: false
 gem "dotenv"
 gem "ffi-libarchive"
 gem "foreman"

--- a/src/supermarket/Gemfile.lock
+++ b/src/supermarket/Gemfile.lock
@@ -206,12 +206,11 @@ GEM
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
-    ddtrace (1.1.0)
-      debase-ruby_core_source (<= 0.10.16)
-      libddprof (~> 0.6.0.1.0)
-      libddwaf (~> 1.3.0.2.0)
+    ddtrace (1.0.0)
+      debase-ruby_core_source (<= 0.10.15)
+      libddwaf (~> 1.3.0.0.0.a)
       msgpack
-    debase-ruby_core_source (0.10.16)
+    debase-ruby_core_source (0.10.15)
     diff-lcs (1.5.0)
     digest (3.1.0)
     docile (1.4.0)
@@ -387,8 +386,7 @@ GEM
       letter_opener (~> 1.7)
       railties (>= 5.2)
       rexml
-    libddprof (0.6.0.1.0-x86_64-linux)
-    libddwaf (1.3.0.2.0-x86_64-linux)
+    libddwaf (1.3.0.0.0-x86_64-linux)
       ffi (~> 1.0)
     libhoney (2.2.0)
       addressable (~> 2.0)
@@ -440,7 +438,7 @@ GEM
     mixlib-log (3.0.9)
     mixlib-shellout (3.2.7)
       chef-utils
-    msgpack (1.5.2)
+    msgpack (1.5.1)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.2.0)
@@ -826,7 +824,7 @@ DEPENDENCIES
   compass-rails
   cookstyle (~> 7.32.1)
   database_cleaner
-  ddtrace (= 1.1.0)
+  ddtrace (= 1.0.0)
   dotenv
   dry-struct (~> 1.4)
   execjs


### PR DESCRIPTION
This reverts commit 3aeb3a2341a304f8a7cb17e1f0a1d2e57a2d5e71.

### Description

[Please describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
