### PR TITLE
Update doc for supermarket configuration with Chef Identity

### DIFF
--- a/docs-chef-io/content/supermarket/install_supermarket.md
+++ b/docs-chef-io/content/supermarket/install_supermarket.md
@@ -80,17 +80,29 @@ To configure Chef Supermarket to use Chef Identity, do the following:
 
     The `uid` and `secret` values will be needed later on during the setup process for Chef Supermarket.
 
-    For Chef Infra Server version a new field `confidential` would added to this configuration:
+{{< note >}}
 
-    ```javascript
-    {
-      "name": "supermarket",
-      "uid": "0bad0f2eb04e935718e081fb71asdfec3681c81acb9968a8e1e32451d08b",
-      "secret": "17cf1141cc971a10ce307611beda7ffadstr4f1bc98d9f9ca76b9b127879",
-      "redirect_uri": "https://supermarket.mycompany.com/auth/chef_oauth2/callback",
-      "confidential": true
-    }
-    ```
+Private Supermarket users upgrading to Chef Infra Server version 15.8.0 or above, need to refresh their logins and re-authenticate Supermarket(see [link]).
+
+{{< /note >}}
+
+For Chef Infra Server version 15.8.0 and above a new field `confidential` with default value `true` would be added to this configuration:
+
+```javascript
+{
+    "name": "supermarket",
+    "uid": "<uid>",
+    "secret": "<secret>",
+    "redirect_uri": "https://supermarket.mycompany.com/auth/chef_oauth2/callback",
+    "confidential": true
+}
+```
+
+{{< note >}}
+
+The new `confidential` field will automatically be added to the configuration with Chef Infra Server 15.8.0 release. There will be no additional action required from the existing Private Supermarket users.
+
+{{< /note >}}
 
 {{< note >}}
 

--- a/docs-chef-io/content/supermarket/install_supermarket.md
+++ b/docs-chef-io/content/supermarket/install_supermarket.md
@@ -67,42 +67,19 @@ To configure Chef Supermarket to use Chef Identity, do the following:
 
 4. Retrieve Supermarket's OAuth 2.0 client credentials:
 
-    Depending on your Chef Infra Server version and configuration (see [chef-server.rb](/server/config_rb_server_optional_settings/#config-rb-server-insecure-addon-compat)), this can be retrieved via [chef-server-ctl oc-id-show-app supermarket](/ctl_chef_server/#ctl-chef-server-oc-id-show-app) or is located in `/etc/opscode/oc-id-applications/supermarket.json`:
+    Depending on your Chef Infra Server version and configuration (see [chef-server.rb](/server/config_rb_server_optional_settings/#general-14)), you can retrieve this from [chef-server-ctl oc-id-show-app supermarket](/server/ctl_chef_server/#oc-id-show-app) or find it in `/etc/opscode/oc-id-applications/supermarket.json`:
 
-    ```javascript
+    ```json
     {
       "name": "supermarket",
       "uid": "0bad0f2eb04e935718e081fb71asdfec3681c81acb9968a8e1e32451d08b",
       "secret": "17cf1141cc971a10ce307611beda7ffadstr4f1bc98d9f9ca76b9b127879",
-      "redirect_uri": "https://supermarket.mycompany.com/auth/chef_oauth2/callback"
+      "redirect_uri": "https://supermarket.example.com/auth/chef_oauth2/callback",
+      "confidential": true
     }
     ```
 
-    The `uid` and `secret` values will be needed later on during the setup process for Chef Supermarket.
-
-{{< note >}}
-
-Private Supermarket users upgrading to Chef Infra Server version 15.8.0 or above, need to refresh their logins and re-authenticate Supermarket(see [link]).
-
-{{< /note >}}
-
-For Chef Infra Server version 15.8.0 and above a new field `confidential` with default value `true` would be added to this configuration:
-
-```javascript
-{
-    "name": "supermarket",
-    "uid": "<uid>",
-    "secret": "<secret>",
-    "redirect_uri": "https://supermarket.mycompany.com/auth/chef_oauth2/callback",
-    "confidential": true
-}
-```
-
-{{< note >}}
-
-The new `confidential` field will automatically be added to the configuration with Chef Infra Server 15.8.0 release. There will be no additional action required from the existing Private Supermarket users.
-
-{{< /note >}}
+    You will need the `uid` and `secret` later on during the setup process for Chef Supermarket.
 
 {{< note >}}
 

--- a/docs-chef-io/content/supermarket/install_supermarket.md
+++ b/docs-chef-io/content/supermarket/install_supermarket.md
@@ -80,6 +80,18 @@ To configure Chef Supermarket to use Chef Identity, do the following:
 
     The `uid` and `secret` values will be needed later on during the setup process for Chef Supermarket.
 
+    For Chef Infra Server version a new field `confidential` would added to this configuration:
+
+    ```javascript
+    {
+      "name": "supermarket",
+      "uid": "0bad0f2eb04e935718e081fb71asdfec3681c81acb9968a8e1e32451d08b",
+      "secret": "17cf1141cc971a10ce307611beda7ffadstr4f1bc98d9f9ca76b9b127879",
+      "redirect_uri": "https://supermarket.mycompany.com/auth/chef_oauth2/callback",
+      "confidential": true
+    }
+    ```
+
 {{< note >}}
 
 Add as many Chef Identity applications to the `/etc/opscode/chef-server.rb` configuration file as necessary. A JSON file is generated for each application added, which contains the authentication tokens for that application. The secrets are added to the Chef Identity database and are available to all nodes in the Chef Infra Server front end group. The generated JSON files do not need to be copied anywhere.

--- a/docs-chef-io/content/supermarket/supermarket_upgrade.md
+++ b/docs-chef-io/content/supermarket/supermarket_upgrade.md
@@ -157,19 +157,7 @@ Each Private Supermarket installation is unique. The PostgreSQL upgrade steps ar
 
 ## Release Specific Upgrade: Chef Infra Server 15.8.x
 
-Private Supermarket users upgrading to Chef Infra Server version 15.8.0 or above, will be required to refresh their logins and re-authenticate Supermarket with Chef Identity.
- As part of this upgrade a new text would be added to the existing authorization prompt in Chef Identity.
-
-    The application will be able to :
-    Read
-
-The new text signifies the authorization scope(Read, in this case) granted to the application.
-
-{{< note >}}
-
-This text is purely informatory and doesn't require any additional action from existing Private Supermarket users during authorization.
-
-{{< /note >}}
+Private Supermarket users upgrading to Chef Infra Server version 15.8.0 or above must refresh their logins and re-authenticate Supermarket with Chef Identity.
 
 ## Troubleshooting
 

--- a/docs-chef-io/content/supermarket/supermarket_upgrade.md
+++ b/docs-chef-io/content/supermarket/supermarket_upgrade.md
@@ -155,6 +155,22 @@ Each Private Supermarket installation is unique. The PostgreSQL upgrade steps ar
     sudo supermarket-ctl restart
     ```
 
+## Release Specific Upgrade: Chef Infra Server 15.8.x
+
+Private Supermarket users upgrading to Chef Infra Server version 15.8.0 or above, will be required to refresh their logins and re-authenticate Supermarket with Chef Identity.
+ As part of this upgrade a new text would be added to the existing authorization prompt in Chef Identity.
+
+    The application will be able to :
+    Read
+
+The new text signifies the authorization scope(Read, in this case) granted to the application.
+
+{{< note >}}
+
+This text is purely informatory and doesn't require any additional action from existing Private Supermarket users during authorization.
+
+{{< /note >}}
+
 ## Troubleshooting
 
 ### Recovering from Database Cleanup Failures


### PR DESCRIPTION
### Description
As part of the oc-id upgrade, it was  found that one of the main gem Doorkeeper has two  security vulnerability issues:
- [CVE-2018-1000211](https://nvd.nist.gov/vuln/detail/CVE-2018-1000211)
- [CVE-2020-10187](https://nvd.nist.gov/vuln/detail/CVE-2020-10187)
Consequentially,  doorkeeper gem has been upgraded from version 4.3 to use 5+. As a part of the doorkeeper upgrade, there has been few updates  in the authorization of applications such as Supermarket with `oc-id` or Chef-Identity. 
The same change that would entail this upgrade has been outlined here: [Supermarket authorization with Chef Identity](https://chefio.atlassian.net/wiki/spaces/TP/blog/2023/09/18/2816737399/Supermarket+authorization+with+Chef+Identity)
### Issues Resolved
This PR aims to update `install_supermarket.md` file to reflect the addition of a new field `confidential` to the supermarket config file for Chef Infra Server versions 15.8.x
Retrieval of  Supermarket's OAuth 2.0 client credentials will the return this config along with this new `confidential` field.

### Demo
1. [supermarket_integration_smoke_test.mov](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/Eb4LhzZpbQFNp__Lh_wCUfoB0kGDTkKhA7sIb_4nKya6tA?e=1UIPD3)
2. [Cookbook_upload_download.mov](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/EfdnRfVb-lNFr7EYSapcphABcgpCdceXWxjliG51PhmjtQ?e=TwFole)


### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
