### PR TITLE
Potential fix for code scanning alert no. 23: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/src/supermarket/engines/fieri/app/models/cookbook_artifact.rb
+++ b/src/supermarket/engines/fieri/app/models/cookbook_artifact.rb
@@ -94,7 +94,7 @@ class CookbookArtifact
   #
   def download
     File.open(Tempfile.new("archive"), "wb") do |saved_file|
-      URI.open(url, "rb") do |read_file|
+      URI(url).open("rb") do |read_file|
         saved_file.write(read_file.read)
       end
       saved_file


### PR DESCRIPTION
Potential fix for [https://github.com/chef/supermarket/security/code-scanning/23](https://github.com/chef/supermarket/security/code-scanning/23)

To fix this vulnerability, we should avoid calling `URI.open` directly with a non-constant value. The recommended approach is to instantiate a URI object with `URI(url)` and then call `.open("rb")` on this object, which is both safe and idiomatic. This ensures Ruby treats the value as a URI rather than a file path (where leading `|` characters would otherwise result in shell execution).

Specifically:
- In `def download` (lines 95–102), replace `URI.open(url, "rb") do |read_file| ... end` with `URI(url).open("rb") do |read_file| ... end`.  
- No additional packages are required, as the methods in question are part of the Ruby standard library.
- No other code needs to change since the use of the result does not alter functionality.  
- This fix maintains all logic and behavior as before, only improving safety.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
