### PR TITLE
Fix issues with github actions

### DIFF
--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -20,25 +20,25 @@ jobs:
   cspell-action:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: carlosperate/download-file-action@v1.0.3
+      - uses: carlosperate/download-file-action@v2
         id: download-cspell-config
         with:
           file-url: 'https://github.com/chef/chef-web-docs/blob/main/cspell.yaml'
           file-name: 'cspell.yaml'
-      - uses: carlosperate/download-file-action@v1.0.3
+      - uses: carlosperate/download-file-action@v2
         id: download-chef-dictionary
         with:
           file-url: 'https://raw.githubusercontent.com/chef/chef_dictionary/main/chef.txt'
           file-name: 'chef_dictionary.txt'
-      - uses: carlosperate/download-file-action@v1.0.3
+      - uses: carlosperate/download-file-action@v2
         id: download-docs-dictionary
         with:
           file-url: 'https://raw.githubusercontent.com/chef/chef_dictionary/main/docs.txt'
           file-name: 'docs_dictionary.txt'
-      - uses: streetsidesoftware/cspell-action@v1.3.4
+      - uses: streetsidesoftware/cspell-action@v5
         with:
           files: '*.md'
           root: './docs-chef-io/content/supermarket'

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: carlosperate/download-file-action@v1.0.3
         id: download-cspell-config
         with:
-          file-url: 'https://github.com/chef/chef-web-docs/blob/main/cspell.json'
-          file-name: 'cspell.json'
+          file-url: 'https://github.com/chef/chef-web-docs/blob/main/cspell.yaml'
+          file-name: 'cspell.yaml'
       - uses: carlosperate/download-file-action@v1.0.3
         id: download-chef-dictionary
         with:

--- a/.github/workflows/docs-lint.yml
+++ b/.github/workflows/docs-lint.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: DavidAnson/markdownlint-cli2-action@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v14
         with:
           globs: |
             content/*.md

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,8 +4,11 @@ on:
 
 jobs:
   triage:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@main
+      - uses: actions/labeler@v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Description

Fix the GitHub actions

- the labeler action runs from the main branch, but was updated with breaking changes so now it blows up on every PR. This pins it to V4 of the labeler.
- I replaced the cspell.json with a YAML file so it's easier to read. This update should pull the correct file now.
- update other action deps

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG
