### PR TITLE
CHEF-29352 - Replace CODE_OF_CONDUCT.md file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,20 +1,3 @@
-This project's code of conduct is documented in the [Chef Community
-Guidelines](https://github.com/chef/chef-rfc/blob/master/rfc020-community-guidelines.md).
+# Chef Code of Conduct
 
-Paraphrasing and excerpting from these guidelines, we would like to
-reaffirm some of those beliefs here:
-
-* Diversity is one of our biggest strengths.
-* We are welcoming, inclusive, friendly, and patient.
-* We are considerate.
-* We are respectful.
-* We are professional.
-* We are careful in the words that we choose.
-* When we disagree, we all work together to understand why.
-* YOU are welcome here!
-
-Borrowing from the ubuntu philosophy:
-
-> I am because you are.
-> When you suffer, I suffer.
-> When you thrive, I thrive.
+Participants in this project must adhere to the [Chef Code of Conduct](https://chef.github.io/chef-oss-practices/policies/code-of-conduct/).


### PR DESCRIPTION
As part of the [repo standardization effort](https://github.com/chef-boneyard/oss-repo-standardization-2025) we are standardizing all repos to have a standard CODE_OF_CONDUCT.md file that points to the main Chef Code of Conduct. This is not intended to be a change in policy, but rather an administrative change