### PR TITLE
Chef 26286 supermarket build issue for aws sdk gem

### DIFF
--- a/omnibus/Gemfile.lock
+++ b/omnibus/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 2dc7aa6530d7bf2860c6771f1f572e06d1b52907
+  revision: e5f302c1140764c1167ec89ed2138bca2cfa9b5e
   branch: main
   specs:
-    omnibus-software (24.6.323)
+    omnibus-software (25.9.346)
       omnibus (>= 9.0.0)
 
 GIT
   remote: https://github.com/chef/omnibus.git
-  revision: 3efa84c1a26daf55c4d477bf3653e5905ab4f737
+  revision: 39f0b3049936841589406bdcfb9d115f4db17041
   branch: main
   specs:
-    omnibus (9.0.25)
+    omnibus (9.1.1)
       aws-sdk-s3 (~> 1.116.0)
       chef-cleanroom (~> 1.0)
       chef-utils (>= 15.4)

--- a/omnibus/config/software/file.rb
+++ b/omnibus/config/software/file.rb
@@ -25,6 +25,8 @@ license "custom"
 license_file "COPYING"
 
 source url: "ftp://ftp.astron.com/pub/file/file-#{version}.tar.gz"
+internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/#{name}/#{name}-#{version}.tar.gz",
+                authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
 
 relative_path "file-#{version}"
 

--- a/omnibus/config/software/postgresql13.rb
+++ b/omnibus/config/software/postgresql13.rb
@@ -33,6 +33,9 @@ source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{vers
 version("13.18") { source sha256: "ceea92abee2a8c19408d278b68de6a78b6bd3dbb4fa2d653fa7ca745d666aab1" }
 version("13.4") { source sha256: "ea93e10390245f1ce461a54eb5f99a48d8cabd3a08ce4d652ec2169a357bc0cd" }
 
+internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/#{name}/#{name}-#{version}.tar.bz2",
+                authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
+
 relative_path "postgresql-#{version}"
 
 build do

--- a/omnibus/config/software/postgresql93-bin.rb
+++ b/omnibus/config/software/postgresql93-bin.rb
@@ -32,6 +32,9 @@ dependency "config_guess"
 source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
 version("9.3.25") { source sha256: "e4953e80415d039ccd33d34be74526a090fd585cf93f296cd9c593972504b6db" }
 
+internal_source url: "#{ENV["ARTIFACTORY_REPO_URL"]}/#{name}/postgresql-#{version}.tar.bz2",
+                authorization: "X-JFrog-Art-Api:#{ENV["ARTIFACTORY_TOKEN"]}"
+
 relative_path "postgresql-#{version}"
 
 build do

--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -33,7 +33,9 @@
 use_s3_caching true
 s3_access_key  ENV['AWS_ACCESS_KEY_ID']
 s3_secret_key  ENV['AWS_SECRET_ACCESS_KEY']
-s3_bucket      ENV['AWS_S3_BUCKET'] || 'opscode-omnibus-cache'
+s3_bucket      "opscode-omnibus-cache-private"
+s3_acl         "private"
+s3_region      "us-west-2"
 
 # Customize compiler bits
 # ------------------------------
@@ -44,6 +46,9 @@ fetcher_read_timeout 120
 # ------------------------------
 # software_gems ['omnibus-software', 'my-company-software']
 # local_software_dirs ['/path/to/local/software']
+
+# note, this is statically set in the omnibus-buildkite-plugin, you are always going to be forced to use internal sources. If you dont want internal sources, you must enable this to false.
+use_internal_sources ENV.fetch("OMNIBUS_USE_INTERNAL_SOURCES", true)
 
 # Build in FIPS compatability mode
 # ------------------------------


### PR DESCRIPTION
### Description

[Please describe what this change achieves]

- Updated dependency source files to fetch packages from the internal Artifactory .

- Modified the Gemfile to use the latest version of Omnibus software that includes the fix to fetch dependencies from internal sources.
 
- Changed configuration to fetch sources from the S3 private bucket, utilizing the updated Omnibus version for improved reliability and compliance with internal sourcing

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All buildkite tests pass
- [ ] Full omnibus build and tests in buildkite pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/main/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [x] PR title is a worthy inclusion in the CHANGELOG
