### PR TITLE
Fix 'occured' -> 'occurred' typo in CookbookUpload#save yieldparam doc

### DIFF
--- a/src/supermarket/app/models/cookbook_upload.rb
+++ b/src/supermarket/app/models/cookbook_upload.rb
@@ -18,7 +18,7 @@ class CookbookUpload
   #
   # Finishes the upload process for this +CookbookUpload+'s parameters.
   #
-  # @yieldparam errors [ActiveModel::Errors] errors which occured while
+  # @yieldparam errors [ActiveModel::Errors] errors which occurred while
   #   finishing the upload. May be empty.
   # @yieldparam result [Cookbook, nil] the cookbook, if the upload succeeds
   # @yieldparam cookbook_version [CookbookVersion, nil] the cookbook version, if


### PR DESCRIPTION
The YARD `@yieldparam` on `CookbookUpload#save` in `src/supermarket/app/models/cookbook_upload.rb:21` used `errors which occured while`. Doc-only Ruby change.