### PR TITLE
add doc changes for feature flag and gtm_id

### DIFF
--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -258,9 +258,9 @@ Use these settings to set up [Google Analytics](https://analytics.google.com) tr
 
 : Whether to enable Google Analytics tracking.
 
-  Allowed values: `true`, `false`.
+  Allowed values: `"true"`, `"false"`.
 
-  Default value: `false`.
+  Default value: `"false"`.
 
 `default['supermarket']['google_analytics_id']`
 
@@ -274,9 +274,9 @@ Use these settings to set up [Google Analytics](https://analytics.google.com) tr
 
 : Whether to enable [OneTrust](https://www.onetrust.com) cookie consent verification for Supermarket.
 
-  Allowed values: `true`, `false`.
+  Allowed values: `"true"`, `"false"`.
 
-  Default value: `false`.
+  Default value: `"false"`.
 
 ### Google Tag Manager
 
@@ -286,9 +286,9 @@ Use these settings to set up [Google Tag Manager](https://tagmanager.google.com/
 
 : Whether to enable google tag manager.
 
-  Allowed values: `true`, `false`.
+  Allowed values: `"true"`, `"false"`.
 
-  Default value: `false`.
+  Default value: `"false"`.
 
 `default['supermarket']['gtm_id']`
 

--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -252,11 +252,36 @@ Use these settings to integrate Supermarket with GitHub Enterprise.
 
 ### Google Analytics
 
-Use this setting to set up [Google Analytics](https://analytics.google.com) tracking for Supermarket:
+Use this setting to set up [Google Analytics with GTag](https://analytics.google.com) tracking for Supermarket:
+
+`default['supermarket']['enable_gtag']`
+
+: The Google tag feature flag's default value: "false". Set to `"true"` to enable google tag tracking.
 
 `default['supermarket']['google_analytics_id']`
 
 : The Google Analytics [tracking ID](https://support.google.com/analytics/answer/7372977?hl=en) for Supermarket. Default value: `nil`.
+
+
+### Onetrust
+
+Use this setting to enable [Onetrust](www.onetrust.com) cookie consent verification for Supermarket:
+
+`default['supermarket']['enable_onetrust']`
+
+: The Onetrust consent flag's default value: "false". Set to `"true"` to enable onetrust consent verification.
+
+### Google Tag Manager
+
+Use this setting to enable [Google Tag Manager](https://tagmanager.google.com/) for Supermarket:
+
+`default['supermarket']['enable_gtm']`
+
+: The Google tag manager feature flag's default value: "false". Set to `"true"` to enable google tag manager.
+
+`default['supermarket']['gtm_id']`
+
+: The Google Tag Manager [container ID](https://support.google.com/tagmanager/answer/6103696?hl=en) for Supermarket. Default value: nil.
 
 ### Nginx
 

--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -264,7 +264,7 @@ Use these settings to set up [Google Analytics](https://analytics.google.com) tr
 
 `default['supermarket']['google_analytics_id']`
 
-: The Google Analytics [tracking ID](https://support.google.com/analytics/answer/7372977?hl=en) for Supermarket.
+: The Google Analytics [tracking ID](https://support.google.com/analytics/answer/9539598?hl=en) for Supermarket.
 
   Default value: `nil`.
 

--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -284,7 +284,7 @@ Use these settings to set up [Google Tag Manager](https://tagmanager.google.com/
 
 `default['supermarket']['enable_gtm']`
 
-: Whether to enable google tag manager.
+: Whether to enable Google Tag Manager.
 
   Allowed values: `"true"`, `"false"`.
 
@@ -292,7 +292,7 @@ Use these settings to set up [Google Tag Manager](https://tagmanager.google.com/
 
 `default['supermarket']['gtm_id']`
 
-: The Google Tag Manager [container ID](https://support.google.com/tagmanager/answer/6103696?hl=en) for Supermarket. 
+: The Google Tag Manager [container ID](https://support.google.com/tagmanager/answer/6103696?hl=en) for Supermarket.
 
   Default value: `nil`.
 

--- a/docs-chef-io/content/supermarket/config_rb_supermarket.md
+++ b/docs-chef-io/content/supermarket/config_rb_supermarket.md
@@ -252,36 +252,49 @@ Use these settings to integrate Supermarket with GitHub Enterprise.
 
 ### Google Analytics
 
-Use this setting to set up [Google Analytics with GTag](https://analytics.google.com) tracking for Supermarket:
+Use these settings to set up [Google Analytics](https://analytics.google.com) tracking for Supermarket.
 
 `default['supermarket']['enable_gtag']`
 
-: The Google tag feature flag's default value: "false". Set to `"true"` to enable google tag tracking.
+: Whether to enable Google Analytics tracking.
+
+  Allowed values: `true`, `false`.
+
+  Default value: `false`.
 
 `default['supermarket']['google_analytics_id']`
 
-: The Google Analytics [tracking ID](https://support.google.com/analytics/answer/7372977?hl=en) for Supermarket. Default value: `nil`.
+: The Google Analytics [tracking ID](https://support.google.com/analytics/answer/7372977?hl=en) for Supermarket.
 
+  Default value: `nil`.
 
-### Onetrust
-
-Use this setting to enable [Onetrust](www.onetrust.com) cookie consent verification for Supermarket:
+### OneTrust
 
 `default['supermarket']['enable_onetrust']`
 
-: The Onetrust consent flag's default value: "false". Set to `"true"` to enable onetrust consent verification.
+: Whether to enable [OneTrust](https://www.onetrust.com) cookie consent verification for Supermarket.
+
+  Allowed values: `true`, `false`.
+
+  Default value: `false`.
 
 ### Google Tag Manager
 
-Use this setting to enable [Google Tag Manager](https://tagmanager.google.com/) for Supermarket:
+Use these settings to set up [Google Tag Manager](https://tagmanager.google.com/) for Supermarket:
 
 `default['supermarket']['enable_gtm']`
 
-: The Google tag manager feature flag's default value: "false". Set to `"true"` to enable google tag manager.
+: Whether to enable google tag manager.
+
+  Allowed values: `true`, `false`.
+
+  Default value: `false`.
 
 `default['supermarket']['gtm_id']`
 
-: The Google Tag Manager [container ID](https://support.google.com/tagmanager/answer/6103696?hl=en) for Supermarket. Default value: nil.
+: The Google Tag Manager [container ID](https://support.google.com/tagmanager/answer/6103696?hl=en) for Supermarket. 
+
+  Default value: `nil`.
 
 ### Nginx
 


### PR DESCRIPTION
### Description

Add documentation changes for following feature flags

- gtm_id
- enable_onetrust
- enable_gtm
- enable_gtag

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
