### PR TITLE
Potential fix for code scanning alert no. 30: Code injection

### DIFF
--- a/src/supermarket/app/controllers/collaborators_controller.rb
+++ b/src/supermarket/app/controllers/collaborators_controller.rb
@@ -1,6 +1,10 @@
 class CollaboratorsController < ApplicationController
   include CollaboratorProcessing
 
+  ALLOWED_RESOURCE_TYPES = {
+    'Cookbook' => Cookbook,
+    'Tool' => Tool
+  }.freeze
   before_action :authenticate_user!
   before_action :find_collaborator, only: [:destroy, :transfer]
   skip_before_action :verify_authenticity_token, only: [:destroy]
@@ -32,8 +36,9 @@ class CollaboratorsController < ApplicationController
   # Add a collaborator to a resource.
   #
   def create
-    if %w{Cookbook Tool}.include?(collaborator_params[:resourceable_type])
-      resource = collaborator_params[:resourceable_type].constantize.find(
+    resource_class = ALLOWED_RESOURCE_TYPES[collaborator_params[:resourceable_type]]
+    if resource_class
+      resource = resource_class.find(
         collaborator_params[:resourceable_id]
       )
 
@@ -73,8 +78,9 @@ class CollaboratorsController < ApplicationController
   def destroy_group
     group = Group.find(params[:id])
 
-    if %w{Cookbook Tool}.include?(params[:resourceable_type])
-      resource = params[:resourceable_type].constantize.find(
+    resource_class = ALLOWED_RESOURCE_TYPES[params[:resourceable_type]]
+    if resource_class
+      resource = resource_class.find(
         params[:resourceable_id]
       )
 


### PR DESCRIPTION
Potential fix for [https://github.com/chef/supermarket/security/code-scanning/30](https://github.com/chef/supermarket/security/code-scanning/30)

To fix the problem, remove the use of `.constantize` on user-provided input. Instead, explicitly map allowed user input values to their corresponding classes using a Ruby hash. For example, use a lookup table: `ALLOWED_RESOURCE_TYPES = {'Cookbook' => Cookbook, 'Tool' => Tool}` and do `resource_class = ALLOWED_RESOURCE_TYPES[params[:resourceable_type]]`. Then, only proceed if the mapping is successful.

In this file, there are two places using `.constantize`:
- In `create`, on lines 35-38, it is already protected by a whitelist array, but should use the mapping approach.
- In `destroy_group`, on lines 76-79, similar direct use of `.constantize` should be replaced with a safe mapping.

Define the mapping at the top of the class, and use it both in `create` and `destroy_group`. Do not rely on dynamic lookup.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
