### PR TITLE
CHEF-6076:Whitelisting urls for GTM

### DIFF
--- a/src/supermarket/config/initializers/content_security_policy.rb
+++ b/src/supermarket/config/initializers/content_security_policy.rb
@@ -9,7 +9,7 @@ Rails.application.config.content_security_policy do |policy|
   policy.font_src :self, :https, :data, "http://fonts.gstatic.com"
   policy.img_src :self, :https, :data, "www.googletagmanager.com"
   policy.connect_src :self, :https, "wss://ws.hotjar.com"
-  policy.script_src :self, :blob, :https, :unsafe_eval, "https://www.googletagmanager.com",
+  policy.script_src :self, :blob, :https, "https://www.googletagmanager.com",
                                     "https://www.google-analytics.com",
                                     "http://cdn.segment.com"
   policy.object_src :none

--- a/src/supermarket/config/initializers/content_security_policy.rb
+++ b/src/supermarket/config/initializers/content_security_policy.rb
@@ -8,7 +8,10 @@ Rails.application.config.content_security_policy do |policy|
   policy.default_src :self, :https
   policy.font_src :self, :https, :data, "http://fonts.gstatic.com"
   policy.img_src :self, :https, :data, "www.googletagmanager.com"
-  policy.script_src :self, :https, "https://www.googletagmanager.com", "https://www.google-analytics.com", "http://cdn.segment.com"
+  policy.connect_src :self, :https, "wss://ws.hotjar.com"
+  policy.script_src :self, :blob, :https, :unsafe_eval, "https://www.googletagmanager.com",
+                                    "https://www.google-analytics.com",
+                                    "http://cdn.segment.com"
   policy.object_src :none
   # Need to keep the unsafe_inline for style-src directive as
   # there is an inline css embedded in the application.js file.


### PR DESCRIPTION
### Description

[Please describe what this change achieves]
Whitelisting urls to resolve errors related to GTM in supermarket 
Demo: [Whitelist_url_supermarket_gtm_demo.mov](https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/ERnfqMxfTLBMsLCzN6sNCVUBR6XjMXIiuJpoD7HgeB09_A?e=CHxFOa)
### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [x] All buildkite tests pass
- [x] Full omnibus build and tests in buildkite pass
- x ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
