### PR TITLE
Potential fix for code scanning alert no. 29: Code injection

### DIFF
--- a/src/supermarket/app/controllers/collaborators_controller.rb
+++ b/src/supermarket/app/controllers/collaborators_controller.rb
@@ -32,8 +32,14 @@ class CollaboratorsController < ApplicationController
   # Add a collaborator to a resource.
   #
   def create
-    if %w{Cookbook Tool}.include?(collaborator_params[:resourceable_type])
-      resource = collaborator_params[:resourceable_type].constantize.find(
+    resourceable_type = collaborator_params[:resourceable_type]
+    RESOURCEABLE_MODELS = {
+      "Cookbook" => Cookbook,
+      "Tool" => Tool
+    }
+    if RESOURCEABLE_MODELS.key?(resourceable_type)
+      resourceable_klass = RESOURCEABLE_MODELS[resourceable_type]
+      resource = resourceable_klass.find(
         collaborator_params[:resourceable_id]
       )
 


### PR DESCRIPTION
Potential fix for [https://github.com/chef/supermarket/security/code-scanning/29](https://github.com/chef/supermarket/security/code-scanning/29)

The root problem is allowing user-controlled input to be dynamically constantized into a class name using `constantize`, which can lead to code injection. Instead, the solution is to create a static mapping of the permitted resource types (`"Cookbook"` and `"Tool"`) to their respective classes. We replace
```rb
resource = collaborator_params[:resourceable_type].constantize.find(
  collaborator_params[:resourceable_id]
)
```
with a safe mapping, e.g.:
```rb
RESOURCEABLE_MODELS = {
  "Cookbook" => Cookbook,
  "Tool" => Tool
}

resourceable_klass = RESOURCEABLE_MODELS[collaborator_params[:resourceable_type]]
resource = resourceable_klass.find(collaborator_params[:resourceable_id])
```
This eliminates dynamic constantization. Also, ensure this mapping is defined in the same class or as a private constant.

The only file to modify is `src/supermarket/app/controllers/collaborators_controller.rb`, in the `create` action (lines 34-52).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
