### PR TITLE
CHEF-30534 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/LICENSE
+++ b/LICENSE
@@ -186,8 +186,6 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright 2013 Chef, Inc.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/README.md
+++ b/README.md
@@ -353,3 +353,6 @@ One of these keys is called `FEATURES` and it controls a number of features that
 * announcement
 * github
 * no_crawl
+
+# Copyright
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/omnibus/LICENSE
+++ b/omnibus/LICENSE
@@ -186,8 +186,6 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright 2013 Chef, Inc.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/omnibus/README.md
+++ b/omnibus/README.md
@@ -110,8 +110,6 @@ For a complete list of all commands and platforms, run `kitchen list` or
 
 # License
 
-Copyright (c) 2014 Chef Software, Inc.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -123,3 +121,6 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+# Copyright
+See [COPYRIGHT.md](./../COPYRIGHT.md).

--- a/omnibus/config/projects/supermarket.rb
+++ b/omnibus/config/projects/supermarket.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Chef Software, Inc.
+#  Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/config/software/file.rb
+++ b/omnibus/config/software/file.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2017, Chef Software, Inc.
+# Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/config/software/more-ruby-cleanup-supermarket.rb
+++ b/omnibus/config/software/more-ruby-cleanup-supermarket.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) Chef Software Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/omnibus/config/software/postgresql13.rb
+++ b/omnibus/config/software/postgresql13.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Chef Software, Inc.
+#  Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/config/software/supermarket-cookbooks.rb
+++ b/omnibus/config/software/supermarket-cookbooks.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/config/software/supermarket-ctl.rb
+++ b/omnibus/config/software/supermarket-ctl.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/config/software/supermarket.rb
+++ b/omnibus/config/software/supermarket.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/config/templates/supermarket-ctl/supermarket-ctl.erb
+++ b/omnibus/config/templates/supermarket-ctl/supermarket-ctl.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2014 Chef Software, Inc.
+# Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/LICENSE
+++ b/omnibus/cookbooks/omnibus-supermarket/LICENSE
@@ -186,8 +186,6 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright 2013 Chef, Inc.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/omnibus/cookbooks/omnibus-supermarket/README.md
+++ b/omnibus/cookbooks/omnibus-supermarket/README.md
@@ -53,3 +53,6 @@ run `kitchen converge`.
 
 To run the [Serverspec](http://serverspec.org/) tests in
 test/integration/default/serverspec, use `kitchen verify`.
+
+# Copyright
+See [COPYRIGHT.md](./../../../COPYRIGHT.md).

--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/notice.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/notice.rb
@@ -2781,7 +2781,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 (bi) Progress Chef Supermarket v5.3 incorporates ffi-yajl	 v2.6.0. Such technology is subject to the following terms and conditions: 
 
 Copyright (c) 2014 Lamont Granquist
-Copyright (c) 2014 Chef Software, Inc.
+Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 Copyright (c) 2008-2011 Brian Lopez - http://github.com/brianmario
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/version.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/files/default/ctl-commands/version.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2019 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/app.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/app.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: app
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/config.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: config
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/cookbook_test.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/cookbook_test.rb
@@ -2,7 +2,7 @@
 # Cookbook:: omnibus-supermarket
 # Recipe:: cookbook_test
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/database.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/database.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: database
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/default.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: default
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/log_management.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/log_management.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: log_management
 #
-# Copyright:: 2015 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/nginx.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/nginx.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: nginx
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/postgresql-external.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/postgresql-external.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: postgresql
 #
-# Copyright:: Chef Software, Inc.
+#  Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/postgresql.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/postgresql.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: postgresql
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/rails.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/rails.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: rails
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/redis.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/redis.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: redis
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/show_config.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/show_config.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: show_config
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/sidekiq.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/sidekiq.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: sidekiq
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/omnibus-supermarket/recipes/ssl.rb
+++ b/omnibus/cookbooks/omnibus-supermarket/recipes/ssl.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket
 # Recipe:: ssl
 #
-# Copyright:: 2014 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/omnibus/cookbooks/supermarket-builder/recipes/default.rb
+++ b/omnibus/cookbooks/supermarket-builder/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: supermarket-builder
 # Recipe:: default
 #
-# Copyright:: 2018 Chef Software, Inc.
+# Copyright:: Copyright (c) 2013-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/supermarket/engines/fieri/LICENSE
+++ b/src/supermarket/engines/fieri/LICENSE
@@ -186,8 +186,6 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright 2013 Chef, Inc.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/src/supermarket/engines/fieri/README.md
+++ b/src/supermarket/engines/fieri/README.md
@@ -52,3 +52,6 @@ root of the Supermarket app (`src/supermarket`):
 ```
 rake quality_metrics:run:on_version[test_cookbook,1.2.3]
 ```
+
+# Copyright
+See [COPYRIGHT.md](./../../../../COPYRIGHT.md).


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2013-2026 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `LICENSE:189` - Copyright in LICENSE file (move to COPYRIGHT)
- `NOTICE.txt:1` - Copyright in NOTICE file (move to COPYRIGHT)
- `README.md:1` - adjust-readme
- `omnibus/LICENSE:189` - Copyright in LICENSE file (move to COPYRIGHT)
- `omnibus/README.md:113` - adjust-readme
- `omnibus/cookbooks/omnibus-supermarket/LICENSE:189` - Copyright in LICENSE file (move to COPYRIGHT)
- `src/supermarket/db/seeds/ccla/head.md:7` - Multiple entities in copyright (review needed)
- `src/supermarket/engines/fieri/LICENSE:189` - Copyright in LICENSE file (move to COPYRIGHT)
- `docs-chef-io/content/supermarket/ctl_supermarket.md:227` - Unmatched copyright format (review needed)
- `CONTRIBUTING.md:17` - Unmatched copyright format (review needed)

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
