### PR TITLE
supermarket upgrade instruction fix

### DIFF
--- a/docs-chef-io/content/supermarket/supermarket_upgrade.md
+++ b/docs-chef-io/content/supermarket/supermarket_upgrade.md
@@ -52,7 +52,7 @@ Every Private Supermarket installation is unique. These are general steps for up
          rpm -Uvh /path/to/package/supermarket*.rpm
          ```
 
-  1. Start the supermarket services
+  1. Start the Chef Supermarket services:
 
         ```bash
         sudo supermarket-ctl start

--- a/docs-chef-io/content/supermarket/supermarket_upgrade.md
+++ b/docs-chef-io/content/supermarket/supermarket_upgrade.md
@@ -52,6 +52,12 @@ Every Private Supermarket installation is unique. These are general steps for up
          rpm -Uvh /path/to/package/supermarket*.rpm
          ```
 
+  1. Start the supermarket services
+
+        ```bash
+        sudo supermarket-ctl start
+        ```
+
   1. Reconfigure Chef Supermarket server:
 
       ```bash


### PR DESCRIPTION
### Description

Currently the instructions to upgrade supermarket misses one step for which the reconfigure operation fails. This PR is to add the missing step in the public docs of supermarket which will fix this issue faced by customers.

### Issues Resolved

[CHEF-16756](https://progresssoftware.atlassian.net/browse/CHEF-16756)

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [ ] PR title is a worthy inclusion in the CHANGELOG


[CHEF-16756]: https://progresssoftware.atlassian.net/browse/CHEF-16756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ